### PR TITLE
Define MediaStreamError exclusively for legacy gUM callback interface use

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3104,6 +3104,8 @@
           Error in obtaining a <code><a>MediaStream</a></code> as described in the failure steps of the <a href="#widl-NavigatorUserMedia-getUserMedia-void-MediaStreamConstraints-constraints-NavigatorUserMediaSuccessCallback-successCallback-NavigatorUserMediaErrorCallback-errorCallback"><code>navigator.getUserMedia()</code></a> algorithm.
         </dd>
       </dl>
+      <dl class="idl" title=
+      "typedef (DOMException or OverconstrainedError) MediaStreamError">
     </section>
 
     <section>


### PR DESCRIPTION
The legacy callback-based gUM interface needs an error callback, for which it needs an error type value.  This typedef makes clear that we now only have two such kinds of errors:  DOMException and OverconstrainedError.
This is in partial fulfillment of Issue #162.
