### PR TITLE
Fix applyConstraints steps to avoid unused var and bail on reject. 

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4038,12 +4038,11 @@ if(!supports["width"] || !supports["height"]) {
                   calling
                   <code>OverconstrainedError(<var>failedConstraint</var>,
                   <var>message</var>)</code>.  The
-                  <var>existingConstraints</var> remain in effect in
-                  this case.</p>
+                  existing constraints remain in effect in this case.</p>
                 </li>
 
                 <li>In a single operation, remove
-                <var>existingConstraints</var> from <var>object</var>, apply
+                the existing constraints from <var>object</var>, apply
                 <var>newConstraints</var>, and apply
                 <var>successfulSettings</var> as the current settings.</li>
 

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4032,12 +4032,12 @@ if(!supports["width"] || !supports["height"]) {
                   the <code><a>SelectSettings</a></code> algorithm,
                   let <var>message</var> be
                   either <code>undefined</code> or an informative
-                  human-readable message, and reject <var>p</var> with
+                  human-readable message, reject <var>p</var> with
                   a new
                   <code>OverconstrainedError</code> created by
                   calling
                   <code>OverconstrainedError(<var>failedConstraint</var>,
-                  <var>message</var>)</code>.  The
+                  <var>message</var>)</code>, and abort these steps.  The
                   existing constraints remain in effect in this case.</p>
                 </li>
 


### PR DESCRIPTION
The steps never bail after rejecting the promise, causing *newConstraints* to be applied regardless of failure. I also removed the use of the undefined *existingConstraints* variable.