### PR TITLE
Video preview

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2720,28 +2720,94 @@
             devices have the same group identifier if they belong to the same
             physical device; for example a monitor with a built in camera and microphone.</p>
           </dd>
+
+          <dt>Promise&lt;Blob> grabPreview()</dt>
+
+          <dd>
+            <p>This method generates an image Blob [[!FILE-API]] that can be
+            used to display a preview of a <code>videoinput</code> source.</p>
+
+            <p>Note that this code does not require the same user consent
+            that <a href="#dom-mediadevices-getusermedia">MediaDevices.getUserMedia()</a>
+            does.  Therefore, it is possible for a site to use this API to cause
+            indicators to turn on, which can be disconcerting for users.</p>
+
+            <p>User agents are advised to limit access to this API.  User
+            agents <em class="rfc2119">should</em> limit the rate that this API
+            can be used to acquire preview images.  Users
+            agents <em class="rfc2119">should</em> avoid opening devices unless
+            the API call is associated with
+            an <a href="https://dvcs.w3.org/hg/pointerlock/raw-file/default/index.html#dfn-engagement-gesture">engagement
+            gesture</a>.</p>
+
+            <p>When the <code>grabPreview()</code> method is called, the user
+            agent runs the following steps:</p>
+            <ol>
+              <li>Let <var>promise</var> be a
+              new <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">promise</a>.</li>
+              <li>Run these steps in parallel:
+                <ol>
+                  <li>If the current device is not a <code>videoinput</code>
+                  source, then reject <var>promise</var> and abort this
+                  process.</li>
+
+                  <li>If access to the device is currently limited for any
+                  reason, resolve <var>promise</var> with a cross origin blob
+                  containing static content. This
+                  content <em class="rfc2119">may</em> be populated from a
+                  recent call to this API.</li>
+
+                  <li>Open the video input device.</li>
+
+                  <li>If the device cannot be opened,
+                  reject <var>promise</var>.</li>
+
+                  <li>Capture a single frame from the device by
+                  invoking <code>ImageCapture.grabFrame()</code>
+                  [[!image-capture]].</li>
+
+                  <li>If <code>grabFrame()</code> is not successful,
+                  reject <var>promise</var>.</li>
+
+                  <li>Let <var>frame</var> be the result
+                  of <code>grabFrame()</code></li>
+
+                  <li>Mark <var>frame</var> as being cross origin, preventing
+                  access to its contents from any origin.  This permits
+                  rendering to the screen only,
+                  using <code>URL.createObjectURL()</code>[[FILE-API]].</li>
+
+                  <li>Resolve <var>promise</var> with <var>frame</var>.</li>
+                </ol>
+              </li>
+              <li>Return <var>promise</var>.</li>
+            </ol>
+          </dd>
         </dl>
 
-        <dl class="idl" title="enum MediaDeviceKind">
-          <dt>audioinput</dt>
+        <section>
+          <h2>Media Device Kinds</h2>
+          <dl class="idl" title="enum MediaDeviceKind">
+            <dt>audioinput</dt>
 
-          <dd>
-            <p>Represents an audio input device; for example a microphone.</p>
-          </dd>
+            <dd>
+              <p>Represents an audio input device; for example a microphone.</p>
+            </dd>
 
-          <dt>audiooutput</dt>
+            <dt>audiooutput</dt>
 
-          <dd>
-            <p>Represents an audio output device; for example a pair of
-            headphones.</p>
-          </dd>
+            <dd>
+              <p>Represents an audio output device; for example a pair of
+                headphones.</p>
+            </dd>
 
-          <dt>videoinput</dt>
+            <dt>videoinput</dt>
 
-          <dd>
-            <p>Represents a video input device; for example a webcam.</p>
-          </dd>
-        </dl>
+            <dd>
+              <p>Represents a video input device; for example a webcam.</p>
+            </dd>
+          </dl>
+        </section>
       </section>
     </section>
 


### PR DESCRIPTION
This adds a new method to `MediaDeviceInfo` called `grabPreview`.  It provides applications with a way of acquiring a preview image for a video input device.

I didn't add the ability to acquire a preview stream, because that is totally creepy.  This does risk creeping people out in a similar fashion, so I've suggested that access be limited.  I think that the measures I have described are adequate, particularly because they offer the UA quite a bit of flexibility in how often lights come on.  However, if we can't convince ourselves that they are, then this probably isn't a great idea to pursue.

What I haven't done here is provide information on the aspect ratio of the preview image, which will be necessary for the application to successfully draw this without distorting it.  I'll add that in a subsequent commit if this idea sounds appealing.
