### PR TITLE
Add missing ref to image-capture spec

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -438,8 +438,8 @@
             <a>MediaStream</a>
           </code> consumers currently include the media elements [[HTML5]],
         <code>RTCPeerConnection</code> [[WEBRTC10]],
-        <code>MediaRecorder</code> [[mediastream-rec]] and
-        <code>ImageCapture</code> [[mediastream-imagecap]].</p>
+        <code>MediaRecorder</code> [[mediastream-recording]] and
+        <code>ImageCapture</code> [[image-capture]].</p>
 
         <p class="note"><code>
             <a>MediaStream</a>
@@ -4020,8 +4020,8 @@ if(supports["facingMode"]) {
 
       <div>
         <p>This example allows people to take photos of themselves from the
-        local video camera. Note that the forthcoming Image Capture
-        specification may provide a simpler way to accomplish this.</p>
+        local video camera. Note that the Image Capture
+        specification [[image-capture]] provides a simpler way to accomplish this.</p>
 
         <pre class="example highlight" xml:space="preserve">
 &lt;article&gt;

--- a/getusermedia.js
+++ b/getusermedia.js
@@ -66,27 +66,5 @@ var respecConfig = {
    // This is important for Rec-track documents, do not copy a patent URI from a random
    // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
    // Team Contact.
-   wgPatentURI:   ["http://www.w3.org/2004/01/pp-impl/47318/status","http://www.w3.org/2004/01/pp-impl/43696/status"],
-
-   localBiblio:  {
-      "mediastream-rec": {
-        title: "MediaStream Recording",
-        href: "https://dvcs.w3.org/hg/dap/raw-file/tip/media-stream-capture/MediaRecorder.html",
-        authors:  [
-            "Jim Barnett",
-            "Travis Leithead"
-        ],
-        status:   "WD",
-        publisher:  "W3C"
-      },
-      "mediastream-imagecap": {
-        title: "MediaStream Image Capture",
-        href: "http://www.w3.org/TR/image-capture/",
-        authors:  [
-            "Giridhar Mandyam"
-        ],
-        status:   "WD",
-        publisher:  "W3C"
-      }
-   }
+   wgPatentURI:   ["http://www.w3.org/2004/01/pp-impl/47318/status","http://www.w3.org/2004/01/pp-impl/43696/status"]
 };


### PR DESCRIPTION
fixes bug https://www.w3.org/Bugs/Public/show_bug.cgi?id=25767
also, replaced local bibliography with centralized one for mediastream recording and image capture
