### PR TITLE
Change NotFoundError from a MediaStreamError to a DOMException

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2885,7 +2885,7 @@
 
                   <p>If <var>finalSet</var> is the empty set, let
                   <var>error</var> be a new
-                  <code><a>MediaStreamError</a></code> object whose
+                  <code><a>DOMException</a></code> object whose
                   <code><a>name</a></code> attribute has the value
                   <code>NotFoundError</code> and jump to the step labeled
                   <em>Error Task</em> below.</p>


### PR DESCRIPTION
Partially fulfills #162. See also #170.