### PR TITLE
Can't synchronize everything without magic

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -255,7 +255,9 @@
             <a>MediaStreamTrack</a>
           </code> objects. All tracks in a <code>
             <a>MediaStream</a>
-          </code> are intended to be synchronized when rendered. Different
+          </code> are intended to be synchronized when rendered. This is not a
+          hard requirement, since it might not be possible to synchronize tracks
+          from sources that have different clocks. Different
         <code>
             <a>MediaStream</a>
           </code> objects do not need to be synchronized.</p>


### PR DESCRIPTION
I think that the choice of "intended" sort of covers this point, but there is no harm in actually saying it.  Otherwise we get some crazy questions.

For example, imagine using webrtc to stream a live concert, where there are multiple endpoints with different camera angles on the stage.  A simple - and wrong - assumption might be that you could create a PC to each endpoint and then assemble the tracks they produce into a single MediaStream to synchronize everything properly, then simply select which track was played out.  If you understand how this actually works: that would require magic to work in the expected fashion.  Usually, people find they need to substitute hard work for magic.
