### PR TITLE
Defining active first, then inactive

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -681,22 +681,9 @@
           <dt>readonly attribute boolean active</dt>
 
           <dd>
-            <p>The <dfn id="dom-mediastream-active">
-                <code>MediaStream.active</code>
-              </dfn> attribute returns true if the <code>
-                <a>MediaStream</a>
-              </code> is active (see <a href="#stream-inactive">inactive</a>),
-            and false otherwise.</p>
-
-            <p>When a <code>
-                <a>MediaStream</a>
-              </code> object is created, its <code>
-                <a href="#dom-mediastream-active">active</a>
-              </code> attribute MUST be set to true, unless stated otherwise
-            (for example by the <code>
-                <a href="#dom-mediastream">MediaStream()</a>
-              </code> constructor algorithm).</p>
-          </dd>
+            <p>This attribute is true if the <code><a>MediaStream</a></code>
+            is <a href="#stream-active">active</a> and false otherwise.</p>
+         </dd>
 
           <dt>attribute EventHandler onactive</dt>
 


### PR DESCRIPTION
Concentrating on inactive and then defining active as a consequence of that is odd.  This concentrates on the positive.
