### PR TITLE
Add MediaStreamTrack.ended promise

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4618,6 +4618,11 @@ if(supports["facingMode"]) {
 
       <h2>Changes since September 24, 2014</h2>
       <ol>
+        <li>Bug 26939: Added track.ended promise to determine whether track
+          ended successfully or failed with a reason.</li>
+     </ol>
+
+      <ol>
         <li>Bug 25777: Added example of capabilities when only two
         video sizes are available.</li>
       </ol>


### PR DESCRIPTION
I took a stab at the various failure conditions, mirroring them on getUserMedia as much as possible.

http://htmlpreview.github.io/?https://raw.githubusercontent.com/jan-ivar/mediacapture-main/ended/getusermedia.html#life-cycle-and-media-flow
