### PR TITLE
make applyConstraints arg optional to fix webidl error

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1,4 +1,4 @@
-x<!DOCTYPE html>
+<!DOCTYPE html>
 <!--
    To publish this document, see instructions in README
    -->

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+x<!DOCTYPE html>
 <!--
    To publish this document, see instructions in README
    -->
@@ -1083,7 +1083,7 @@
 
           <dd>
             <dl class="parameters">
-              <dt>MediaTrackConstraints constraints</dt>
+              <dt>optional MediaTrackConstraints constraints</dt>
 
               <dd>
                 <p>A new constraint structure to apply to this object.</p>
@@ -3488,7 +3488,7 @@ if(!supports["width"] || !supports["height"]) {
 
         <dd>
           <dl class="parameters">
-            <dt>Constraints constraints</dt>
+            <dt>optional Constraints constraints</dt>
 
             <dd>
               <p>A new constraint structure to apply to this object.</p>


### PR DESCRIPTION
```
 0:17.87 WebIDL.WebIDLError: error: Dictionary argument or union argument containing a dictionary not followed by a required argument must be optional, /Users/Jan/moz/mozilla-central/dom/webidl/MediaStreamTrack.webidl line 75:67
 0:17.87     Promise<void>          applyConstraints (MediaTrackConstraints constraints);
 0:17.87                                                                    ^
```

From https://heycam.github.io/webidl/#idl-operations

"If the type of an argument is a dictionary type or a union type that has a dictionary type as one of its flattened member types, and that dictionary type and its ancestors have no required members, and the argument is either the final argument or is followed only by optional arguments, then the argument MUST be specified as optional. Such arguments are always considered to have a default value of an empty dictionary, unless otherwise specified."