### PR TITLE
Align onoverconstrained

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3770,13 +3770,17 @@ if(!supports["width"] || !supports["height"]) {
         <dt>attribute EventHandler onoverconstrained</dt>
 
         <dd>
-          This event handler, of type <code><a>overconstrained</a></code>, is
-          executed when the User Agent is no longer able to satisfy the
-          <var>requiredConstraints</var> from the currently valid Constraints.
-          <p>
+          The event type of this event handler is <code><a>overconstrained</a></code>.
+          <p>When the User Agent is no longer able to satisfy the
+          <var>requiredConstraints</var> from the currently valid
+          Constraints, the User Agent MUST queue a task that fires
+          an <code>OverconstrainedErrorEvent</code>, initialized
+          as described in the following paragraph, at the constrainable object.
+          The event firing task MAY also be used to update the
+          constrainable object as a result of the overconstrained
+          situation.</p>
 
-          <p>When executed, the event handler is passed an
-          <code>OverconstrainedErrorEvent</code> as parameter, which
+          <p>The <code>OverconstrainedErrorEvent</code>
           references an
           <code><a>OverconstrainedError</a></code> whose
           <code>constraint</code> attribute is set to one of the

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3467,6 +3467,30 @@ if(!supports["width"] || !supports["height"]) {
       "#media-stream-track-interface-definition">MediaStreamTrack Interface
       Definition</a> for an example of this.</p>
 
+          <p>When the User Agent is no longer able to satisfy the
+          <var>requiredConstraints</var> from the currently valid
+          Constraints, the User Agent MUST queue a task that fires
+          an <code>OverconstrainedErrorEvent</code>, initialized
+          as described in the following paragraph, at the constrainable object.
+          The event firing task MAY also be used to update the
+          constrainable object as a result of the overconstrained
+          situation.</p>
+
+          <p>The <code>OverconstrainedErrorEvent</code>
+          references an
+          <code><a>OverconstrainedError</a></code> whose
+          <code>constraint</code> attribute is set to one of the
+          <var>requiredConstraints</var> that can no longer be satisfied. The
+          <code>message</code> attribute of
+          the <code>OverconstrainedError</code> SHOULD contain a
+          string that is useful for debugging. The conditions under
+          which this error might occur are platform and
+          application-specific. For example, the user might physically
+          manipulate a camera in a way that makes it impossible to
+          provide a resolution that satisfies the constraints. The
+          User Agent MAY take other actions as a result of the
+          overconstrained situation.</p>
+
       <dl class="idl" title=
       "[NoInterfaceObject] interface ConstrainablePattern">
         <dt>Capabilities getCapabilities()</dt>
@@ -3771,30 +3795,6 @@ if(!supports["width"] || !supports["height"]) {
 
         <dd>
           The event type of this event handler is <code><a>overconstrained</a></code>.
-          <p>When the User Agent is no longer able to satisfy the
-          <var>requiredConstraints</var> from the currently valid
-          Constraints, the User Agent MUST queue a task that fires
-          an <code>OverconstrainedErrorEvent</code>, initialized
-          as described in the following paragraph, at the constrainable object.
-          The event firing task MAY also be used to update the
-          constrainable object as a result of the overconstrained
-          situation.</p>
-
-          <p>The <code>OverconstrainedErrorEvent</code>
-          references an
-          <code><a>OverconstrainedError</a></code> whose
-          <code>constraint</code> attribute is set to one of the
-          <var>requiredConstraints</var> that can no longer be satisfied. The
-          <code>message</code> attribute of
-          the <code>OverconstrainedError</code> SHOULD contain a
-          string that is useful for debugging. The conditions under
-          which this error might occur are platform and
-          application-specific. For example, the user might physically
-          manipulate a camera in a way that makes it impossible to
-          provide a resolution that satisfies the constraints. The
-          User Agent MAY take other actions as a result of the
-          overconstrained situation.</p>
-          <p>
         </dd>
       </dl>
 


### PR DESCRIPTION
To address issue #227.   The changes are split into two commits -- the first makes wording changes, and the second merely moves the new text to a new location.
