### PR TITLE
Issue #189: getUserMedia: Reject with TypeError if no media types are given

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2910,10 +2910,6 @@
 
           <ol>
             <li>
-              <p>Let <var>p</var> be a new promise.</p>
-            </li>
-
-            <li>
               <p>Let <var>constraints</var> be the method's first argument.</p>
             </li>
 
@@ -2924,11 +2920,12 @@
             </li>
 
             <li>
-              <p>If <var>requestedMediaTypes</var> is the empty set, reject
-              <var>p</var> with a new
-              <code><a>DOMException</a></code> object whose
-              <code><a>name</a></code> attribute has the value
-              <code>NotSupportedError</code> and return <var>p</var>.</p>
+              <p>If <var>requestedMediaTypes</var> is the empty set, return a
+              promise rejected with a <code>TypeError</code>.</p>
+            </li>
+
+            <li>
+              <p>Let <var>p</var> be a new promise.</p>
             </li>
 
             <li>


### PR DESCRIPTION
Also moved bullet where p, the promise, is created to align with style in Promise Guide.