### PR TITLE
Changing respec to load from https URL

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -13,7 +13,7 @@
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 
     <script class="remove"
-    src="http://www.w3.org/Tools/respec/respec-w3c-common"
+    src="https://www.w3.org/Tools/respec/respec-w3c-common"
     type="text/javascript"> // &lt;!-- keep this comment --&gt; // </script>
 
     <script class="remove" src="getusermedia.js" type="text/javascript"> //


### PR DESCRIPTION
As it turns out, the current spec is available from https://w3c.github.com/mediacapture-main/, but it can't be used on some more recent browsers because it loads active mixed content: respec.js.  This one character change fixes that.
