### PR TITLE
Remove text about firing event handlers (from event handler attribute descriptions)

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3354,28 +3354,6 @@ if(!supports["width"] || !supports["height"]) {
       "#media-stream-track-interface-definition">MediaStreamTrack Interface
       Definition</a> for an example of this.</p>
 
-      <p>When the User Agent is no longer able to satisfy the
-      required constraints</var> from the currently valid Constraints, the User
-      Agent MUST queue a task that fires a <code>MediaStreamErrorEvent</code>
-      named <code>overconstrained</code>, initialized as described in the
-      following paragraph, at the constrainable object. The event firing task
-      MAY also be used to update the constrainable object as a result
-      of the overconstrained situation.</p>
-
-      <p>The <code>MediaStreamErrorEvent</code> associated with the
-      <code>overconstrained</code> event references a
-      <code>MediaStreamError</code> whose <code>name</code> is
-      <code>OverconstrainedError</code>, and whose
-      <code>constraintName</code> attribute is set to one of the
-      <var>requiredConstraints</var> that can no longer be satisfied. The
-      <code>message</code> attribute of the MediaStreamError SHOULD contain
-      a string that is useful for debugging. The conditions under which
-      this error might occur are platform and application-specific. For
-      example, the user might physically manipulate a camera in a way that
-      makes it impossible to provide a resolution that satisfies the
-      constraints. The User Agent MAY take other actions as a result of the
-      overconstrained situation.</p>
-
       <dl class="idl" title=
       "[NoInterfaceObject] interface ConstrainablePattern">
         <dt>Capabilities getCapabilities()</dt>
@@ -3670,7 +3648,25 @@ if(!supports["width"] || !supports["height"]) {
         <dt>attribute EventHandler onoverconstrained</dt>
 
         <dd>
-          The event type of this event handler is <code>overconstrained</code>.
+          This event handler, of type <code><a>overconstrained</a></code>, is
+          executed when the User Agent is no longer able to satisfy the
+          <var>requiredConstraints</var> from the currently valid Constraints.
+          <p>
+
+          <p>When executed, the event handler is passed a
+          <code>MediaStreamErrorEvent</code> as parameter, which references a
+          <code>MediaStreamError</code> whose <code>name</code> is
+          <code>OverconstrainedError</code>, and whose
+          <code>constraintName</code> attribute is set to one of the
+          <var>requiredConstraints</var> that can no longer be satisfied. The
+          <code>message</code> attribute of the MediaStreamError SHOULD contain
+          a string that is useful for debugging. The conditions under which
+          this error might occur are platform and application-specific. For
+          example, the user might physically manipulate a camera in a way that
+          makes it impossible to provide a resolution that satisfies the
+          constraints. The User Agent MAY take other actions as a result of the
+          overconstrained situation.</p>
+          <p>
         </dd>
       </dl>
 

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -579,34 +579,29 @@
         <dt>attribute EventHandler onactive</dt>
 
         <dd>
-          <p>This event handler, of type <code><a href=
-          "#event-mediastream-active">active</a></code>, is executed when the
-          MediaStream becomes active.</p>
+          <p>The event type of this event handler is <code><a href=
+          "#event-mediastream-active">active</a></code>.</p>
         </dd>
 
         <dt>attribute EventHandler oninactive</dt>
 
         <dd>
-          <p>This event handler, of type <code><a href=
-          "#event-mediastream-inactive">inactive</a></code>, is executed when
-          the MediaStream becomes inactive.</p>
+          <p>The event type of this event handler is <code><a href=
+          "#event-mediastream-inactive">inactive</a></code>.</p>
         </dd>
 
         <dt>attribute EventHandler onaddtrack</dt>
 
         <dd>
-          <p>This event handler, of type <code><a href=
-          "#event-mediastream-addtrack">addtrack</a></code>, is executed when a
-          <code><a>MediaStreamTrack</a></code> is added to the MediaStream.</p>
+          <p>The event type of this event handler is <code><a href=
+          "#event-mediastream-addtrack">addtrack</a></code>.</p>
         </dd>
 
         <dt>attribute EventHandler onremovetrack</dt>
 
         <dd>
-          <p>This event handler, of type <code><a href=
-          "#event-mediastream-removetrack">removetrack</a></code>, is executed
-          when a <code><a>MediaStreamTrack</a></code> is removed from the
-          MediaStream.</p>
+          <p>The event type of this event handler is <code><a href=
+          "#event-mediastream-removetrack">removetrack</a></code>.</p>
         </dd>
       </dl>
     </section>
@@ -957,19 +952,15 @@
           <dt>attribute EventHandler onmute</dt>
 
           <dd>
-            <p>This event handler, of type <code><a href=
-            "#event-mediastreamtrack-mute">mute</a></code>, is executed when
-            the <code>MediaStreamTrack</code> source is temporarily unable to
-            provide data.</p>
+            <p>The event type of this event handler is <code><a href=
+            "#event-mediastreamtrack-mute">mute</a></code>.</p>
           </dd>
 
           <dt>attribute EventHandler onunmute</dt>
 
           <dd>
-            <p>This event handler, of type <code><a href=
-            "#event-mediastreamtrack-unmute">unmute</a></code>, is executed
-            when the <code>MediaStreamTrack</code> source is live again after
-            having been temporarily unable to provide data.</p>
+            <p>The event type of this event handler is <code><a href=
+            "#event-mediastreamtrack-unmute">unmute</a></code>.</p>
           </dd>
 
           <dt>readonly attribute boolean _readonly</dt>
@@ -1004,11 +995,8 @@
           <dt>attribute EventHandler onended</dt>
 
           <dd>
-            <p>This event handler, of type <code><a href=
-            "#event-mediastreamtrack-ended">ended</a></code>, is executed when
-            the <code>MediaStreamTrack</code> source will no longer provide any
-            data, either due to a user action (revoked permission, removal of
-            capture device) or due to an error.</p>
+            <p>The event type of this event handler is <code><a href=
+            "#event-mediastreamtrack-ended">ended</a></code>.</p>
           </dd>
 
           <dt>MediaStreamTrack clone()</dt>
@@ -1090,8 +1078,11 @@
           <dt>attribute EventHandler onoverconstrained</dt>
 
           <dd>
+            <p>The event type of this event handler is <code><a href=
+            "#event-mediastreamtrack-overconstrained">overconstrained</a></code>.</p>
+
             <p>See <a href="#constrainable-interface">ConstrainablePattern
-            Interface</a> for the definition of this event handler.</p>
+            Interface</a> for more information about the <code>overconstrained</code> event.</p>
           </dd>
         </dl>
 
@@ -2390,10 +2381,8 @@
         <dt>attribute EventHandler ondevicechange</dt>
 
         <dd>
-          <p>This event handler, of type <code><a href=
-          "#event-mediadevices-devicechange">devicechange</a></code>, is
-          executed when the set of media devices available to the user agent
-          has changed.</p>
+          <p>The event type of this event handler is <code><a href=
+          "#event-mediadevices-devicechange">devicechange</a></code>.</p>
         </dd>
 
         <dt>Promise&lt;sequence&lt;MediaDeviceInfo&gt;&gt; enumerateDevices
@@ -3365,6 +3354,28 @@ if(!supports["width"] || !supports["height"]) {
       "#media-stream-track-interface-definition">MediaStreamTrack Interface
       Definition</a> for an example of this.</p>
 
+      <p>When the User Agent is no longer able to satisfy the
+      required constraints</var> from the currently valid Constraints, the User
+      Agent MUST queue a task that fires a <code>MediaStreamErrorEvent</code>
+      named <code>overconstrained</code>, initialized as described in the
+      following paragraph, at the constrainable object. The event firing task
+      MAY also be used to update the constrainable object as a result
+      of the overconstrained situation.</p>
+
+      <p>The <code>MediaStreamErrorEvent</code> associated with the
+      <code>overconstrained</code> event references a
+      <code>MediaStreamError</code> whose <code>name</code> is
+      <code>OverconstrainedError</code>, and whose
+      <code>constraintName</code> attribute is set to one of the
+      <var>requiredConstraints</var> that can no longer be satisfied. The
+      <code>message</code> attribute of the MediaStreamError SHOULD contain
+      a string that is useful for debugging. The conditions under which
+      this error might occur are platform and application-specific. For
+      example, the user might physically manipulate a camera in a way that
+      makes it impossible to provide a resolution that satisfies the
+      constraints. The User Agent MAY take other actions as a result of the
+      overconstrained situation.</p>
+
       <dl class="idl" title=
       "[NoInterfaceObject] interface ConstrainablePattern">
         <dt>Capabilities getCapabilities()</dt>
@@ -3659,25 +3670,7 @@ if(!supports["width"] || !supports["height"]) {
         <dt>attribute EventHandler onoverconstrained</dt>
 
         <dd>
-          This event handler, of type <code><a>overconstrained</a></code>, is
-          executed when the User Agent is no longer able to satisfy the
-          <var>requiredConstraints</var> from the currently valid Constraints.
-          <p>
-
-          <p>When executed, the event handler is passed a
-          <code>MediaStreamErrorEvent</code> as parameter, which references a
-          <code>MediaStreamError</code> whose <code>name</code> is
-          <code>OverconstrainedError</code>, and whose
-          <code>constraintName</code> attribute is set to one of the
-          <var>requiredConstraints</var> that can no longer be satisfied. The
-          <code>message</code> attribute of the MediaStreamError SHOULD contain
-          a string that is useful for debugging. The conditions under which
-          this error might occur are platform and application-specific. For
-          example, the user might physically manipulate a camera in a way that
-          makes it impossible to provide a resolution that satisfies the
-          constraints. The User Agent MAY take other actions as a result of the
-          overconstrained situation.</p>
-          <p>
+          The event type of this event handler is <code>overconstrained</code>.
         </dd>
       </dl>
 


### PR DESCRIPTION
We should not have any text in the event handler attribute descriptions saying that this event handler is fired when this or that happens. The event handler attributes are fired as part of the event flow procedure and that's redundant to describe for every single attribute handler.

This PR simplifies the event handler attribute descriptions to only mention the corresponding event type (that links to the event summary table).