### PR TITLE
Fix Not Found Error in gUM algorithm

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2798,17 +2798,6 @@
                   <code><a>name</a></code> attribute has the value
                   <code>SecurityError</code>.</p>
                 </li>
-
-                <li>
-                  <p><em>Constraint Failure</em>: Let <var>error</var> be a new
-                  <code><a>MediaStreamError</a></code> object whose
-                  <code><a>name</a></code> attribute has the value
-                  <code>ConstraintNotSatisfiedError</code> and whose
-                  <code><a href=
-                  "#widl-MediaStreamError-constraintName">constraintName</a></code>
-                  attribute is set to the name of the constraint that caused
-                  the error.</p>
-                </li>
               </ol>
             </li>
 

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2706,12 +2706,17 @@
                     </li>
                   </ol>
 
-                  <p>If <var>finalSet</var> is the empty set, let
-                  <var>error</var> be a new
-                  <code><a>DOMException</a></code> object whose
+                  <p>If <var>finalSet</var> is the empty set, reject
+                  <var>p</var> with a new
+                  <code><a>MediaStreamError</a></code> object whose
                   <code><a>name</a></code> attribute has the value
-                  <code>NotFoundError</code> and jump to the step labeled
-                  <em>Error Task</em> below.</p>
+                  <code>ConstraintNotSatisfiedError</code> and whose
+                  <code><a>constraintName</a></code> attribute is set
+                  to any required constraint whose fitness distance
+                  was infinity for all settings dictionaries examined
+                  while executing
+                  the <code><a>SelectSettings</a></code> algorithm, then
+                  abort these steps.</p>
                 </li>
 
                 <li>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2680,6 +2680,12 @@
 
                       <p>Call this set of tracks the
                       <var>candidateSet</var>.</p>
+
+                      <p>If <var>candidateSet</var> is the empty set,  reject
+                      <var>p</var> with a new
+                      <code><a>DOMException</a></code> object whose
+                      <code><a>name</a></code> attribute has the value
+                      <code>NotFoundError</code> and abort these steps.</p>
                     </li>
 
                     <li>If the value of the <var>T</var> entry of

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2787,6 +2787,17 @@
                   <code><a>name</a></code> attribute has the value
                   <code>SecurityError</code>.</p>
                 </li>
+
+                <li>
+                  <p><em>Constraint Failure</em>: Let <var>error</var> be a new
+                  <code><a>MediaStreamError</a></code> object whose
+                  <code><a>name</a></code> attribute has the value
+                  <code>ConstraintNotSatisfiedError</code> and whose
+                  <code><a href=
+                  "#widl-MediaStreamError-constraintName">constraintName</a></code>
+                  attribute is set to the name of the constraint that caused
+                  the error.</p>
+                </li>
               </ol>
             </li>
 


### PR DESCRIPTION
It appears that the rewrite of the gUM algorithm to use SelectSettings inadvertently changed some of the errors.  Specifically, the NotFoundError should have been for the case where no suitable sources were available even before applying constraints, and the ConstraintNotSatisfiedError should have been used for the case where no suitable sources were found after applying constraints, meaning that at least one required constraint could not be satisfied.
