### PR TITLE
remove DOMExceptions from error names table

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2177,6 +2177,14 @@
     <section>
       <h3>Error names</h3>
 
+      <p class="note">There is a known issue with this table of error
+      names, because <code>MediaStreamError</code> has been removed
+      but is still needed in the legacy, callback-based getUserMedia
+      interface.  This issue will be fixed through resolution
+      of <a href="https://github.com/w3c/mediacapture-main/pull/216">PR
+      #216</a>.
+      </p>
+
       <p>The table below lists the error names defined in this
       specification.</p>
 

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2182,7 +2182,7 @@
 
       <table>
         <caption>
-          <code><a>MediaStreamError</a></code> names
+          Error names
         </caption>
 
         <thead>
@@ -2197,22 +2197,6 @@
 
         <tbody>
           <tr>
-            <th><code><dfn>NotSupportedError</dfn></code></th>
-
-            <td>The operation is not supported.</td>
-
-            <td>Same as defined in [[DOM4]]</td>
-          </tr>
-
-          <tr>
-            <th><code><dfn>SecurityError</dfn></code></th>
-
-            <td>The user did not grant permission for the operation.</td>
-
-            <td></td>
-          </tr>
-
-          <tr>
             <th><code><dfn>OverconstrainedError</dfn></code></th>
 
             <td>One of the mandatory <a>Constraints</a> could not be
@@ -2220,31 +2204,6 @@
 
             <td>The <code>constraint</code> attribute gets set to the name
             of the constraint that caused the error</td>
-          </tr>
-
-          <tr>
-            <th><code><dfn>NotFoundError</dfn></code></th>
-
-            <td>The object can not be found here.</td>
-
-            <td>Same as defined in [[DOM4]]</td>
-          </tr>
-
-          <tr>
-            <th><code><dfn>AbortError</dfn></code></th>
-
-            <td>The operation was aborted.</td>
-
-            <td>Same as defined in [[DOM4]]</td>
-          </tr>
-
-          <tr>
-            <th><code><dfn>NotReadableError</dfn></code></th>
-
-            <td>The source of the MediaStream could not be accessed due to a
-            hardware error (e.g. lock from another process).</td>
-
-            <td></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Now that updates to the error names have been completed, can we just remove all the ones from this table that are actually DOMExceptions?