### PR TITLE
Change NotSupportedError from a MediaStreamError to a DOMException

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2819,7 +2819,7 @@
                 <li>
                   <p>If <var>requestedMediaTypes</var> is the empty set, let
                   <var>error</var> be a new
-                  <code><a>MediaStreamError</a></code> object whose
+                  <code><a>DOMException</a></code> object whose
                   <code><a>name</a></code> attribute has the value
                   <code>NotSupportedError</code> and jump to the step labeled
                   <em>Error Task</em> below.</p>


### PR DESCRIPTION
Partially fulfills #162.  See also #170.
