### PR TITLE
Allow device capabilities to be discoverable via enumerateDevices

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2415,8 +2415,7 @@
           <code><a>MediaStream</a></code> returned by <code>getUserMedia({deviceId: <i>id</i>})</code>
           where <i>id</i> is the value of the <code>deviceId</code> attribute of this <code>MediaDeviceInfo</code>.</p>
 
-          <p>For output devices, this attribute will always be <code>null</code>. Future changes to this API will address
-          the acquisition of output device capabilities.</p>
+          <p>For output devices, this attribute has the value <code>null</code>.</p>
         </dd>
 
         <dt>readonly attribute DOMString groupId</dt>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2248,9 +2248,8 @@
           User Agent's available media input and output devices if enumeration
           is successful.</p>
 
-          <p>Elements of this sequence which represent input devices will be of type
-          <code><a>InputDeviceInfo</a></code> which extends <code><a>MediaDeviceInfo</a></code>
-          with input-specific elements.</p>
+          <p>Elements of this sequence that represent input devices will be of type
+          <code><a>InputDeviceInfo</a></code> which extends <code><a>MediaDeviceInfo</a></code>.</p>
 
           <p>Camera and microphone sources <em class="rfc2119">should</em> be
           enumerable. Specifications that add additional types of source will
@@ -2441,19 +2440,22 @@
       </dl>
     </section>
     <section>
-      <h2>Input-Specific Device Info</h2>
+      <h2>Input-specific Device Info</h2>
       <dl class="idl" title="interface InputDeviceInfo : MediaDeviceInfo">
         <dt>MediaTrackCapabilities getCapabilities()</dt>
 
         <dd>
-          <p>Returns a <code><a>MediaTrackCapabilities</a></code> object describing the device's audio or video track
+          <p>Returns a <code><a>MediaTrackCapabilities</a></code> object describing the primary
+          audio or video track of a device's <code><a>MediaStream</a></code>
           (according to its <code>kind</code> value), in the absence of any user-supplied constraints.
-          These capabilities will be identical to those that would have been obtained by calling
+          These capabilities MUST be identical to those that would have been obtained by calling
           <code>getCapabilities()</code> on the first <code><a>MediaStreamTrack</a></code> of this type in a
           <code><a>MediaStream</a></code> returned by <code>getUserMedia({deviceId: <i>id</i>})</code>
-          where <i>id</i> is the value of the <code>deviceId</code> attribute of this <code>MediaDeviceInfo</code>.</p>
-          <p>If no access has been granted to any local devices and this <code>InputDeviceInfo</code> has been filtered
-          with respect to unique identifying information (see above description of <code>enumerateDevices()</code> result), then this method returns <code>null</code>.
+          where <i>id</i> is the value of the <code>deviceId</code> attribute
+          of this <code>MediaDeviceInfo</code>.</p>
+          <p>If no access has been granted to any local devices and this <code>InputDeviceInfo</code>
+          has been filtered with respect to unique identifying information (see above description of <code>
+          enumerateDevices()</code> result), then this method returns <code>null</code>.
         </dd>
       </dl>
 

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2329,7 +2329,8 @@
                   a copy of <var>resultList</var>, and all its elements, where
                   the <code><a href=
                   "#widl-MediaDeviceInfo-label">label</a></code> member is the
-                  empty string.</p>
+                  empty string and the <code><a href=
+                  "#widl-MediaDeviceInfo-capabilities">capabilities</a></code> member is <code>null</code>.</p>
                 </li>
 
                 <li>
@@ -2360,7 +2361,7 @@
 
         <p>If access has been granted for a media device, the
         <code><a>MediaDeviceInfo</a></code> dictionary will contain the
-        deviceId, kind, label, and groupId.</p>
+        deviceId, kind, label, capabilities and groupId.</p>
       </section>
     </section>
 
@@ -2402,6 +2403,19 @@
           <p>A label describing this device (for example "External USB
           Webcam"). If the device has no associated label, then this attribute
           MUST return the empty string.</p>
+        </dd>
+
+        <dt>readonly attribute MediaTrackCapabilities capabilities</dt>
+
+        <dd>
+          <p>Returns a default set of capabilities describing the device's audio or video track
+          (according to its <code>kind</code> value), in the absence of any user-supplied constraints.
+          For input devices these capabilities will be identical to those that would have been obtained by calling
+          <code>getCapabilities()</code> on the first <code><a>MediaStreamTrack</a></code> of this type in a
+          <code><a>MediaStream</a></code> returned by <code>getUserMedia({deviceId: <i>id</i>})</code>
+          where <i>id</i> is the value of the <code>deviceId</code> attribute of this <code>MediaDeviceInfo</code>.
+          For output devices, the capabilities describe a hypothetical MediaStreamTrack whose characteristics
+          exactly match those of the device.</p>
         </dd>
 
         <dt>readonly attribute DOMString groupId</dt>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2333,8 +2333,7 @@
                   a copy of <var>resultList</var>, and all its elements, where
                   the <code><a href=
                   "#widl-MediaDeviceInfo-label">label</a></code> member is the
-                  empty string and the <code><a href=
-                  "#widl-MediaDeviceInfo-capabilities">capabilities</a></code> member is <code>null</code>.</p>
+                  empty string.</p>
                 </li>
 
                 <li>
@@ -2449,7 +2448,7 @@
         <dd>
           <p>Returns a <code><a>MediaTrackCapabilities</a></code> object describing the device's audio or video track
           (according to its <code>kind</code> value), in the absence of any user-supplied constraints.
-          For input devices these capabilities will be identical to those that would have been obtained by calling
+          These capabilities will be identical to those that would have been obtained by calling
           <code>getCapabilities()</code> on the first <code><a>MediaStreamTrack</a></code> of this type in a
           <code><a>MediaStream</a></code> returned by <code>getUserMedia({deviceId: <i>id</i>})</code>
           where <i>id</i> is the value of the <code>deviceId</code> attribute of this <code>MediaDeviceInfo</code>.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2405,17 +2405,18 @@
           MUST return the empty string.</p>
         </dd>
 
-        <dt>readonly attribute MediaTrackCapabilities capabilities</dt>
+        <dt>readonly attribute Object capabilities</dt>
 
         <dd>
-          <p>Returns a default set of capabilities describing the device's audio or video track
+          <p>For input devices, contains a <code><a>MediaTrackCapabilities</a></code> object describing the device's audio or video track
           (according to its <code>kind</code> value), in the absence of any user-supplied constraints.
           For input devices these capabilities will be identical to those that would have been obtained by calling
           <code>getCapabilities()</code> on the first <code><a>MediaStreamTrack</a></code> of this type in a
           <code><a>MediaStream</a></code> returned by <code>getUserMedia({deviceId: <i>id</i>})</code>
-          where <i>id</i> is the value of the <code>deviceId</code> attribute of this <code>MediaDeviceInfo</code>.
-          For output devices, the capabilities describe a hypothetical MediaStreamTrack whose characteristics
-          exactly match those of the device.</p>
+          where <i>id</i> is the value of the <code>deviceId</code> attribute of this <code>MediaDeviceInfo</code>.</p>
+
+          <p>For output devices, this attribute will always be <code>null</code>. Future changes to this API will address
+          the acquisition of output device capabilities.</p>
         </dd>
 
         <dt>readonly attribute DOMString groupId</dt>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2248,6 +2248,10 @@
           User Agent's available media input and output devices if enumeration
           is successful.</p>
 
+          <p>Elements of this sequence which represent input devices will be of type
+          <code><a>InputDeviceInfo</a></code> which extends <code><a>MediaDeviceInfo</a></code>
+          with input-specific elements.</p>
+
           <p>Camera and microphone sources <em class="rfc2119">should</em> be
           enumerable. Specifications that add additional types of source will
           provide recommendations about whether the source type should be
@@ -2361,7 +2365,7 @@
 
         <p>If access has been granted for a media device, the
         <code><a>MediaDeviceInfo</a></code> dictionary will contain the
-        deviceId, kind, label, capabilities and groupId.</p>
+        deviceId, kind, label, and groupId.</p>
       </section>
     </section>
 
@@ -2405,19 +2409,6 @@
           MUST return the empty string.</p>
         </dd>
 
-        <dt>readonly attribute Object capabilities</dt>
-
-        <dd>
-          <p>For input devices, contains a <code><a>MediaTrackCapabilities</a></code> object describing the device's audio or video track
-          (according to its <code>kind</code> value), in the absence of any user-supplied constraints.
-          For input devices these capabilities will be identical to those that would have been obtained by calling
-          <code>getCapabilities()</code> on the first <code><a>MediaStreamTrack</a></code> of this type in a
-          <code><a>MediaStream</a></code> returned by <code>getUserMedia({deviceId: <i>id</i>})</code>
-          where <i>id</i> is the value of the <code>deviceId</code> attribute of this <code>MediaDeviceInfo</code>.</p>
-
-          <p>For output devices, this attribute has the value <code>null</code>.</p>
-        </dd>
-
         <dt>readonly attribute DOMString groupId</dt>
 
         <dd>
@@ -2429,7 +2420,6 @@
 
         <dt>serializer = { attribute }</dt>
       </dl>
-
       <dl class="idl" title="enum MediaDeviceKind">
         <dt>audioinput</dt>
 
@@ -2450,6 +2440,24 @@
           <p>Represents a video input device; for example a webcam.</p>
         </dd>
       </dl>
+    </section>
+    <section>
+      <h2>Input-Specific Device Info</h2>
+      <dl class="idl" title="interface InputDeviceInfo : MediaDeviceInfo">
+        <dt>MediaTrackCapabilities getCapabilities()</dt>
+
+        <dd>
+          <p>Returns a <code><a>MediaTrackCapabilities</a></code> object describing the device's audio or video track
+          (according to its <code>kind</code> value), in the absence of any user-supplied constraints.
+          For input devices these capabilities will be identical to those that would have been obtained by calling
+          <code>getCapabilities()</code> on the first <code><a>MediaStreamTrack</a></code> of this type in a
+          <code><a>MediaStream</a></code> returned by <code>getUserMedia({deviceId: <i>id</i>})</code>
+          where <i>id</i> is the value of the <code>deviceId</code> attribute of this <code>MediaDeviceInfo</code>.</p>
+          <p>If no access has been granted to any local devices and this <code>InputDeviceInfo</code> has been filtered
+          with respect to unique identifying information (see above description of <code>enumerateDevices()</code> result), then this method returns <code>null</code>.
+        </dd>
+      </dl>
+
     </section>
   </section>
 


### PR DESCRIPTION
LC proposal documented in https://lists.w3.org/Archives/Public/public-media-capture/2015Jun/0034.html to allow applications to discover device capabilities.