### PR TITLE
Once you implement a MediaTrackSupportedConstraints member, you support it

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1158,51 +1158,51 @@
         the [[!RTCWEB-CONSTRAINTS]] registry.</p>
 
         <dl class="idl" title="dictionary MediaTrackSupportedConstraints">
-          <dt>boolean width</dt>
+          <dt>boolean width = true</dt>
 
           <dd />
 
-          <dt>boolean height</dt>
+          <dt>boolean height = true</dt>
 
           <dd />
 
-          <dt>boolean aspectRatio</dt>
+          <dt>boolean aspectRatio = true</dt>
 
           <dd />
 
-          <dt>boolean frameRate</dt>
+          <dt>boolean frameRate = true</dt>
 
           <dd />
 
-          <dt>boolean facingMode</dt>
+          <dt>boolean facingMode = true</dt>
 
           <dd />
 
-          <dt>boolean volume</dt>
+          <dt>boolean volume = true</dt>
 
           <dd />
 
-          <dt>boolean sampleRate</dt>
+          <dt>boolean sampleRate = true</dt>
 
           <dd />
 
-          <dt>boolean sampleSize</dt>
+          <dt>boolean sampleSize = true</dt>
 
           <dd />
 
-          <dt>boolean echoCancellation</dt>
+          <dt>boolean echoCancellation = true</dt>
 
           <dd />
 
-          <dt>boolean latency</dt>
+          <dt>boolean latency = true</dt>
 
           <dd />
 
-          <dt>boolean deviceId</dt>
+          <dt>boolean deviceId = true</dt>
 
           <dd />
 
-          <dt>boolean groupId</dt>
+          <dt>boolean groupId = true</dt>
 
           <dd />
         </dl>


### PR DESCRIPTION
The [spec says](http://w3c.github.io/mediacapture-main/getusermedia.html#widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints):

"A supported constrainable property MUST be represented by a member whose name is the constraint name and *whose value is true*. Any constrainable properties not supported by the User Agent MUST *not be present* in the returned dictionary."

In other words, members are always true. This optimizes the WebIDL to match.

I was originally against the breakdown of discrete dictionaries here, because of the code maintenance burden (more places to forget to update for each new constraint implemented), but I like that this at least can be managed entirely in the WebIDL definition file (and WebIDL binding code) without needing to define members *and* remembering to add manual code somewhere as well to set values to true.