### PR TITLE
Reformat with enforced line wrap at 80

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
  - git clone https://github.com/w3c/webrtc-respec-ci.git
  - make -f webrtc-respec-ci/Makefile travissetup
 script:
- - make -f webrtc-respec-ci/Makefile check
+ - make -f webrtc-respec-ci/Makefile check LINEWRAP=true LINEWRAPLENGTH=80

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2,98 +2,81 @@
 <!--
    To publish this document, see instructions in README
    -->
-
 <html lang="en-us">
 <head>
   <link href="getusermedia.css" rel="stylesheet" type="text/css">
-
   <title>Media Capture and Streams</title>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <script class="remove" src=
   "https://www.w3.org/Tools/respec/respec-w3c-common" type="text/javascript">
-// &lt;!-- keep this comment --&gt; // 
+  // &lt;!-- keep this comment --&gt; // 
   </script>
   <script class="remove" src="getusermedia.js" type="text/javascript">
-//
+  //
     &lt;!-- keep this comment --&gt; // 
   </script>
 </head>
-
 <body>
   <section id="abstract">
     <p>This document defines a set of JavaScript APIs that allow local media,
     including audio and video, to be requested from a platform.</p>
   </section>
-
   <section id="sotd">
     <p>This document is not complete. It is subject to major changes and, while
     early experimentations are encouraged, it is therefore not intended for
     implementation. The API is based on preliminary work done in the
     WHATWG.</p>
   </section>
-
   <section class="informative" id="intro">
     <h2>Introduction</h2>
-
     <p>This document defines APIs for requesting access to local multimedia
     devices, such as microphones or video cameras.</p>
-
     <p>This document also defines the MediaStream API, which provides the means
     to control where multimedia stream data is consumed, and provides some
     control over the devices that produce the media. It also exposes
     information about devices able to capture and render media.</p>
   </section>
-
   <section id="conformance">
     <p>This specification defines conformance criteria that apply to a single
     product: the <dfn>User Agent</dfn> that implements the interfaces that it
     contains.</p>
-
     <p>Conformance requirements phrased as algorithms or specific steps may be
     implemented in any manner, so long as the end result is equivalent. (In
     particular, the algorithms defined in this specification are intended to be
     easy to follow, and not intended to be performant.)</p>
-
     <p>Implementations that use ECMAScript [[ECMA-262]] to implement the APIs
     defined in this specification must implement them in a manner consistent
     with the ECMAScript Bindings defined in the Web IDL specification
     [[!WEBIDL-1]], as this specification uses that specification and
     terminology.</p>
   </section>
-
   <section>
     <h2>Terminology</h2>
-
     <dl>
       <dt><i>HTML Terms:</i></dt>
-
       <dd>
         <p>The <code><a href=
         "http://dev.w3.org/html5/spec/webappapis.html#eventhandler">EventHandler</a></code>
         interface represents a callback used for event handlers as defined in
         [[!HTML5]].</p>
-
         <p>The concepts <dfn><a href=
         "http://dev.w3.org/html5/spec/webappapis.html#queue-a-task">queue a
         task</a></dfn> and <dfn><a href=
         "http://dev.w3.org/html5/spec/webappapis.html#fire-a-simple-event">fires
         a simple event</a></dfn> are defined in [[!HTML5]].</p>
-
         <p>The terms <dfn><a href=
         "http://dev.w3.org/html5/spec/webappapis.html#event-handlers">event
         handlers</a></dfn> and <dfn><a href=
         "http://dev.w3.org/html5/spec/webappapis.html#event-handler-event-type">
         event handler event types</a></dfn> are defined in [[!HTML5]].</p>
       </dd>
-
       <dt><code><dfn>DOMException</dfn></code></dt>
-
-      <dd>The term <code>DOMException</code> is defined
-      in <a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMException">WebIDL</a>
-        [[!WEBIDL-1]]</dd>
-
+      <dd>
+        The term <code>DOMException</code> is defined in <a href=
+        "https://www.w3.org/TR/WebIDL-1/#idl-DOMException">WebIDL</a>
+        [[!WEBIDL-1]]
+      </dd>
       <dt><dfn>source</dfn></dt>
-
       <dd>
         <p>A source is the "thing" providing the source of a media stream
         track. The source is the broadcaster of the media itself. A source can
@@ -101,20 +84,17 @@
         user's hard drive, network resource, or static image. Note that this
         document describes the use of microphone and camera type sources only,
         the use of other source types is described in other documents.</p>
-
         <p>An application that has no prior authorization regarding sources is
         only given the number of available sources, their type and any
         relationship to other devices. Additional information about sources can
         become available when applications are authorized to use a source (see
         <a href="#access-control-model"></a>).</p>
-
         <p>Sources <strong>do not</strong> have constraints — tracks have
         constraints. When a source is connected to a track, it must produce
         media that conforms to the constraints present on that track. Multiple
         tracks can be attached to the same source. User Agent processing, such
         as downsampling, MAY be used to ensure that all tracks have appropriate
         media.</p>
-
         <p>Sources have constrainable properties which have
         <code><a>capabilities</a></code> and <code><a>settings</a></code>. The
         constrainable properties are "owned" by the source and are common to
@@ -123,47 +103,38 @@
         capability or setting information, they will get back the same
         answer).</p>
       </dd>
-
       <dt>Setting (Source Setting)</dt>
-
       <dd>
         <p>A <a href="#settings">setting</a> refers to the immediate, current
         value of the source's constrainable properties. Settings are always
         read-only.</p>
-
         <p>A source's settings can change dynamically over time due to
         environmental conditions, sink configurations, or constraint changes. A
         source's settings must always conform to the current set of mandatory
         constraints on all attached tracks. A source that cannot conform to
         mandatory constraints causes affected tracks to become
-        <a>overconstrained</a> and therefore <a href="#track-muted">muted</a>. A <a>User Agent</a>
-        attempts to ensure that sources adhere to optional constraints as
-        closely as possible, see <a href="#constrainable-interface"></a>.</p>
-
+        <a>overconstrained</a> and therefore <a href="#track-muted">muted</a>.
+        A <a>User Agent</a> attempts to ensure that sources adhere to optional
+        constraints as closely as possible, see <a href=
+        "#constrainable-interface"></a>.</p>
         <p>Although settings are a property of the source, they are only
         exposed to the application through the tracks attached to the source.
         This is exposed via the <a>ConstrainablePattern</a> interface.</p>
       </dd>
-
       <dt>Capabilities</dt>
-
       <dd>
         <p>For each constrainable property, there is a capability that
         describes whether it is supported by the source and if so, the range of
         supported values. As with settings, capabilities are exposed to the
         application via the <a>ConstrainablePattern</a> interface.</p>
-
         <p>The values of the supported capabilities must be normalized to the
         ranges and enumerated types defined in this specification.</p>
-
         <p>A <a>getCapabilities()</a> call on a track returns the same
         underlying per-source capabilities for all tracks connected to the
         source.</p>
-
         <p>Source capabilities are effectively constant. Applications should be
         able to depend on a specific source having the same capabilities for
         any browsing session.</p>
-
         <p>This API is intentionally simplified. Capabilities are not capable
         of describing interactions between different values. For instance, it
         is not possible to accurately describe the capabilities of a camera
@@ -172,26 +143,21 @@
         complete range of each value. Interactions between constraints are
         exposed by attempting to apply constraints.</p>
       </dd>
-
       <dt><dfn>Constraints</dfn></dt>
-
       <dd>
         <p>Constraints provide a general control surface that allows
         applications to both select an appropriate source for a track and, once
         selected, to influence how a source operates.</p>
-
         <p>Constraints limit the range of operating modes that a source can use
         when providing media for a track. Without provided track constraints,
         implementations are free to select a source's settings from the full
         ranges of its supported capabilities. Implementations may also adjust
         source settings at any time within the bounds imposed by all applied
         constraints.</p>
-
         <p><a>getUserMedia()</a> uses constraints to help select an appropriate
         source for a track and configure it. Additionally, the
         <a>ConstrainablePattern</a> interface on tracks includes an API for
         dynamically changing the track's constraints at any later time.</p>
-
         <p>A track will not be connected to a source using
         <a>getUserMedia()</a> if its initial constraints cannot be satisfied.
         However, the ability to meet the constraints on a track can change over
@@ -200,30 +166,23 @@
         defines an appropriate error to inform the application. <a href=
         "#the-model-sources-sinks-constraints-and-settings"></a> explains how
         constraints interact in more detail.</p>
-
         <p>In general, User Agents will have more flexibility to optimize the
         media streaming experience the fewer constraints are applied, so
         application authors are strongly encouraged to use mandatory
         constraints sparingly.</p>
-
         <p>For each constrainable property, a constraint exists whose name
         corresponds with the relevant source setting name and capability
         name.</p>
       </dd>
-
       <dt><code>RTCPeerConnection</code></dt>
-
       <dd><dfn><code>RTCPeerConnection</code></dfn> is defined in
       [[WEBRTC10]].</dd>
     </dl>
   </section>
-
   <section id="stream-api">
     <h2>MediaStream API</h2>
-
     <section>
       <h2>Introduction</h2>
-
       <p>The two main components in the MediaStream API are the
       <code><a>MediaStreamTrack</a></code> and <code><a>MediaStream</a></code>
       interfaces. The <code><a>MediaStreamTrack</a></code> object represents
@@ -232,7 +191,6 @@
       <code><a>MediaStream</a></code> is used to group several
       <code><a>MediaStreamTrack</a></code> objects into one unit that can be
       recorded or rendered in a media element.</p>
-
       <p>Each <code><a>MediaStream</a></code> can contain zero or more
       <code><a>MediaStreamTrack</a></code> objects. All tracks in a
       <code><a>MediaStream</a></code> are intended to be synchronized when
@@ -240,7 +198,6 @@
       to synchronize tracks from sources that have different clocks. Different
       <code><a>MediaStream</a></code> objects do not need to be
       synchronized.</p>
-
       <p class="note">While the intent is to synchronize tracks, it could be
       better in some circumstances to permit tracks to lose synchronization. In
       particular, when tracks are remotely sourced and real-time [[WEBRTC10]],
@@ -248,14 +205,12 @@
       delays or risk glitches and other artifacts. Implementations are expected
       to understand the implications of choices regarding synchronization of
       playback and the effect that these have on user perception.</p>
-
       <p>A single <code><a>MediaStreamTrack</a></code> can represent
       multi-channel content, such as stereo or 5.1 audio or stereoscopic video,
       where the channels have a well defined relationship to each other.
       Information about channels might be exposed through other APIs, such as
       [[WEBAUDIO]], but this specification provides no direct access to
       channels.</p>
-
       <p>A <code><a>MediaStream</a></code> object has an input and an output
       that represent the combined input and output of all the object's tracks.
       The output of the <code><a>MediaStream</a></code> controls how the object
@@ -263,7 +218,6 @@
       what is displayed if the object is used in a <code>video</code> element.
       A single <code><a>MediaStream</a></code> object can be attached to
       multiple different outputs at the same time.</p>
-
       <p>A new <code><a>MediaStream</a></code> object can be created from
       existing media streams or tracks using the <code><a href=
       "#dom-mediastream">MediaStream()</a></code> constructor. The constructor
@@ -272,7 +226,6 @@
       new <code><a>MediaStream</a></code> object, or an array of
       <code><a>MediaStreamTrack</a></code> objects. The latter form makes it
       possible to compose a stream from different source streams.</p>
-
       <p>Both <code><a>MediaStream</a></code> and
       <code><a>MediaStreamTrack</a></code> objects can be cloned. A cloned
       <code><a>MediaStream</a></code> contains clones of all member tracks from
@@ -283,64 +236,52 @@
       <a>consumer</a>s. The <code>MediaStream</code> object is also used in
       contexts outside <code>getUserMedia</code>, such as [[WEBRTC10]].</p>
     </section>
-
     <section>
       <h2>MediaStream</h2>
-
       <p>The <dfn id="dom-mediastream"><code>MediaStream()</code></dfn>
       constructor composes a new stream out of existing tracks. It takes an
       optional argument of type <code><a>MediaStream</a></code> or an array of
       <code><a>MediaStreamTrack</a></code> objects. <dfn id=
       "mediastream-constructor">When the constructor is invoked</dfn>, the User
       Agent must run the following steps:</p>
-
       <ol>
         <li>
           <p>Let <var>stream</var> be a newly constructed
           <code><a>MediaStream</a></code> object.</p>
         </li>
-
         <li>
           <p>Initialize <var>stream's</var> <code><a href=
           "#dom-mediastream-id">id</a></code> attribute to a newly generated
           value.</p>
         </li>
-
         <li>
           <p>If the constructor's argument is present, construct a set of
           tracks, <var>tracks</var> based on the type of argument:</p>
-
           <ul>
             <li>
               <p>A <code><a>MediaStream</a></code> object:</p>
-
               <p>Let <var>tracks</var> be a set containing all the
               <code><a>MediaStreamTrack</a></code> objects in the
               <code><a>MediaStream</a></code> <a href="#track-set">track
               set</a>.</p>
             </li>
-
             <li>
               <p>A sequence of <code><a>MediaStreamTrack</a></code>
               objects:</p>
-
               <p>Let <var>tracks</var> be a set containing all the
               <code><a>MediaStreamTrack</a></code> objects in the provided
               sequence.</p>
             </li>
           </ul>
         </li>
-
         <li>
-          <p><a href="#stream-add-track">Add each track</a> in <var>tracks</var>
-          to <var>stream</var>.</p>
+          <p><a href="#stream-add-track">Add each track</a> in
+          <var>tracks</var> to <var>stream</var>.</p>
         </li>
-
         <li>
           <p>Return <var>stream</var>.</p>
         </li>
       </ol>
-
       <p>The tracks of a <code><a>MediaStream</a></code> are stored in a
       <dfn id="track-set">track set</dfn>. The track set MUST contain the
       <code><a>MediaStreamTrack</a></code> objects that correspond to the
@@ -349,7 +290,6 @@
       The proper way to find a specific <code><a>MediaStreamTrack</a></code>
       object in the set is to look it up by its <code><a href=
       "#dom-mediastreamtrack-id">id</a></code>.</p>
-
       <p>An object that reads data from the output of a
       <code><a>MediaStream</a></code> is referred to as a
       <code><a>MediaStream</a></code> <dfn>consumer</dfn>. The list of
@@ -360,175 +300,140 @@
       (<code>MediaRecorder</code>) [[mediastream-recording]], image capture
       (<code>ImageCapture</code>) [[image-capture]], and web audio
       (<code>MediaStreamAudioSourceNode</code>) [[WEBAUDIO]].</p>
-
       <p class="note"><code><a>MediaStream</a></code> consumers must be able to
       handle tracks being added and removed. This behavior is specified per
       consumer.</p>
-
       <p>A <code><a>MediaStream</a></code> object is said to be <dfn id=
       "stream-active">active</dfn> when it has at least one
       <code><a>MediaStreamTrack</a></code> that has not <a href=
       "#track-ended">ended</a>. A <code><a>MediaStream</a></code> that does not
       have any tracks or only has tracks that are <a href=
       "#track-ended">ended</a> is <dfn id="stream-inactive">inactive</dfn>.</p>
-
       <p>To <dfn id="stream-add-track">add a track</dfn> to a
-      <code><a>MediaStream</a></code>, the User Agent MUST run the
-      following steps:</p>
-
+      <code><a>MediaStream</a></code>, the User Agent MUST run the following
+      steps:</p>
       <ol>
         <li>
-          <p>Let <var>track</var> be the
-          <code><a>MediaStreamTrack</a></code> in question and
-          <var>stream</var> the <code><a>MediaStream</a></code>
+          <p>Let <var>track</var> be the <code><a>MediaStreamTrack</a></code>
+          in question and <var>stream</var> the <code><a>MediaStream</a></code>
           object to which <var>track</var> is to be added.</p>
         </li>
-
         <li>
           <p>If <var>track</var> is already in <var>stream's</var> <a href=
           "#track-set">track set</a>, then abort these steps.</p>
         </li>
-
         <li>
           <p>Add <var>track</var> to <var>stream</var>'s <a href=
           "#track-set">track set</a>.</p>
         </li>
       </ol>
-      
-            <p>To <dfn id="stream-remove-track">remove a track</dfn> from a
-      <code><a>MediaStream</a></code>, the User Agent MUST run the
-      following steps:</p>
-
+      <p>To <dfn id="stream-remove-track">remove a track</dfn> from a
+      <code><a>MediaStream</a></code>, the User Agent MUST run the following
+      steps:</p>
       <ol>
         <li>
-          <p>Let <var>track</var> be the
-          <code><a>MediaStreamTrack</a></code> in question and
-          <var>stream</var> the <code><a>MediaStream</a></code>
+          <p>Let <var>track</var> be the <code><a>MediaStreamTrack</a></code>
+          in question and <var>stream</var> the <code><a>MediaStream</a></code>
           object from which <var>track</var> is to be removed.</p>
         </li>
-
         <li>
           <p>If <var>track</var> is not in <var>stream's</var> <a href=
           "#track-set">track set</a>, then abort these steps.</p>
         </li>
-
         <li>
           <p>Remove <var>track</var> from <var>stream</var>'s <a href=
           "#track-set">track set</a>.</p>
         </li>
       </ol>
-
       <p>The User Agent may update a <code><a>MediaStream</a></code>'s <a href=
-      "#track-set">track set</a> in response to, for example, an external event.
-      This specification does not specify any such cases, but other specifications
-      using the MediaStream API may. One such example is the WebRTC 1.0
-      [[WEBRTC10]] specification where the <a href="#track-set">track set</a>
-      of a <code><a>MediaStream</a></code>, received from another peer, can be
-      updated as a result of changes to the media session.</p>
-
-      <p>When the User Agent initiates adding a track to a <code>
-      <a>MediaStream</a></code>, with the exception of initializing a newly
-      created <code><a>MediaStream</a></code> with tracks, the User Agent MUST
-      queue a task that runs the following steps:</p>
-
+      "#track-set">track set</a> in response to, for example, an external
+      event. This specification does not specify any such cases, but other
+      specifications using the MediaStream API may. One such example is the
+      WebRTC 1.0 [[WEBRTC10]] specification where the <a href=
+      "#track-set">track set</a> of a <code><a>MediaStream</a></code>, received
+      from another peer, can be updated as a result of changes to the media
+      session.</p>
+      <p>When the User Agent initiates adding a track to a
+      <code><a>MediaStream</a></code>, with the exception of initializing a
+      newly created <code><a>MediaStream</a></code> with tracks, the User Agent
+      MUST queue a task that runs the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>track</var> be the
-          <code><a>MediaStreamTrack</a></code> in question and
-          <var>stream</var> the <code><a>MediaStream</a></code>
+          <p>Let <var>track</var> be the <code><a>MediaStreamTrack</a></code>
+          in question and <var>stream</var> the <code><a>MediaStream</a></code>
           object to which <var>track</var> is to be added.</p>
         </li>
-
         <li>
           <p><a href="#stream-add-track">Add</a> <var>track</var> to
           <var>stream</var>.</p>
         </li>
-
         <li>
           <p>If the operation in the previous step was aborted prematurely,
           then abort these steps.</p>
         </li>
-
         <li>
           <p>Fire a track event named <code><a href=
           "#event-mediastream-addtrack">addtrack</a></code> with
           <var>track</var> at <var>stream</var>.</p>
         </li>
       </ol>
-
-      <p>When the User Agent initiates removing a track from a <code>
-      <a>MediaStream</a></code>, the User Agent MUST queue a task that runs the
-      following steps:</p>
-
+      <p>When the User Agent initiates removing a track from a
+      <code><a>MediaStream</a></code>, the User Agent MUST queue a task that
+      runs the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>track</var> be the
-          <code><a>MediaStreamTrack</a></code> in question and
-          <var>stream</var> the <code><a>MediaStream</a></code>
+          <p>Let <var>track</var> be the <code><a>MediaStreamTrack</a></code>
+          in question and <var>stream</var> the <code><a>MediaStream</a></code>
           object to which <var>track</var> is to be added.</p>
         </li>
-
         <li>
           <p><a href="#stream-remove-track">Remove</a> <var>track</var> from
           <var>stream</var>.</p>
         </li>
-
         <li>
           <p>If the operation in the previous step was aborted prematurely,
           then abort these steps.</p>
         </li>
-
         <li>
           <p>Fire a track event named <code><a href=
           "#event-mediastream-removetrack">removetrack</a></code> with
           <var>track</var> at <var>stream</var>.</p>
         </li>
       </ol>
-
-      <dl class="idl" title="[Exposed=Window] interface MediaStream : EventTarget">
+      <dl class="idl" title=
+      "[Exposed=Window] interface MediaStream : EventTarget">
         <dt>Constructor()</dt>
-
         <dd>
           <p>See the <a href="#mediastream-constructor">MediaStream constructor
           algorithm</a></p>
         </dd>
-
         <dt>Constructor(MediaStream stream)</dt>
-
         <dd>
           <p>See the <a href="#mediastream-constructor">MediaStream constructor
           algorithm</a></p>
         </dd>
-
         <dt>Constructor(sequence&lt;MediaStreamTrack&gt; tracks)</dt>
-
         <dd>
           <p>See the <a href="#mediastream-constructor">MediaStream constructor
           algorithm</a></p>
         </dd>
-
         <dt>readonly attribute DOMString id</dt>
-
         <dd>
           <p>When a <code><a>MediaStream</a></code> object is created, the User
           Agent MUST generate an identifier string, and MUST initialize the
           object's <code><a href="#dom-mediastream-id">id</a></code> attribute
           to that string. A good practice is to use a UUID [[rfc4122]], which
           is 36 characters long in its canonical form. To avoid fingerprinting,
-          implementations SHOULD use the forms in section 4.4 or 4.5 of
-          RFC 4122 when generating UUIDs.</p>
-
-          <p>The <dfn data-lt-noDefault id="dom-mediastream-id"><code>id</code></dfn> attribute
-          MUST return the value to which it was initialized when the object was
-          created.</p>
+          implementations SHOULD use the forms in section 4.4 or 4.5 of RFC
+          4122 when generating UUIDs.</p>
+          <p>The <dfn data-lt-nodefault="" id=
+          "dom-mediastream-id"><code>id</code></dfn> attribute MUST return the
+          value to which it was initialized when the object was created.</p>
         </dd>
-
         <dt>sequence&lt;MediaStreamTrack&gt; getAudioTracks()</dt>
-
         <dd>
           <p>Returns a sequence of <code><a>MediaStreamTrack</a></code> objects
           representing the audio tracks in this stream.</p>
-
           <p>The <dfn id=
           "dom-mediastream-getaudiotracks"><code>getAudioTracks()</code></dfn>
           method MUST return a sequence that represents a snapshot of all the
@@ -539,13 +444,10 @@
           "#track-set">track set</a> to the sequence is User Agent defined and
           the order does not have to be stable between calls.</p>
         </dd>
-
         <dt>sequence&lt;MediaStreamTrack&gt; getVideoTracks()</dt>
-
         <dd>
           <p>Returns a sequence of <code><a>MediaStreamTrack</a></code> objects
           representing the video tracks in this stream.</p>
-
           <p>The <dfn id=
           "dom-mediastream-getvideotracks"><code>getVideoTracks()</code></dfn>
           method MUST return a sequence that represents a snapshot of all the
@@ -556,13 +458,10 @@
           "#track-set">track set</a> to the sequence is User Agent defined and
           the order does not have to be stable between calls.</p>
         </dd>
-
         <dt>sequence&lt;MediaStreamTrack&gt; getTracks()</dt>
-
         <dd>
           <p>Returns a sequence of <code><a>MediaStreamTrack</a></code> objects
           representing all the tracks in this stream.</p>
-
           <p>The <dfn id=
           "dom-mediastream-gettracks"><code>getTracks()</code></dfn> method
           MUST return a sequence that represents a snapshot of all the
@@ -572,9 +471,7 @@
           <a href="#track-set">track set</a> to the sequence is User Agent
           defined and the order does not have to be stable between calls.</p>
         </dd>
-
         <dt>MediaStreamTrack? getTrackById(DOMString trackId)</dt>
-
         <dd>
           <p>The <dfn id=
           "dom-mediastream-gettrackbyid"><code>getTrackById()</code></dfn>
@@ -583,167 +480,132 @@
           <code><a href="#dom-mediastreamtrack-id">id</a></code> is equal to
           <var>trackId</var>, or null, if no such track exists.</p>
         </dd>
-
         <dt>void addTrack(MediaStreamTrack track)</dt>
-
         <dd>
           <p>Adds the given <code><a>MediaStreamTrack</a></code> to this
           <code><a>MediaStream</a></code>.</p>
-
           <p>When the <dfn id=
           "dom-mediastream-addtrack"><code>addTrack()</code></dfn> method is
           invoked, the User Agent MUST <a href="#stream-add-track">add the
           track</a>, specified by the method's first argument, to this
           <code><a>MediaStream</a></code>.</p>
         </dd>
-
         <dt>void removeTrack(MediaStreamTrack track)</dt>
-
         <dd>
           <p>Removes the given <code><a>MediaStreamTrack</a></code> object from
           this <code><a>MediaStream</a></code>.</p>
-
           <p>When the <dfn id=
-          "dom-mediastream-removetrack"><code>removeTrack()</code></dfn> method is
-          invoked, the User Agent MUST <a href="#stream-remove-track">remove the
-          track</a>, specified by the method's first argument, from this
+          "dom-mediastream-removetrack"><code>removeTrack()</code></dfn> method
+          is invoked, the User Agent MUST <a href="#stream-remove-track">remove
+          the track</a>, specified by the method's first argument, from this
           <code><a>MediaStream</a></code>.</p>
         </dd>
-
         <dt>MediaStream clone()</dt>
-
         <dd>
           <p>Clones the given <code><a>MediaStream</a></code> and all its
           tracks.</p>
-
-          <p>When the <code>clone()</code> method
-          is invoked, the User Agent MUST run the following steps:</p>
-
+          <p>When the <code>clone()</code> method is invoked, the User Agent
+          MUST run the following steps:</p>
           <ol>
             <li>
               <p>Let <var>streamClone</var> be a newly constructed
               <code><a>MediaStream</a></code> object.</p>
             </li>
-
             <li>
               <p>Initialize <var>streamClone</var>'s <code><a href=
               "#dom-mediastream-id">id</a></code> attribute to a newly
               generated value.</p>
             </li>
-
             <li>
               <p><a href="#track-clone">Clone each track</a> in this
               <code><a>MediaStream</a></code> object and add the result to
               <var>streamClone</var>'s <a href="#track-set">track set</a>.</p>
             </li>
-
             <li>Return <var>streamClone</var>.</li>
           </ol>
         </dd>
-
         <dt>readonly attribute boolean active</dt>
-
         <dd>
-          <p>The <code>active</code> attribute
-          MUST return <code>true</code> if this <code><a>MediaStream</a></code>
-          is <a href="#stream-active">active</a> and <code>false</code>
-            otherwise.</p>
+          <p>The <code>active</code> attribute MUST return <code>true</code> if
+          this <code><a>MediaStream</a></code> is <a href=
+          "#stream-active">active</a> and <code>false</code> otherwise.</p>
         </dd>
-
         <dt>attribute EventHandler onaddtrack</dt>
-
         <dd>
           <p>The event type of this event handler is <code><a href=
           "#event-mediastream-addtrack">addtrack</a></code>.</p>
         </dd>
-
         <dt>attribute EventHandler onremovetrack</dt>
-
         <dd>
           <p>The event type of this event handler is <code><a href=
           "#event-mediastream-removetrack">removetrack</a></code>.</p>
         </dd>
       </dl>
     </section>
-
     <section>
       <h2>MediaStreamTrack</h2>
-
       <p>A <code><a>MediaStreamTrack</a></code> object represents a media
       source in the User Agent. Several <code><a>MediaStreamTrack</a></code>
       objects can represent the same media source, e.g., when the user chooses
       the same camera in the UI shown by two consecutive calls to
       <code><a>getUserMedia()</a></code> .</p>
-
       <p>The data from a <code><a>MediaStreamTrack</a></code> object does not
       necessarily have a canonical binary form; for example, it could just be
       "the video currently coming from the user's video camera". This allows
       User Agents to manipulate media in whatever fashion is most suitable on
       the user's platform.</p>
-
       <p>A script can indicate that a <code><a>MediaStreamTrack</a></code>
-      object no longer needs its source with the
-      <code><a href="#dom-mediastreamtrack-stop">stop()</a></code> method.
-      When all tracks using a source have been stopped or ended by some other
-      means, the source is <dfn id="source-stopped">stopped</dfn>. Unless there
-      is a stored permission for the source in question, the given permission is
-      revoked and the User Agent SHOULD also remove the "permission granted"
-      indicator for the source. If the data is being generated from a
-      live source (e.g., a microphone or camera), then the User Agent SHOULD
-      remove any active "on-air" indicator for that source. An implementation
-      may use a per-source reference count to keep track of source usage, but
-      the specifics are out of scope for this specification.</p>
-
-      <p>To <dfn id="track-clone">clone a track</dfn> the User Agent MUST
-      run the following steps:</p>
-
+      object no longer needs its source with the <code><a href=
+      "#dom-mediastreamtrack-stop">stop()</a></code> method. When all tracks
+      using a source have been stopped or ended by some other means, the source
+      is <dfn id="source-stopped">stopped</dfn>. Unless there is a stored
+      permission for the source in question, the given permission is revoked
+      and the User Agent SHOULD also remove the "permission granted" indicator
+      for the source. If the data is being generated from a live source (e.g.,
+      a microphone or camera), then the User Agent SHOULD remove any active
+      "on-air" indicator for that source. An implementation may use a
+      per-source reference count to keep track of source usage, but the
+      specifics are out of scope for this specification.</p>
+      <p>To <dfn id="track-clone">clone a track</dfn> the User Agent MUST run
+      the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>track</var> be the
-          <code><a>MediaStreamTrack</a></code> object to be cloned.</p>
+          <p>Let <var>track</var> be the <code><a>MediaStreamTrack</a></code>
+          object to be cloned.</p>
         </li>
-
         <li>
           <p>Let <var>trackClone</var> be a newly constructed
           <code><a>MediaStreamTrack</a></code> object.</p>
         </li>
-
         <li>
           <p>Initialize <var>trackClone</var>'s <code><a href=
           "#dom-mediastreamtrack-id">id</a></code> attribute to a newly
           generated value.</p>
         </li>
-
         <li>
           <p>Initialize <var>trackClone</var>'s <code><a href=
           "#dom-mediastreamtrack-kind">kind</a></code>, <code><a href=
           "#dom-mediastreamtrack-label">label</a></code>, <code><a href=
           "#dom-mediastreamtrack-readystate">readyState</a></code>, and
-          <code><a href=
-          "#dom-mediastreamtrack-enabled">enabled</a></code> attributes by
-          copying the corresponding values from <var>track</var>.</p>
+          <code><a href="#dom-mediastreamtrack-enabled">enabled</a></code>
+          attributes by copying the corresponding values from
+          <var>track</var>.</p>
         </li>
-
         <li>
           <p>Let <var>trackClone</var>'s underlying source be the source of
           <var>track</var>.</p>
         </li>
-
         <li>
           <p>Set <var>trackClone</var>'s constraints to the active constrains
           of <var>track</var>.</p>
         </li>
-
         <li>
           <p>Return <var>trackClone</var>.</p>
         </li>
       </ol>
-
       <section>
         <h3>Life-cycle and Media Flow</h3>
-
         <h4>Life-cycle</h4>
-
         <p>A <code><a>MediaStreamTrack</a></code> has two states in its
         life-cycle: <code>live</code> and <code>ended</code>. A newly created
         <code><a>MediaStreamTrack</a></code> can be in either state depending
@@ -751,13 +613,11 @@
         new ended track. The current state is reflected by the object's
         <code><a href="#dom-mediastreamtrack-readystate">readyState</a></code>
         attribute.</p>
-
         <p>In the <code>live</code> state, the track is active and media is
         available for use by consumers (but may be replaced by
         zero-information-content if the <code><a>MediaStreamTrack</a></code> is
         <a href="#track-muted">muted</a> or <a href=
         "#track-enabled">disabled</a>, see below).</p>
-
         <p>A muted or disabled <code><a>MediaStreamTrack</a></code> renders
         either silence (audio), black frames (video), or a
         zero-information-content equivalent. For example, a video element
@@ -767,14 +627,12 @@
         a source are muted or disabled, the "on-air" or "recording" indicator
         for that source can be turned off; when the track is no longer muted or
         disabled, it MUST be turned back on.</p>
-
         <p>The muted/unmuted state of a track reflects whether the source
         provides any media at this moment. The enabled/disabled state is under
         application control and determines whether the track outputs media (to
         its consumers). Hence, media from the source only flows when a
         <code><a>MediaStreamTrack</a></code> object is both unmuted and
         enabled.</p>
-
         <p>A <code><a>MediaStreamTrack</a></code> is <a href=
         "#track-muted">muted</a> when the source is temporarily unable to
         provide the track with data. A track can be muted by a user. Often this
@@ -782,27 +640,22 @@
         result of the user hitting a hardware switch or toggling a control in
         the operating system / browser chrome. A track can also be muted by the
         User Agent.</p>
-
         <p>Applications are able to <a href="#track-enabled">enable</a> or
         disable a <code><a>MediaStreamTrack</a></code> to prevent it from
         rendering media from the source. A muted track will however, regardless
         of the enabled state, render silence and blackness. A disabled track is
         logically equivalent to a muted track, from a consumer point of
         view.</p>
-
         <p>For a newly created <code><a>MediaStreamTrack</a></code> object, the
         following applies. The track is always enabled unless stated otherwise
         (for example when cloned) and the muted state reflects the state of the
         source at the time the track is created.</p>
-
         <p>A <code><a>MediaStreamTrack</a></code> object is said to
         <em>end</em> when the source of the track is disconnected or
         exhausted.</p>
-
-        <p>If all <code><a>MediaStreamTrack</a></code>s that are using
-        the same source are <a href= "#track-ended">ended</a>, the
-        source will be <a href="#source-stopped">stopped</a>.</p>
-
+        <p>If all <code><a>MediaStreamTrack</a></code>s that are using the same
+        source are <a href="#track-ended">ended</a>, the source will be
+        <a href="#source-stopped">stopped</a>.</p>
         <p>When a <code><a>MediaStreamTrack</a></code> object ends for any
         reason (e.g., because the user rescinds the permission for the page to
         use the local camera, or because the application invoked the
@@ -810,12 +663,10 @@
         the <code><a>MediaStreamTrack</a></code> object, or because the User
         Agent has instructed the track to end for any reason) it is said to be
         <dfn id="track-ended">ended</dfn>.</p>
-
         <p>When a <code><a>MediaStreamTrack</a></code> <var>track</var> ends
         for any reason other than the <code><a href=
         "#dom-mediastreamtrack-stop">stop()</a></code> method being invoked,
         the User Agent MUST queue a task that runs the following steps:</p>
-
         <ol>
           <li>
             <p>If the <var>track's</var> <code><a href=
@@ -823,40 +674,32 @@
             has the value <code>ended</code> already, then abort these
             steps.</p>
           </li>
-
           <li>
             <p>Set <var>track's</var> <code><a href=
             "#dom-mediastreamtrack-readystate">readyState</a></code> attribute
             to <code>ended</code>.</p>
           </li>
-
           <li>
             <p>Notify <var>track</var>'s source that <var>track</var> is
-            <a href="#track-ended">ended</a> so that the source may be
-            <a href="#source-stopped">stopped</a>, unless other
+            <a href="#track-ended">ended</a> so that the source may be <a href=
+            "#source-stopped">stopped</a>, unless other
             <code><a>MediaStreamTrack</a></code> objects depend on it.</p>
           </li>
-
           <li>
             <p>Fire a simple event named <code><a href=
             "#event-mediastreamtrack-ended">ended</a></code> at the object.</p>
           </li>
         </ol>
-
         <p>If the end of the stream was reached due to a user request, the
         event source for this event is the user interaction event source.</p>
-
         <h4>Media Flow</h4>
-
         <p>There are two dimensions related to the media flow for a
         <code>live</code> <code><a>MediaStreamTrack</a></code> : muted / not
         muted, and enabled / disabled.</p>
-
-        <p><dfn data-lt-noDefault data-lt="track-muted"
-        id="track-muted">Muted</dfn> refers to the input to the
+        <p><dfn data-lt-nodefault="" data-lt="track-muted" id=
+        "track-muted">Muted</dfn> refers to the input to the
         <code><a>MediaStreamTrack</a></code>. If live samples are not made
         available to the <code><a>MediaStreamTrack</a></code> it is muted.</p>
-
         <p>Muted is out of control for the application, but can be observed by
         the application by reading the <code><a href=
         "#dom-mediastreamtrack-muted">muted</a></code> attribute and listening
@@ -868,39 +711,32 @@
         toggling a control in the operating system, the user clicking a mute
         button in the browser chrome, the User Agent (on behalf of the user)
         mutes, etc.</p>
-
-        <p>To <dfn id="update-track-muted">update a track's muted state</dfn> to
-        <var>newState</var>, the User Agent MUST queue a task to run the
+        <p>To <dfn id="update-track-muted">update a track's muted state</dfn>
+        to <var>newState</var>, the User Agent MUST queue a task to run the
         following steps:</p>
-
         <ol>
           <li>
             <p>Let <var>track</var> be the <code>MediaStreamTrack</code> in
             question.</p>
           </li>
-
           <li>
             <p>Set <var>track</var>'s <code>muted</code> attribute to
             <var>newState</var>.</p>
           </li>
-
           <li>
             <p>If <var>newState</var> is <code>true</code> let
             <var>eventName</var> be <code>mute</code>, otherwise
             <code>unmute</code>.</p>
           </li>
-
           <li>
             <p>Fire a simple event named <var>eventName</var> on
             <var>track</var>.</p>
           </li>
         </ol>
-
         <p><dfn id="track-enabled">Enabled/disabled</dfn> on the other hand is
         available to the application to control (and observe) via the
         <code><a href="#dom-mediastreamtrack-enabled">enabled</a></code>
         attribute.</p>
-
         <p>The result for the consumer is the same in the sense that whenever
         <code><a>MediaStreamTrack</a></code> is muted or disabled (or both) the
         consumer gets zero-information-content, which means silence for audio
@@ -910,46 +746,35 @@
         disabled <code><a>MediaStreamTrack</a></code> (contained in a
         <code><a>MediaStream</a></code> ), is playing but rendering
         blackness.</p>
-
         <p>For a newly created <code><a>MediaStreamTrack</a></code> object, the
         following applies: the track is always enabled unless stated otherwise
         (for example when cloned) and the muted state reflects the state of the
         source at the time the track is created.</p>
       </section>
-
       <section>
         <h3>Tracks and Constraints</h3>
-
         <p>Constraints are set on tracks and may affect sources.</p>
-
         <p>Whether <code><a>Constraints</a></code> were provided at track
         initialization time or need to be established later at runtime, the
         APIs defined in the <a>ConstrainablePattern</a> Interface allow the
         retrieval and manipulation of the constraints currently established on
         a track.</p>
-
-        <p>If the <code><a>overconstrained</a></code> event is thrown,
-        the track MUST be muted
-        until either new satisfiable constraints are applied or the existing
-        constraints become satisfiable.</p>
+        <p>If the <code><a>overconstrained</a></code> event is thrown, the
+        track MUST be muted until either new satisfiable constraints are
+        applied or the existing constraints become satisfiable.</p>
       </section>
-
       <section id="media-stream-track-interface-definition">
         <h3>Interface Definition</h3>
-
-        <dl class="idl" title="[Exposed=Window] interface MediaStreamTrack : EventTarget">
+        <dl class="idl" title=
+        "[Exposed=Window] interface MediaStreamTrack : EventTarget">
           <dt>readonly attribute DOMString kind</dt>
-
           <dd>
-            <p>The <dfn id=
-            "dom-mediastreamtrack-kind"><code>kind</code></dfn>
-            attribute MUST return the string "<code>audio</code>" if this object
-            represents an audio track or "<code>video</code>" if this object
-            represents a video track.</p>
+            <p>The <dfn id="dom-mediastreamtrack-kind"><code>kind</code></dfn>
+            attribute MUST return the string "<code>audio</code>" if this
+            object represents an audio track or "<code>video</code>" if this
+            object represents a video track.</p>
           </dd>
-
           <dt>readonly attribute DOMString id</dt>
-
           <dd>
             <p>Unless a <code><a>MediaStreamTrack</a></code> object is created
             as a part of a special purpose algorithm that specifies how the
@@ -957,74 +782,58 @@
             identifier string and initialize the object's <code><a href=
             "#dom-mediastreamtrack-id">id</a></code> attribute to that string.
             See <code><a>MediaStream</a></code>'s <code><a href=
-            "#dom-mediastream-id">id</a></code> attribute
-            for guidelines on how to generate such an identifier.</p>
-
+            "#dom-mediastream-id">id</a></code> attribute for guidelines on how
+            to generate such an identifier.</p>
             <p>An example of an algorithm that specifies how the track id must
             be initialized is the algorithm to represent an incoming network
             component with a <code><a>MediaStreamTrack</a></code> object.
             [[WEBRTC10]]</p>
-
-            <p><dfn data-lt-noDefault id="dom-mediastreamtrack-id" data-lt=
-            "dom-mediastreamtrack-id"><code>id</code></dfn>
-            attribute MUST return the value to which it was initialized when
-            the object was created.</p>
+            <p><dfn data-lt-nodefault="" id="dom-mediastreamtrack-id" data-lt=
+            "dom-mediastreamtrack-id"><code>id</code></dfn> attribute MUST
+            return the value to which it was initialized when the object was
+            created.</p>
           </dd>
-
           <dt>readonly attribute DOMString label</dt>
-
           <dd>
             <p>User Agents MAY label audio and video sources (e.g., "Internal
             microphone" or "External USB Webcam"). The <dfn id=
-            "dom-mediastreamtrack-label"><code>label</code></dfn>
-            attribute MUST return the label of the object's corresponding
-            source, if any. If the corresponding source has or had no label,
-            the attribute MUST instead return the empty string.</p>
+            "dom-mediastreamtrack-label"><code>label</code></dfn> attribute
+            MUST return the label of the object's corresponding source, if any.
+            If the corresponding source has or had no label, the attribute MUST
+            instead return the empty string.</p>
           </dd>
-
           <dt>attribute boolean enabled</dt>
-
           <dd>
             <p>The <dfn id=
-            "dom-mediastreamtrack-enabled"><code>enabled</code></dfn>
-            attribute controls the <code><a href=
-            "#track-enabled">enabled</a></code> state for the object.</p>
-
+            "dom-mediastreamtrack-enabled"><code>enabled</code></dfn> attribute
+            controls the <code><a href="#track-enabled">enabled</a></code>
+            state for the object.</p>
             <p>On getting, the attribute MUST return the value to which it was
             last set. On setting, it MUST be set to the new value.</p>
-
             <p class="note">Thus, after a <code><a>MediaStreamTrack</a></code>
             has <a href="#track-ended">ended</a>, its <code><a href=
             "#dom-mediastreamtrack-enabled">enabled</a></code> attribute still
             changes value when set; it just doesn't do anything with that new
             value.</p>
           </dd>
-
           <dt>readonly attribute boolean muted</dt>
-
           <dd>
-            <p>The <dfn data-lt-noDefault id=
-            "dom-mediastreamtrack-muted"><code>muted</code></dfn>
-            attribute MUST return <code>true</code> if the track is <a href=
+            <p>The <dfn data-lt-nodefault="" id=
+            "dom-mediastreamtrack-muted"><code>muted</code></dfn> attribute
+            MUST return <code>true</code> if the track is <a href=
             "#track-muted">muted</a>, and <code>false</code> otherwise.</p>
           </dd>
-
           <dt>attribute EventHandler onmute</dt>
-
           <dd>
             <p>The event type of this event handler is <code><a href=
             "#event-mediastreamtrack-mute">mute</a></code>.</p>
           </dd>
-
           <dt>attribute EventHandler onunmute</dt>
-
           <dd>
             <p>The event type of this event handler is <code><a href=
             "#event-mediastreamtrack-unmute">unmute</a></code>.</p>
           </dd>
-
           <dt>readonly attribute boolean _readonly</dt>
-
           <dd>
             <p>If the track (audio or video) source is a local microphone or
             camera that is shared so that constraints applied to the track
@@ -1033,170 +842,131 @@
             attribute MUST return the value <code>true</code>. Otherwise, it
             must return the value <code>false</code>.</p>
           </dd>
-
           <dt>readonly attribute boolean remote</dt>
-
           <dd>
             <p>If the track is sourced by a non-local source, the <dfn id=
             "dom-mediastreamtrack-remote"><code>remote</code></dfn> attribute
             MUST return the value <code>true</code>. Otherwise, it must return
             the value <code>false</code>.</p>
           </dd>
-
           <dt>readonly attribute MediaStreamTrackState readyState</dt>
-
           <dd>
             <p>The <dfn id=
             "dom-mediastreamtrack-readystate"><code>readyState</code></dfn>
             attribute represents the state of the track. It MUST return the
             value as most recently set by the User Agent.</p>
           </dd>
-
           <dt>attribute EventHandler onended</dt>
-
           <dd>
             <p>The event type of this event handler is <code><a href=
             "#event-mediastreamtrack-ended">ended</a></code>.</p>
           </dd>
-
           <dt>MediaStreamTrack clone()</dt>
-
           <dd>
             <p>Clones this <code><a>MediaStreamTrack</a></code>.</p>
-
-            <p>When the <code>clone()</code>
-            method is invoked, the User Agent MUST return the result of
-            <a href="#track-clone">cloning this track</a>.</p>
+            <p>When the <code>clone()</code> method is invoked, the User Agent
+            MUST return the result of <a href="#track-clone">cloning this
+            track</a>.</p>
           </dd>
-
           <dt>void stop()</dt>
-
           <dd>
             <p>When a <code><a>MediaStreamTrack</a></code> object's <dfn id=
             "dom-mediastreamtrack-stop"><code>stop()</code></dfn> method is
             invoked, the User Agent MUST run following steps:</p>
-
             <ol>
               <li>
                 <p>Let <var>track</var> be the current
                 <code><a>MediaStreamTrack</a></code> object.</p>
               </li>
-
               <li>
                 <p>If <var>track</var> is sourced by a non-local source, then
                 abort these steps.</p>
               </li>
-
               <li>
                 <p>Notify <var>track</var>'s source that <var>track</var> is
                 <a href="#track-ended">ended</a> so that the source may be
                 <a href="#source-stopped">stopped</a>, unless other
                 <code><a>MediaStreamTrack</a></code> objects depend on it.</p>
               </li>
-
               <li>
                 <p>Set <var>track's</var> <code><a href=
                 "#dom-mediastreamtrack-readystate">readyState</a></code>
                 attribute to <code>ended</code>.</p>
               </li>
             </ol>
-
             <p>The task source for the <span title="concept-task">tasks</span>
             queued for the <code><a href=
             "#dom-mediastreamtrack-stop">stop()</a></code> method is the DOM
             manipulation task source.</p>
           </dd>
-
           <dt>MediaTrackCapabilities getCapabilities()</dt>
-
           <dd>
             <p>See <a href="#constrainable-interface">ConstrainablePattern
             Interface</a> for the definition of this method.</p>
-
             <p class="fingerprint">Since this method gives likely persistent,
             cross-origin information about the underlying device, it adds to
             the fingerprint surface of the device.</p>
           </dd>
-
           <dt>MediaTrackConstraints getConstraints()</dt>
-
           <dd>
             <p>See <a href="#constrainable-interface">ConstrainablePattern
             Interface</a> for the definition of this method.</p>
           </dd>
-
           <dt>MediaTrackSettings getSettings()</dt>
-
           <dd>
             <p>See <a href="#constrainable-interface">ConstrainablePattern
             Interface</a> for the definition of this method.</p>
           </dd>
-
           <dt>Promise&lt;void&gt; applyConstraints()</dt>
-
           <dd>
             <dl class="parameters">
               <dt>optional MediaTrackConstraints constraints</dt>
-
               <dd>
                 <p>A new constraint structure to apply to this object.</p>
               </dd>
             </dl>See <a href="#constrainable-interface">ConstrainablePattern
             Interface</a> for the definition of this method.
           </dd>
-
           <dt>attribute EventHandler onoverconstrained</dt>
-
           <dd>
             <p>The event type of this event handler is <code><a href=
             "#event-mediastreamtrack-overconstrained">overconstrained</a></code>.</p>
-
             <p>See <a href="#constrainable-interface">ConstrainablePattern
-            Interface</a> for more information about the <code>overconstrained</code> event.</p>
+            Interface</a> for more information about the
+            <code>overconstrained</code> event.</p>
           </dd>
         </dl>
-
         <dl class="idl" title="enum MediaStreamTrackState">
           <dt>live</dt>
-
           <dd>
             <p>The track is active (the track's underlying media source is
             making a best-effort attempt to provide data in real time).</p>
-
             <p>The output of a track in the <code>live</code> state can be
             switched on and off with the <code><a href=
             "#dom-mediastreamtrack-enabled">enabled</a></code> attribute.</p>
           </dd>
-
           <dt>ended</dt>
-
           <dd>
             <p>The track has <a href="#track-ended">ended</a> (the track's
             underlying media source is no longer providing data, and will never
             provide more data for this track). Once a track enters this state,
             it never exits it.</p>
-
             <p>For example, a video track in a <code><a>MediaStream</a></code>
             ends when the user unplugs the USB web camera that acts as the
             track's media source.</p>
           </dd>
         </dl>
       </section>
-
       <section>
         <h2>Track Source Types</h2>
-
         <dl class="idl" title="enum SourceTypeEnum">
           <dt>camera</dt>
-
           <dd>
             <p>A valid source type only for video
             <code><a>MediaStreamTrack</a></code> s. The source is a local
             video-producing camera source.</p>
           </dd>
-
           <dt>microphone</dt>
-
           <dd>
             <p>A valid source type only for audio
             <code><a>MediaStreamTrack</a></code> s. The source is a local
@@ -1204,125 +974,75 @@
           </dd>
         </dl>
       </section>
-
       <section id="media-track-supported-constraints">
         <h2>MediaTrackSupportedConstraints</h2>
-
         <p><code><a>MediaTrackSupportedConstraints</a></code> represents the
         list of constraints recognized by a User Agent for controlling the
         <a>Capabilities</a> of a <code><a>MediaStreamTrack</a></code>
         object.</p>
-
         <p>Future specifications can extend the MediaTrackSupportedConstraints
         dictionary by defining a partial dictionary with dictionary members of
         type boolean.</p>
-
         <dl class="idl" title="dictionary MediaTrackSupportedConstraints">
           <dt>boolean width = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean height = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean aspectRatio = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean frameRate = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean facingMode = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean volume = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean sampleRate = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean sampleSize = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean echoCancellation = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean latency = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean channelCount = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean deviceId = true</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean groupId = true</dt>
-
-          <dd />
+          <dd></dd>
         </dl>
       </section>
-
       <section id="media-track-capabilities">
         <h2>MediaTrackCapabilities</h2>
-
         <p><code><a>MediaTrackCapabilities</a></code> represents the
         <a>Capabilities</a> of a <code><a>MediaStreamTrack</a></code>
         object.</p>
-
         <p>Future specifications can extend the MediaTrackCapabilities
         dictionary by defining a partial dictionary with dictionary members of
         appropriate type.</p>
-
         <dl class="idl" title="dictionary MediaTrackCapabilities">
           <dt>(long or LongRange) width</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>(long or LongRange) height</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>(double or DoubleRange) aspectRatio</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>(double or DoubleRange) frameRate</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>sequence&lt;DOMString&gt; facingMode</dt>
-
           <dd>
             <p>A camera can report multiple facing modes. For example, in a
-            high-end telepresence solution with several cameras facing the user,
-            a camera to the left of the user can report both "left" and
+            high-end telepresence solution with several cameras facing the
+            user, a camera to the left of the user can report both "left" and
             "user".</p>
           </dd>
-
           <dt>(double or DoubleRange) volume</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>(long or LongRange) sampleRate</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>(long or LongRange) sampleSize</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>sequence&lt;boolean&gt; echoCancellation</dt>
-
           <dd>
             <p>If the User Agent cannot do echo cancellation a single
             <code>false</code> is reported. If echo cancellation cannot be
@@ -1330,436 +1050,314 @@
             can control the feature, the User Agent reports a list with both
             <code>true</code> and <code>false</code> as possible values.</p>
           </dd>
-
           <dt>(double or DoubleRange) latency</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>(long or LongRange) channelCount</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>DOMString deviceId</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>DOMString groupId</dt>
-
-          <dd />
+          <dd></dd>
         </dl>
       </section>
-
       <section id="media-track-constraints">
         <h2>MediaTrackConstraints</h2>
-
         <dl class="idl" title=
         "dictionary MediaTrackConstraints : MediaTrackConstraintSet">
           <dt>sequence&lt;MediaTrackConstraintSet&gt; advanced</dt>
-
           <dd>
             <p>See <a href="#constraints">Constraints and ConstraintSet</a> for
             the definition of this element.</p>
           </dd>
         </dl>
-
         <p>Future specifications can extend the MediaTrackConstraintSet
         dictionary by defining a partial dictionary with dictionary members of
         appropriate type.</p>
-
         <dl class="idl" title="dictionary MediaTrackConstraintSet">
           <dt>ConstrainLong width</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainLong height</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainDouble aspectRatio</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainDouble frameRate</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainDOMString facingMode</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainDouble volume</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainLong sampleRate</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainLong sampleSize</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainBoolean echoCancellation</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainDouble latency</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainLong channelCount</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainDOMString deviceId</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>ConstrainDOMString groupId</dt>
-
-          <dd />
+          <dd></dd>
         </dl>
       </section>
-
       <section id="media-track-settings">
         <h2>MediaTrackSettings</h2>
-
         <p><code><a>MediaTrackSettings</a></code> represents the
         <a>Settings</a> of a <code><a>MediaStreamTrack</a></code> object.</p>
-
-        <p>Future specifications can extend the MediaTrackSettings dictionary by
-        defining a partial dictionary with dictionary members of appropriate
+        <p>Future specifications can extend the MediaTrackSettings dictionary
+        by defining a partial dictionary with dictionary members of appropriate
         type.</p>
-
         <dl class="idl" title="dictionary MediaTrackSettings">
           <dt>long width</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>long height</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>double aspectRatio</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>double frameRate</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>DOMString facingMode</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>double volume</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>long sampleRate</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>long sampleSize</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>boolean echoCancellation</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>double latency</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>long channelCount</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>DOMString deviceId</dt>
-
-          <dd />
-
+          <dd></dd>
           <dt>DOMString groupId</dt>
-
-          <dd />
+          <dd></dd>
         </dl>
       </section>
       <section>
         <h2>Constrainable Properties</h2>
-
         <p>The names of the initial set of constrainable properties for
-          MediaStreamTrack are defined below.</p>
-
+        MediaStreamTrack are defined below.</p>
         <p>The following constrainable properties are defined to apply to both
-          video and audio <code><a>MediaStreamTrack</a></code> objects:</p>
-
+        video and audio <code><a>MediaStreamTrack</a></code> objects:</p>
         <table class="simple">
           <thead>
             <tr>
               <th>Property Name</th>
-
               <th>Values</th>
-
               <th>Notes</th>
             </tr>
           </thead>
-
           <tbody>
             <tr id="def-constraint-sourceType">
               <td><dfn>sourceType</dfn></td>
-
               <td><code><a>SourceTypeEnum</a></code></td>
-
-              <td>The type of the source of the <a>MediaStreamTrack</a>. Note
+              <td>
+                The type of the source of the <a>MediaStreamTrack</a>. Note
                 that the setting of this property is uniquely determined by the
                 source that is attached to the Track. In particular,
                 <a>getCapabilities()</a> will return only a single value for
-                sourceType. This property can therefore be used for initial media
-                selection with <a>getUserMedia()</a>. However, it is not useful for
-                subsequent media control with <a>applyConstraints()</a>, since any
-                attempt to set a different value will result in an unsatisfiable
-                <a>ConstraintSet</a>.</td>
+                sourceType. This property can therefore be used for initial
+                media selection with <a>getUserMedia()</a>. However, it is not
+                useful for subsequent media control with
+                <a>applyConstraints()</a>, since any attempt to set a different
+                value will result in an unsatisfiable <a>ConstraintSet</a>.
+              </td>
             </tr>
-
             <tr id="def-constraint-deviceId">
               <td><dfn>deviceId</dfn></td>
-
               <td>DOMString</td>
-
-              <td>The origin-unique identifier for the source of the
-                <a>MediaStreamTrack</a>. The same identifier MUST be valid between
-                browsing sessions of this origin, but MUST also be different for other
-                origins. Some sort of GUID is recommended for the identifier.
-                Note that the setting of this property is uniquely determined by
-                the source that is attached to the Track. In particular,
-                <a>getCapabilities()</a> will return only a single value for
-                deviceId. This property can therefore be used for initial media
-                selection with <a>getUserMedia()</a>. However, it is not useful for
-                subsequent media control with <a>applyConstraints()</a>, since any
-                attempt to set a different value will result in an unsatisfiable
-                <a>ConstraintSet</a>.</td>
+              <td>
+                The origin-unique identifier for the source of the
+                <a>MediaStreamTrack</a>. The same identifier MUST be valid
+                between browsing sessions of this origin, but MUST also be
+                different for other origins. Some sort of GUID is recommended
+                for the identifier. Note that the setting of this property is
+                uniquely determined by the source that is attached to the
+                Track. In particular, <a>getCapabilities()</a> will return only
+                a single value for deviceId. This property can therefore be
+                used for initial media selection with <a>getUserMedia()</a>.
+                However, it is not useful for subsequent media control with
+                <a>applyConstraints()</a>, since any attempt to set a different
+                value will result in an unsatisfiable <a>ConstraintSet</a>.
+              </td>
             </tr>
-
             <tr id="def-constraint-groupId">
               <td><dfn>groupId</dfn></td>
-
               <td>DOMString</td>
-
-              <td>The origin-unique group identifier for the source of the
-                <a>MediaStreamTrack</a>. Two devices have the same group identifier
-                if they belong to the same physical device; for example, the audio
-                input and output devices representing the speaker and microphone of
-                the same headset would have the same groupId.</td>
+              <td>
+                The origin-unique group identifier for the source of the
+                <a>MediaStreamTrack</a>. Two devices have the same group
+                identifier if they belong to the same physical device; for
+                example, the audio input and output devices representing the
+                speaker and microphone of the same headset would have the same
+                groupId.
+              </td>
             </tr>
           </tbody>
         </table>
-
         <p>The following constrainable properties are defined to apply only to
-          video <code><a>MediaStreamTrack</a></code> objects:</p>
-
+        video <code><a>MediaStreamTrack</a></code> objects:</p>
         <table class="simple">
           <thead>
             <tr>
               <th>Property Name</th>
-
               <th>Values</th>
-
               <th>Notes</th>
             </tr>
           </thead>
-
           <tbody>
             <tr id="def-constraint-width">
               <td><dfn>width</dfn></td>
-
               <td><code><a>ConstrainLong</a></code></td>
-
-              <td>The width or width range, in pixels. As a capability, the range
-                should span the video source's pre-set width values with min being
-                the smallest width and max being the largest width.</td>
+              <td>The width or width range, in pixels. As a capability, the
+              range should span the video source's pre-set width values with
+              min being the smallest width and max being the largest
+              width.</td>
             </tr>
-
             <tr id="def-constraint-height">
               <td><dfn>height</dfn></td>
-
               <td><code><a>ConstrainLong</a></code></td>
-
               <td>The height or height range, in pixels. As a capability, the
-                range should span the video source's pre-set height values with min
-                being the smallest height and max being the largest height.</td>
+              range should span the video source's pre-set height values with
+              min being the smallest height and max being the largest
+              height.</td>
             </tr>
-
             <tr id="def-constraint-frameRate">
               <td><dfn>frameRate</dfn></td>
-
               <td><code><a>ConstrainDouble</a></code></td>
-
               <td>The exact frame rate (frames per second) or frame rate range.
-                If this frame rate cannot be determined (e.g. the source does not
-                natively provide a frame rate, or the frame rate cannot be
-                determined from the source stream), then this value MUST refer to
-                the User Agent's vsync display rate.</td>
+              If this frame rate cannot be determined (e.g. the source does not
+              natively provide a frame rate, or the frame rate cannot be
+              determined from the source stream), then this value MUST refer to
+              the User Agent's vsync display rate.</td>
             </tr>
-
             <tr id="def-constraint-aspect">
               <td><dfn>aspectRatio</dfn></td>
-
               <td><code><a>ConstrainDouble</a></code></td>
-
               <td>The exact aspect ratio (width in pixels divided by height in
-                pixels, represented as a double rounded to the tenth decimal place)
-                or aspect ratio range.</td>
+              pixels, represented as a double rounded to the tenth decimal
+              place) or aspect ratio range.</td>
             </tr>
-
             <tr id="def-constraint-facingMode">
               <td><dfn>facingMode</dfn></td>
-
               <td><code><a>ConstrainDOMString</a></code></td>
-
-              <td>This string (or each string, when a list) should be one of the
-                members of <code><a>VideoFacingModeEnum</a></code>. The members
-                describe the directions that the camera can face, as seen from the
-                user's perspective. Note that <code><a>getConstraints</a></code>
-                may not return exactly the same string for strings not in this
-                enum. This preserves the possibility of using a future version of
-                WebIDL enum for this property.</td>
+              <td>This string (or each string, when a list) should be one of
+              the members of <code><a>VideoFacingModeEnum</a></code>. The
+              members describe the directions that the camera can face, as seen
+              from the user's perspective. Note that
+              <code><a>getConstraints</a></code> may not return exactly the
+              same string for strings not in this enum. This preserves the
+              possibility of using a future version of WebIDL enum for this
+              property.</td>
             </tr>
           </tbody>
         </table>
-
         <dl class="idl" title="enum VideoFacingModeEnum">
           <dt>user</dt>
-
           <dd>
             <p>The source is facing toward the user (a self-view camera).</p>
           </dd>
-
           <dt>environment</dt>
-
           <dd>
             <p>The source is facing away from the user (viewing the
-              environment).</p>
+            environment).</p>
           </dd>
-
           <dt>left</dt>
-
           <dd>
             <p>The source is facing to the left of the user.</p>
           </dd>
-
           <dt>right</dt>
-
           <dd>
             <p>The source is facing to the right of the user.</p>
           </dd>
         </dl>
-
-        <p>Below is an illustration of the video facing modes in relation to the
-          user.<br>
-          <img alt="Illustration of video facing modes in relation to user" src=
-               "images/camera-names-exp.svg" style="width:40%"></p>
-
+        <p>Below is an illustration of the video facing modes in relation to
+        the user.<br>
+        <img alt="Illustration of video facing modes in relation to user" src=
+        "images/camera-names-exp.svg" style="width:40%"></p>
         <p>The following constrainable properties are defined to apply only to
-          audio <code><a>MediaStreamTrack</a></code> objects:</p>
-
+        audio <code><a>MediaStreamTrack</a></code> objects:</p>
         <table class="simple">
           <thead>
             <tr>
               <th>Property Name</th>
-
               <th>Values</th>
-
               <th>Notes</th>
             </tr>
           </thead>
-
           <tbody>
             <tr id="def-constraint-volume">
               <td>volume</td>
-
               <td><code><a>ConstrainDouble</a></code></td>
-
-              <td>The volume or volume range, as a multiplier of the linear audio
-                sample values. A volume of 0.0 is silence, while a volume of 1.0 is
-                the maximum supported volume. A volume of 0.5 will result in an
-                approximately 6 dB<sub>SPL</sub> change in the sound pressure level
-                from the maximum volume. Note that any ConstraintSet that specifies
-                values outside of this range of 0 to 1 can never be satisfied.</td>
+              <td>The volume or volume range, as a multiplier of the linear
+              audio sample values. A volume of 0.0 is silence, while a volume
+              of 1.0 is the maximum supported volume. A volume of 0.5 will
+              result in an approximately 6 dB<sub>SPL</sub> change in the sound
+              pressure level from the maximum volume. Note that any
+              ConstraintSet that specifies values outside of this range of 0 to
+              1 can never be satisfied.</td>
             </tr>
-
             <tr id="def-constraint-sampleRate">
               <td>sampleRate</td>
-
               <td><code><a>ConstrainLong</a></code></td>
-
-              <td>The sample rate in samples per second for the audio data.</td>
+              <td>The sample rate in samples per second for the audio
+              data.</td>
             </tr>
-
             <tr id="def-constraint-sampleSize">
               <td>sampleSize</td>
-
               <td><code><a>ConstrainLong</a></code></td>
-
               <td>The linear sample size in bits. This constraint can only be
-                satisfied for audio devices that produce linear samples.</td>
+              satisfied for audio devices that produce linear samples.</td>
             </tr>
-
             <tr id="def-constraint-echoCancellation">
               <td>echoCancellation</td>
-
               <td><code><a>ConstrainBoolean</a></code></td>
-
-              <td>When one or more audio streams is being played in the processes
-                of various microphones, it is often desirable to attempt to remove
-                the sound being played from the input signals recorded by the
-                microphones. This is referred to as echo cancellation. There are
-                cases where it is not needed and it is desirable to turn it off so
-                that no audio artifacts are introduced. This allows applications to
-                control this behavior.</td>
+              <td>When one or more audio streams is being played in the
+              processes of various microphones, it is often desirable to
+              attempt to remove the sound being played from the input signals
+              recorded by the microphones. This is referred to as echo
+              cancellation. There are cases where it is not needed and it is
+              desirable to turn it off so that no audio artifacts are
+              introduced. This allows applications to control this
+              behavior.</td>
             </tr>
-
             <tr id="def-constraint-latency">
               <td>latency</td>
-
               <td><code><a>ConstrainDouble</a></code></td>
-
-              <td>The latency or latency range, in seconds.  The latency
-                is the time between start of processing (for instance,
-                when sound occurs in the real world) to the data being
-                available to the next step in the process. Low latency is
-                critical for some applications; high latency may be
-                acceptable for other applications because it helps with
-                power constraints. The number is expected to be the target
-                latency of the configuration; the actual latency may show
-                some variation from that.</td>
+              <td>The latency or latency range, in seconds. The latency is the
+              time between start of processing (for instance, when sound occurs
+              in the real world) to the data being available to the next step
+              in the process. Low latency is critical for some applications;
+              high latency may be acceptable for other applications because it
+              helps with power constraints. The number is expected to be the
+              target latency of the configuration; the actual latency may show
+              some variation from that.</td>
             </tr>
-
             <tr id="def-constraint-channelCount">
               <td>channelCount</td>
-
               <td><code><a>ConstrainLong</a></code></td>
-
-              <td>The number of independent channels of sound that the audio data contains, i.e. the number of audio samples per sample frame.</td>
+              <td>The number of independent channels of sound that the audio
+              data contains, i.e. the number of audio samples per sample
+              frame.</td>
             </tr>
           </tbody>
         </table>
-
       </section>
     </section>
-
     <section>
       <h3>MediaStreamTrackEvent</h3>
-
       <p>The <code><a href="#event-mediastream-addtrack">addtrack</a></code>
       and <code title="event-MediaStreamTracklist-removetrack"><a href=
       "#event-mediastream-removetrack">removetrack</a></code> events use the
       <code><a>MediaStreamTrackEvent</a></code> interface.</p>
-
       <p>The <code>addtrack</code> and <code>removetrack</code> events notify
       the script that the <a href="#track-set">track set</a> of a
-      <code><a>MediaStream</a></code> has been updated by the User Agent.
-
+      <code><a>MediaStream</a></code> has been updated by the User Agent.</p>
       <p><dfn data-lt="Fire a track event">Firing a track event named
       <var>e</var></dfn> with a <code><a>MediaStreamTrack</a></code>
       <var>track</var> means that an event with the name <var>e</var>, which
@@ -1769,18 +1367,14 @@
       <code><a href="#dom-mediastreamtrackevent-track">track</a></code>
       attribute set to <var>track</var>, MUST be created and dispatched at the
       given target.</p>
-
       <dl class="idl" data-merge="MediaStreamTrackEventInit" title=
       "[Exposed=Window] interface MediaStreamTrackEvent : Event">
         <dt>Constructor(DOMString type, MediaStreamTrackEventInit
         eventInitDict)</dt>
-
         <dd>
           <p>Constructs a new <code><a>MediaStreamTrackEvent</a></code>.</p>
         </dd>
-
         <dt>[SameObject] readonly attribute MediaStreamTrack track</dt>
-
         <dd>
           <p>The <dfn id=
           "dom-mediastreamtrackevent-track"><code>track</code></dfn> attribute
@@ -1788,42 +1382,35 @@
           with the event.</p>
         </dd>
       </dl>
-
       <dl class="idl" title="dictionary MediaStreamTrackEventInit : EventInit">
         <dt>required MediaStreamTrack track</dt>
       </dl>
     </section>
   </section>
-
   <section class="informative">
     <h2>The model: sources, sinks, constraints, and settings</h2>
-
     <p>Browsers provide a media pipeline from sources to sinks. In a browser,
     sinks are the &lt;img&gt;, &lt;video&gt;, and &lt;audio&gt; tags.
     Traditional sources include streamed content, files, and web resources. The
     media produced by these sources typically does not change over time - these
     sources can be considered to be static.</p>
-
     <p>The sinks that display these sources to the user (the actual tags
     themselves) have a variety of controls for manipulating the source content.
     For example, an &lt;img&gt; tag scales down a huge source image of
     1600x1200 pixels to fit in a rectangle defined with
     <code>width="400"</code> and <code>height="300"</code>.</p>
-
     <p>The getUserMedia API adds dynamic sources such as microphones and
     cameras - the characteristics of these sources can change in response to
     application needs. These sources can be considered to be dynamic in nature.
     A &lt;video&gt; element that displays media from a dynamic source can
     either perform scaling or it can feed back information along the media
     pipeline and have the source produce content more suitable for display.</p>
-
     <div class="note">
       <p><strong>Note:</strong> This sort of feedback loop is obviously just
       enabling an "optimization", but it's a non-trivial gain. This
       optimization can save battery, allow for less network congestion,
       etc...</p>
     </div>
-
     <p>Note that <code>MediaStream</code> sinks (such as
     <code>&lt;video&gt;</code>, <code>&lt;audio&gt;</code>, and even
     <code>RTCPeerConnection</code>) will continue to have mechanisms to further
@@ -1832,7 +1419,6 @@
     offer. (The sink transformation options, including those of
     <code>RTCPeerConnection</code>, are outside the scope of this
     specification.)</p>
-
     <p>The act of changing or applying a track constraint may affect the
     <code><a>settings</a></code> of all tracks sharing that source and
     consequently all down-level sinks that are using that source. Many sinks
@@ -1840,7 +1426,6 @@
     <code>&lt;video&gt;</code> element or <code>RTCPeerConnection</code>.
     Others like the Recorder API may fail as a result of a source setting
     change.</p>
-
     <p>The <code>RTCPeerConnection</code> is an interesting object because it
     acts simultaneously as both a sink <strong>and</strong> a source for
     over-the-network streams. As a sink, it has source transformational
@@ -1849,7 +1434,6 @@
     changed by a track source (though in this specification sources with the
     <code><a>remote</a></code> attribute set to true do not consider the
     current constraints applied to a track).</p>
-
     <p>To illustrate how changes to a given source impact various sinks,
     consider the following example. This example only uses width and height,
     but the same principles apply to all of the <a>Settings</a> exposed in this
@@ -1867,21 +1451,17 @@
     Z).</p><img alt=
     "Changing media stream source effects: before the requested change" src=
     "images/change_states_before.png">
-
     <p>Note that at this moment, all of the sinks on the home client must apply
     a transformation to the original source's provided dimension settings. B is
     scaling the video down, A is scaling the video up (resulting in loss of
     quality), and C is also scaling the video up slightly for sending over the
     network. On the remote client, sink Y is scaling the video <em>way</em>
     down, while sink Z is not applying any scaling.</p>
-
-    <p>In response to <code><a>applyConstraints()</a></code> being called,
-    one of the tracks
-    wants a higher resolution (1920 by 1200 pixels) from the home client's
-    video source.</p><img alt=
+    <p>In response to <code><a>applyConstraints()</a></code> being called, one
+    of the tracks wants a higher resolution (1920 by 1200 pixels) from the home
+    client's video source.</p><img alt=
     "Changing media stream source effects: after the requested change" src=
     "images/change_states_after.png">
-
     <p>Note that the source change immediately affects all of the tracks and
     sinks on the home client, but does not impact any of the sinks (or sources)
     on the remote client. With the increase in the home client source video's
@@ -1889,23 +1469,19 @@
     scale down even further than before. Sink C (the peer connection) must now
     scale down the video in order to keep the transmission constant to the
     remote client.</p>
-
-    <p>While not shown, an equally valid settings change request could be
-    made on the remote
-    client's side. In addition to impacting sink Y and Z in the same manner as
-    A, B and C were impacted earlier, it could lead to re-negotiation with the
-    peer connection on the home client in order to alter the transformation
-    that it is applying to the home client's video source. Such a change is NOT
-    REQUIRED to change anything related to sink A or B or the home client's
-    video source.</p>
-
+    <p>While not shown, an equally valid settings change request could be made
+    on the remote client's side. In addition to impacting sink Y and Z in the
+    same manner as A, B and C were impacted earlier, it could lead to
+    re-negotiation with the peer connection on the home client in order to
+    alter the transformation that it is applying to the home client's video
+    source. Such a change is NOT REQUIRED to change anything related to sink A
+    or B or the home client's video source.</p>
     <p>Note that this specification does not define a mechanism by which a
     change to the remote client's video source could automatically trigger a
     change to the home client's video source. Implementations may choose to
     make such source-to-sink optimizations as long as they only do so within
     the constraints established by the application, as the next example
     demonstrates.</p>
-
     <p>It is fairly obvious that changes to a given source will impact sink
     consumers. However, in some situations changes to a given sink may also
     cause implementations to adjust a source's settings. This is illustrated in
@@ -1923,7 +1499,6 @@
     by 200 pixels down.</p><img alt=
     "Changing media stream sinks may affect sources: before the requested change"
     src="images/change_states_before2.png">
-
     <p>When the application changes sink A to a smaller dimension (from 1920 to
     1024 pixels wide and from 1200 to 768 pixels tall), the browser's media
     pipeline may recognize that none of its sinks require the higher source
@@ -1933,12 +1508,10 @@
     pipeline MAY change the source resolution:</p><img alt=
     "Changing media stream sinks may affect sources: after the requested change"
     src="images/change_states_after2.png">
-
     <p>In the above figure, the home client's video source resolution was
     changed to the greater of that from sink A and B in order to optimize
     playback. While not shown above, the same behavior could apply to peer
     connections and other sinks.</p>
-
     <p>It is possible that <a>constraints</a> can be applied to a track which a
     source is unable to satisfy, either because the source itself cannot
     satisfy the constraint or because the source is already satisfying a
@@ -1947,7 +1520,6 @@
     any of the new constraints. Since no change in constraints occurs in this
     case, there is also no required change to the source itself as a result of
     this condition. Here is an example of this behavior.</p>
-
     <p>In this example, two media streams each have a video track that share
     the same source. The first track initially has no constraints applied. It
     is connected to sink N. Sink N has a resolution of 800 by 600 pixels and is
@@ -1955,10 +1527,8 @@
     has a mandatory constraint forcing off the source's fill light; it is
     connected to sink P. Sink P has a width and height equal to that of the
     source.</p>
-
     <p><img alt="Overconstrained application" src=
     "images/overconstrained_apply.png"></p>
-
     <p>Now, the first track adds a mandatory constraint that the fill light
     should be forced on. At this point, both mandatory constraints cannot be
     satisfied by the source (the fill light cannot be simultaneously on and off
@@ -1966,7 +1536,6 @@
     to apply a conflicting constraint, the constraint application fails and
     there is no change in the source's settings nor to the constraints on
     either track.</p>
-
     <p>Let's look at a slightly different situation starting from the same
     point. In this case, instead of the first track attempting to apply a
     conflicting constraint, the user physically locks the camera into a mode
@@ -1977,608 +1546,537 @@
     remaining active sink only requires a resolution of 800 by 600 and so it
     adjusts its resolution down to match (this is an optional optimization that
     the User Agent is allowed to make given the situation).</p>
-
     <p><img alt="Overconstrained occurrence" src=
     "images/overconstrained_occurrence.png"></p>
-
     <p>At this point, it is the responsibility of the application to address
     the problem that led to the overconstrained situation, perhaps by removing
     the fill light mandatory constraint on the second track or by closing the
     second track altogether and informing the user.</p>
   </section>
-
   <section>
     <h2>MediaStreams in Media Elements</h2>
-
     <div class="note">
       We are now referencing the [[!HTML51]] specification for MediaStream
       playback in a HTMLMediaElement. This section, that defines
       MediaStream-specific exceptions and additions, is still work in progress
       and feedback is most welcome.
     </div>
-
     <p>A <code>MediaStream</code> may be assigned to media elements. A
-    <code>MediaStream</code> is not preloadable or seekable and
-    represents a simple, potentially infinite, linear media timeline. The
-    timeline starts at 0 and increments linearly in real time as long as the
+    <code>MediaStream</code> is not preloadable or seekable and represents a
+    simple, potentially infinite, linear media timeline. The timeline starts at
+    0 and increments linearly in real time as long as the
     <code>MediaStream</code> is playing. The timeline does not increment when
     the playout of the <code>MediaStream</code> is paused.</p>
-
-    
-
-    <p>User Agents that support this specification MUST support
-    the <code><a href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-srcobject">srcObject</a></code>
-    attribute of the <code>HTMLMediaElement</code> interface defined
-    in [[!HTML51]], which includes support for playing <code>MediaStream</code>
-    objects.</p>
-
+    <p>User Agents that support this specification MUST support the
+    <code><a href=
+    "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-srcobject">
+    srcObject</a></code> attribute of the <code>HTMLMediaElement</code>
+    interface defined in [[!HTML51]], which includes support for playing
+    <code>MediaStream</code> objects.</p>
     <p>The [[!HTML51]] document outlines how the <code>HTMLMediaElement</code>
-    works with a <em>media provider object</em>. The following applies when
-    the <em>media provider object</em> is a <code><a>MediaStream</a></code>:</p>
-
+    works with a <em>media provider object</em>. The following applies when the
+    <em>media provider object</em> is a <code><a>MediaStream</a></code>:</p>
     <ul>
-      <li><p>Whenever an [[!HTML51]] <code><a href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#audiotrack">AudioTrack</a></code> or a <code><a href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#videotrack">VideoTrack</a></code> is created, the <code>id</code> and <code>label</code>
-      attributes must be initilized to the corresponding attributes of the
-      <code>MediaStreamTrack</code>, the <code>kind</code> attribute
-      must be initiliszed to "main" and the <code>language</code> attribute to the
-      empty string</p></li>
-
+      <li>
+        <p>Whenever an [[!HTML51]] <code><a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#audiotrack">
+        AudioTrack</a></code> or a <code><a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#videotrack">
+        VideoTrack</a></code> is created, the <code>id</code> and
+        <code>label</code> attributes must be initilized to the corresponding
+        attributes of the <code>MediaStreamTrack</code>, the <code>kind</code>
+        attribute must be initiliszed to "main" and the <code>language</code>
+        attribute to the empty string</p>
+      </li>
       <li>The User Agent MUST always play the current data from the
       <code><a>MediaStream</a></code> and MUST NOT buffer.</li>
-
-      <li><p>Since the order in the <code><a>MediaStream</a></code> 's
-      <a href="#track-set">track set</a> is undefined, no requirements are
-      put on how the <code><a href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#audiotracklist">
-      AudioTrackList</a></code> and <code><a href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#videotracklist"> VideoTrackList</a></code> is ordered</p></li>
-
-      <li><p>When the <code><a>MediaStream</a></code> state moves from the active to the <a href=
-      "#stream-inactive">inactive</a> state, the User Agent MUST raise an
-      <a href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#event-media-ended">
-      ended</a> event on the <code>HTMLMediaElement</code> and set its <a href=
-      "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-ended">ended</a>
-      attribute to <code>true</code>. Note that once <a href=
-      "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-ended">ended</a>
-      equals <code>true</code> the <code>HTMLMediaElement</code> will not play media even
-      if new <code><a>MediaStreamTrack</a></code>'s are added to the
-      <code><a>MediaStream</a></code> (causing it to return to the active state) unless
-      <code>autoplay</code> is <code>true</code> or the web application restarts the
-      element, e.g., by calling <a href=
-      "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-play">play()</a></p></li>
-
-      <li><p>Any calls to the <code> <a href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-fastseek">fastSeek</a></code> method on a <code>HTMLMediaElement</code> 
-      must be ignored</p></li>
+      <li>
+        <p>Since the order in the <code><a>MediaStream</a></code> 's <a href=
+        "#track-set">track set</a> is undefined, no requirements are put on how
+        the <code><a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#audiotracklist">
+        AudioTrackList</a></code> and <code><a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#videotracklist">
+        VideoTrackList</a></code> is ordered</p>
+      </li>
+      <li>
+        <p>When the <code><a>MediaStream</a></code> state moves from the active
+        to the <a href="#stream-inactive">inactive</a> state, the User Agent
+        MUST raise an <a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#event-media-ended">
+        ended</a> event on the <code>HTMLMediaElement</code> and set its
+        <a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-ended">
+        ended</a> attribute to <code>true</code>. Note that once <a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-ended">
+        ended</a> equals <code>true</code> the <code>HTMLMediaElement</code>
+        will not play media even if new <code><a>MediaStreamTrack</a></code>'s
+        are added to the <code><a>MediaStream</a></code> (causing it to return
+        to the active state) unless <code>autoplay</code> is <code>true</code>
+        or the web application restarts the element, e.g., by calling <a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-play">
+        play()</a></p>
+      </li>
+      <li>
+        <p>Any calls to the <code><a href=
+        "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-fastseek">
+        fastSeek</a></code> method on a <code>HTMLMediaElement</code> must be
+        ignored</p>
+      </li>
     </ul>
-
-    <p>The nature of the <code><a>MediaStream</a></code> places certain restrictions
-    on the behavior and attribute values of the associated <code>HTMLMediaElement</code> and
-    on the operations that can be performed on it, as shown below:</p>
-
+    <p>The nature of the <code><a>MediaStream</a></code> places certain
+    restrictions on the behavior and attribute values of the associated
+    <code>HTMLMediaElement</code> and on the operations that can be performed
+    on it, as shown below:</p>
     <table class="simple">
       <thead>
         <tr>
           <th scope="col">Attribute Name</th>
-
           <th scope="col">Attribute Type</th>
-
           <th scope="col">Valid Values When Using a MediaStream</th>
-
           <th scope="col">Additional considerations</th>
         </tr>
       </thead>
-
       <tbody>
-
         <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#attr-media-preload">
-          <code>preload</code></a></td>
-
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#attr-media-preload">
+            <code>preload</code></a>
+          </td>
           <td><code>DOMString</code></td>
-
-          <td>On getting: <code>none</code>. On setting: ignored. </td>
-
+          <td>On getting: <code>none</code>. On setting: ignored.</td>
           <td>A MediaStream cannot be preloaded.</td>
         </tr>
-
         <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-buffered">
-          <code>buffered</code></a></td>
-
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#timeranges"><code>
-          TimeRanges</code></a></td>
-
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-buffered">
+            <code>buffered</code></a>
+          </td>
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#timeranges">
+            <code>TimeRanges</code></a>
+          </td>
           <td><code>buffered.length</code> MUST return <code>0</code>.</td>
-
-          <td>A MediaStream cannot be preloaded. Therefore, the amount
-          buffered is always an empty TimeRange.</td>
+          <td>A MediaStream cannot be preloaded. Therefore, the amount buffered
+          is always an empty TimeRange.</td>
         </tr>
-
         <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-currenttime">
-          <code>currentTime</code></a></td>
-
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-currenttime">
+            <code>currentTime</code></a>
+          </td>
           <td><code>double</code></td>
-
           <td>Any non-negative integer. The initial value is 0 and the values
-          increments linearly in real time whenever the stream is
-          playing.</td>
-
+          increments linearly in real time whenever the stream is playing.</td>
           <td>The value is the current stream position, in seconds. On any
           attempt to set this attribute, the User Agent must throw an
           <code>InvalidStateError</code> exception.</td>
         </tr>
-
         <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-seeking">
-          <code>seeking</code></a></td>
-
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-seeking">
+            <code>seeking</code></a>
+          </td>
           <td><code>boolean</code></td>
-
           <td>false</td>
-
           <td>A MediaStream is not seekable. Therefore, this attribute MUST
           always have the value <code>false</code>.</td>
         </tr>
-
-      <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-defaultplaybackrate">
-          <code>defaultPlaybackRate</code></a></td>
-
+        <tr>
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-defaultplaybackrate">
+            <code>defaultPlaybackRate</code></a>
+          </td>
           <td><code>double</code></td>
-
           <td>On setting: ignored. On getting: return 1.0</td>
-
           <td>A MediaStream is not seekable. Therefore, this attribute MUST
           always have the value <code>1.0</code> and any attempt to alter it
-          MUST be ignored. Note that this also means that the <code><a
-          href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#event-media-ratechange">
+          MUST be ignored. Note that this also means that the <code><a href=
+          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#event-media-ratechange">
           ratechange</a></code> event will not fire.</td>
         </tr>
-
         <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-playbackrate">
-          <code>playbackRate</code></a></td>
-
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-playbackrate">
+            <code>playbackRate</code></a>
+          </td>
           <td><code>double</code></td>
-
           <td>1.0</td>
-
           <td>A MediaStream is not seekable. Therefore, this attribute MUST
           always have the value <code>1.0</code> and any attempt to alter it
-          MUST be ignored. Note that this also means that the <code><a
-          href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#event-media-ratechange">
+          MUST be ignored. Note that this also means that the <code><a href=
+          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#event-media-ratechange">
           ratechange</a></code> event will not fire.</td>
         </tr>
-
         <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-played">
-          <code>played</code></a></td>
-
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#timeranges"><code>
-          TimeRanges</code></a></td>
-
-          <td><code>played.length</code> MUST return <code>1</code>.<br>
-          <code>played.start(0)</code> MUST return <code>0</code>.<br>
-          <code>played.end(0)</code> MUST return the last known <a class=
-          "externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-currenttime">
-          <code>currentTime</code></a> .</td>
-
-          <td>A <code><a>MediaStream</a></code>'s timeline always consists of a single range,
-          starting at 0 and extending up to the currentTime.</td>
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-played">
+            <code>played</code></a>
+          </td>
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#timeranges">
+            <code>TimeRanges</code></a>
+          </td>
+          <td>
+            <code>played.length</code> MUST return <code>1</code>.<br>
+            <code>played.start(0)</code> MUST return <code>0</code>.<br>
+            <code>played.end(0)</code> MUST return the last known <a class=
+            "externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-currenttime">
+            <code>currentTime</code></a> .
+          </td>
+          <td>A <code><a>MediaStream</a></code>'s timeline always consists of a
+          single range, starting at 0 and extending up to the currentTime.</td>
         </tr>
-
         <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-seekable">
-          <code>seekable</code></a></td>
-
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#timeranges"><code>
-          TimeRanges</code></a></td>
-
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-seekable">
+            <code>seekable</code></a>
+          </td>
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#timeranges">
+            <code>TimeRanges</code></a>
+          </td>
           <td><code>seekable.length</code> MUST return <code>0</code>.</td>
-
           <td>A <code><a>MediaStream</a></code> is not seekable.</td>
         </tr>
-
         <tr>
-          <td><a class="externalDFN" href=
-          "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-loop">
-          <code>loop</code></a></td>
-
+          <td>
+            <a class="externalDFN" href=
+            "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#dom-media-loop">
+            <code>loop</code></a>
+          </td>
           <td><code>boolean</code></td>
-
           <td>true, false</td>
-
           <td>Setting the <code>loop</code> attribute has no effect since a
           <code><a>MediaStream</a></code> has no defined end and therefore
           cannot be looped.</td>
         </tr>
       </tbody>
     </table>
-
-    <p>When applicable, behavior outlined above for <code>HTMLMediaElement</code> 
-    carry over to <code> <a href="http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#mediacontroller">
+    <p>When applicable, behavior outlined above for
+    <code>HTMLMediaElement</code> carry over to <code><a href=
+    "http://www.w3.org/TR/2015/WD-html51-20150506/semantics.html#mediacontroller">
     MediaController</a></code>'s.</p>
   </section>
-
   <section>
     <h2>Error Handling</h2>
-
-    <p>This section and its subsections extend the list of Error
-    subclasses defined in [[!ES6]] following the pattern for NativeError
-    in section 19.5.6 of that specification.  Assume the following:</p>
-
+    <p>This section and its subsections extend the list of Error subclasses
+    defined in [[!ES6]] following the pattern for NativeError in section 19.5.6
+    of that specification. Assume the following:</p>
     <ul>
-      <li>that use of syntax such as [[\something]] and %something% is
-      as used in [[!ES6]].</li>
-      <li>that the rules for ECMAScript standard built-in objects
-      ([[!ES6]], section 17) are in effect in this section.</li>
+      <li>that use of syntax such as [[\something]] and %something% is as used
+      in [[!ES6]].</li>
+      <li>that the rules for ECMAScript standard built-in objects ([[!ES6]],
+      section 17) are in effect in this section.</li>
       <li>that the new intrinsic objects %OverconstrainedError% and
-      %OverconstrainedErrorPrototype% are available as if they had
-      been included in ([[!ES6]], Table 7) and all referencing sections,
-      e.g. ([[!ES6]], section 8.2.2), thus behave appropriately.</li>
+      %OverconstrainedErrorPrototype% are available as if they had been
+      included in ([[!ES6]], Table 7) and all referencing sections, e.g.
+      ([[!ES6]], section 8.2.2), thus behave appropriately.</li>
     </ul>
-
     <section>
       <h2>ECMAScript 6 Terminology</h2>
-
       <p>The following terms used in this section are defined in [[!ES6]].</p>
       <table>
         <thead>
-        <tr>
-          <th>Term/Notation</th>
-          <th>Section in [[!ES6]]</th>
-        </tr>
+          <tr>
+            <th>Term/Notation</th>
+            <th>Section in [[!ES6]]</th>
+          </tr>
         </thead>
         <tbody>
-        <tr>
-          <td>Type(X)</td>
-          <td>6</td>
-        <tr>
-          <td>intrinsic object</td>
-          <td>6.1.7.4</td>
-        </tr>
-        <tr>
-          <td>[[\ErrorData]]</td>
-          <td>19.5.1</td>
-        </tr>
-        <tr>
-          <td>internal slot</td>
-          <td>6.1.7.2</td>
-        </tr>
-        <tr>
-          <td>NewTarget</td>
-          <td>various uses, but no definition</td>
-        </tr>
-        <tr>
-          <td>active function object</td>
-          <td>8.3</td>
-        </tr>
-        <tr>
-          <td>OrdinaryCreateFromConstructor()</td>
-          <td>9.1.14</td>
-        </tr>
-        <tr>
-          <td>ReturnIfAbrupt()</td>
-          <td>6.2.2.4</td>
-        </tr>
-        <tr>
-          <td>Assert</td>
-          <td>5.2</td>
-        </tr>
-        <tr>
-          <td>String</td>
-          <td>4.3.17-19, depending on context</td>
-        </tr>
-        <tr>
-          <td>PropertyDescriptor</td>
-          <td>6.2.4</td>
-        </tr>
-        <tr>
-          <td>[[\Value]]</td>
-          <td>6.1.7.1</td>
-        </tr>
-        <tr>
-          <td>[[\Writable]]</td>
-          <td>6.1.7.1</td>
-        </tr>
-        <tr>
-          <td>[[\Enumerable]]</td>
-          <td>6.1.7.1</td>
-        </tr>
-        <tr>
-          <td>[[\Configurable]]</td>
-          <td>6.1.7.1</td>
-        </tr>
-        <tr>
-          <td>DefinePropertyOrThrow()</td>
-          <td>7.3.7</td>
-        </tr>
-        <tr>
-          <td>abrupt completion</td>
-          <td>6.2.2</td>
-        </tr>
-        <tr>
-          <td>ToString()</td>
-          <td>7.1.12</td>
-        </tr>
-        <tr>
-          <td>[[\Prototype]]</td>
-          <td>9.1</td>
-        </tr>
-        <tr>
-          <td>%Error%</td>
-          <td>19.5.1</td>
-        </tr>
-        <tr>
-          <td>Error</td>
-          <td>19.5</td>
-        </tr>
-        <tr>
-          <td>%ErrorPrototype%</td>
-          <td>19.5.3</td>
-        </tr>
-        <tr>
-          <td>Object.prototype.toString</td>
-          <td>19.1.3.6</td>
-        </tr>
+          <tr>
+            <td>Type(X)</td>
+            <td>6</td>
+          </tr>
+          <tr>
+            <td>intrinsic object</td>
+            <td>6.1.7.4</td>
+          </tr>
+          <tr>
+            <td>[[\ErrorData]]</td>
+            <td>19.5.1</td>
+          </tr>
+          <tr>
+            <td>internal slot</td>
+            <td>6.1.7.2</td>
+          </tr>
+          <tr>
+            <td>NewTarget</td>
+            <td>various uses, but no definition</td>
+          </tr>
+          <tr>
+            <td>active function object</td>
+            <td>8.3</td>
+          </tr>
+          <tr>
+            <td>OrdinaryCreateFromConstructor()</td>
+            <td>9.1.14</td>
+          </tr>
+          <tr>
+            <td>ReturnIfAbrupt()</td>
+            <td>6.2.2.4</td>
+          </tr>
+          <tr>
+            <td>Assert</td>
+            <td>5.2</td>
+          </tr>
+          <tr>
+            <td>String</td>
+            <td>4.3.17-19, depending on context</td>
+          </tr>
+          <tr>
+            <td>PropertyDescriptor</td>
+            <td>6.2.4</td>
+          </tr>
+          <tr>
+            <td>[[\Value]]</td>
+            <td>6.1.7.1</td>
+          </tr>
+          <tr>
+            <td>[[\Writable]]</td>
+            <td>6.1.7.1</td>
+          </tr>
+          <tr>
+            <td>[[\Enumerable]]</td>
+            <td>6.1.7.1</td>
+          </tr>
+          <tr>
+            <td>[[\Configurable]]</td>
+            <td>6.1.7.1</td>
+          </tr>
+          <tr>
+            <td>DefinePropertyOrThrow()</td>
+            <td>7.3.7</td>
+          </tr>
+          <tr>
+            <td>abrupt completion</td>
+            <td>6.2.2</td>
+          </tr>
+          <tr>
+            <td>ToString()</td>
+            <td>7.1.12</td>
+          </tr>
+          <tr>
+            <td>[[\Prototype]]</td>
+            <td>9.1</td>
+          </tr>
+          <tr>
+            <td>%Error%</td>
+            <td>19.5.1</td>
+          </tr>
+          <tr>
+            <td>Error</td>
+            <td>19.5</td>
+          </tr>
+          <tr>
+            <td>%ErrorPrototype%</td>
+            <td>19.5.3</td>
+          </tr>
+          <tr>
+            <td>Object.prototype.toString</td>
+            <td>19.1.3.6</td>
+          </tr>
         </tbody>
       </table>
     </section>
-
     <section>
       <h2>OverconstrainedError Object</h2>
-
       <section>
         <h2>OverconstrainedError Constructor</h2>
-
-        <p>The OverconstrainedError Constructor is the
-        %OverconstrainedError% intrinsic object.  When
-        <code>OverconstrainedError</code> is called as a function
-        rather than as a constructor, it creates and initializes a new
-        OverconstrainedError object. A call of the object as a
-        function is equivalent to calling it as a constructor with the
-        same arguments. Thus the function call
-        <code><b>OverconstrainedError(</b>...<b>)</b></code> is
-        equivalent to the object creation expression <code><b>new
+        <p>The OverconstrainedError Constructor is the %OverconstrainedError%
+        intrinsic object. When <code>OverconstrainedError</code> is called as a
+        function rather than as a constructor, it creates and initializes a new
+        OverconstrainedError object. A call of the object as a function is
+        equivalent to calling it as a constructor with the same arguments. Thus
+        the function call <code><b>OverconstrainedError(</b>...<b>)</b></code>
+        is equivalent to the object creation expression <code><b>new
         OverconstrainedError(</b>...<b>)</b></code> with the same
         arguments.</p>
-
-        <p>The <code>OverconstrainedError</code> constructor is
-        designed to be subclassable. It may be used as the value of
-        an <code>extends</code> clause of a class definition. Subclass
-        constructors that intend to inherit the specified
-        <code>OverconstrainedError</code> behaviour must include
-        a <code>super</code> call to
-        the <code>OverconstrainedError</code> constructor to create
-        and initialize the subclass instance with an [[\ErrorData]]
-        internal slot.</p>
-
+        <p>The <code>OverconstrainedError</code> constructor is designed to be
+        subclassable. It may be used as the value of an <code>extends</code>
+        clause of a class definition. Subclass constructors that intend to
+        inherit the specified <code>OverconstrainedError</code> behaviour must
+        include a <code>super</code> call to the
+        <code>OverconstrainedError</code> constructor to create and initialize
+        the subclass instance with an [[\ErrorData]] internal slot.</p>
         <section>
           <h2>OverconstrainedError ( constraint, message )</h2>
-
           <p>When the <code><dfn>OverconstrainedError</dfn></code> function is
-          called with arguments <i>constraint</i> and <i>message</i>
-          the following steps are taken:</p>
+          called with arguments <i>constraint</i> and <i>message</i> the
+          following steps are taken:</p>
           <ol>
-            <li>If NewTarget is <b>undefined</b>, let <i>newTarget</i>
-            be the active function object, else let <i>newTarget</i>
-            be NewTarget.</li>
-            <li>Let <i>O</i> be
-            OrdinaryCreateFromConstructor(<i>newTarget</i>,
+            <li>If NewTarget is <b>undefined</b>, let <i>newTarget</i> be the
+            active function object, else let <i>newTarget</i> be
+            NewTarget.</li>
+            <li>Let <i>O</i> be OrdinaryCreateFromConstructor(<i>newTarget</i>,
             <code>"%OverconstrainedErrorPrototype%"</code>, «[[\ErrorData]]»
             ).</li>
             <li>ReturnIfAbrupt(<i>O</i>).</li>
             <li>If <i>constraint</i> is not <b>undefined</b>, then
-            <ol>
-              <li>Let <i>constraintDesc</i> be the
-              PropertyDescriptor{[[\Value]]:
-              <i>constraint</i>, [[\Writable]]: <b>false</b>,
-              [[\Enumerable]]: <b>false</b>,
-              [[\Configurable]]: <b>false</b>}.</li>
-              <li>Let <i>cStatus</i> be DefinePropertyOrThrow(O,
-              "<code>constraint</code>", <i>constraintDesc</i>).</li>
-              <li>Assert: <i>cStatus</i> is not an abrupt completion.</li>
-            </ol></li>
+              <ol>
+                <li>Let <i>constraintDesc</i> be the
+                PropertyDescriptor{[[\Value]]: <i>constraint</i>,
+                [[\Writable]]: <b>false</b>, [[\Enumerable]]: <b>false</b>,
+                [[\Configurable]]: <b>false</b>}.</li>
+                <li>Let <i>cStatus</i> be DefinePropertyOrThrow(O,
+                "<code>constraint</code>", <i>constraintDesc</i>).</li>
+                <li>Assert: <i>cStatus</i> is not an abrupt completion.</li>
+              </ol>
+            </li>
             <li>If <i>message</i> is not <b>undefined</b>, then
-            <ol>
-              <li>Let <i>msg</i> be ToString(<i>message</i>).</li>
-              <li>Let <i>msgDesc</i> be the PropertyDescriptor{[[\Value]]:
-              <i>msg</i>, [[\Writable]]: <b>true</b>,
-              [[\Enumerable]]: <b>false</b>, [[\Configurable]]:
-              <b>true</b>}.</li>
-              <li>Let <i>mStatus</i> be DefinePropertyOrThrow(O,
-              "<code>message</code>", <i>msgDesc</i>).</li>
-              <li>Assert: <i>mStatus</i> is not an abrupt completion.</li>
-            </ol></li>
+              <ol>
+                <li>Let <i>msg</i> be ToString(<i>message</i>).</li>
+                <li>Let <i>msgDesc</i> be the PropertyDescriptor{[[\Value]]:
+                <i>msg</i>, [[\Writable]]: <b>true</b>, [[\Enumerable]]:
+                <b>false</b>, [[\Configurable]]: <b>true</b>}.</li>
+                <li>Let <i>mStatus</i> be DefinePropertyOrThrow(O,
+                "<code>message</code>", <i>msgDesc</i>).</li>
+                <li>Assert: <i>mStatus</i> is not an abrupt completion.</li>
+              </ol>
+            </li>
             <li>Return <i>O</i>.</li>
           </ol>
         </section>
       </section>
-
       <section>
         <h2>Properties of the OverconstrainedError Constructor</h2>
-
         <p>The value of the [[\Prototype]] internal slot of the
-        OverconstrainedError constructor is the intrinsic object
-        %Error%.</p>
-        <p>Besides the <code>length</code> property (whose value
-        is <b>1</b>), the OverconstrainedError constructor has the
-        following properties:</p>
-
+        OverconstrainedError constructor is the intrinsic object %Error%.</p>
+        <p>Besides the <code>length</code> property (whose value is <b>1</b>),
+        the OverconstrainedError constructor has the following properties:</p>
         <section>
           <h2>OverconstrainedError.prototype</h2>
-
-          <p>The initial value
-          of <code>OverconstrainedError.prototype</code> is the
-          <a href="#properties-of-the-overconstrainederror-prototype-object">OverconstrainedError
+          <p>The initial value of <code>OverconstrainedError.prototype</code>
+          is the <a href=
+          "#properties-of-the-overconstrainederror-prototype-object">OverconstrainedError
           prototype object</a>. This property has the attributes {
           [[\Writable]]: <b>false</b>, [[\Enumerable]]: <b>false</b>,
           [[\Configurable]]: <b>false</b> }.</p>
         </section>
       </section>
-
       <section>
         <h2>Properties of the OverconstrainedError Prototype Object</h2>
-
-        <p>The OverconstrainedError prototype object is an ordinary
-        object. It is not an Error instance and does not have an
-        [[\ErrorData]] internal slot.</p>
+        <p>The OverconstrainedError prototype object is an ordinary object. It
+        is not an Error instance and does not have an [[\ErrorData]] internal
+        slot.</p>
         <p>The value of the [[\Prototype]] internal slot of the
         OverconstrainedError prototype object is the intrinsic object
         %ErrorPrototype%.</p>
-
         <section>
           <h2>OverconstrainedError.prototype.constructor</h2>
-
-          <p>The initial value of the constructor property of the
-          prototype for the OverconstrainedError constructor is the
-          intrinsic
-          object <a href="#error-handling">%OverconstrainedError%</a>.</p>
+          <p>The initial value of the constructor property of the prototype for
+          the OverconstrainedError constructor is the intrinsic object <a href=
+          "#error-handling">%OverconstrainedError%</a>.</p>
         </section>
-
         <section>
           <h2>OverconstrainedError.prototype.constraint</h2>
-
-          <p>The initial value of the constraint property of the
-          prototype for the OverconstrainedError constructor is the
-          empty String.</p>
+          <p>The initial value of the constraint property of the prototype for
+          the OverconstrainedError constructor is the empty String.</p>
         </section>
-
         <section>
           <h2>OverconstrainedError.prototype.message</h2>
-
-          <p>The initial value of the message property of the
-          prototype for the OverconstrainedError constructor is the
-          empty String.</p>
+          <p>The initial value of the message property of the prototype for the
+          OverconstrainedError constructor is the empty String.</p>
         </section>
-
         <section>
           <h2>OverconstrainedError.prototype.name</h2>
-
-          <p>The initial value of the name property of the prototype
-          for the OverconstrainedError constructor is
+          <p>The initial value of the name property of the prototype for the
+          OverconstrainedError constructor is
           <code>"<b>OverconstrainedError</b>"</code>.</p>
         </section>
       </section>
-
       <section>
         <h2>Properties of OverconstrainedError Instances</h2>
-
-        <p>OverconstrainedError instances are ordinary objects that
-        inherit properties from the OverconstrainedError prototype
-        object and have an [[\ErrorData]] internal slot whose value is
-        <b>undefined</b>. The only specified use of [[\ErrorData]] is
-        by Object.prototype.toString ([[!ES6]], section 19.1.3.6) to
-        identify instances of Error or its various subclasses.</p>
+        <p>OverconstrainedError instances are ordinary objects that inherit
+        properties from the OverconstrainedError prototype object and have an
+        [[\ErrorData]] internal slot whose value is <b>undefined</b>. The only
+        specified use of [[\ErrorData]] is by Object.prototype.toString
+        ([[!ES6]], section 19.1.3.6) to identify instances of Error or its
+        various subclasses.</p>
       </section>
-
       <div class="note">
-        The following will need to be updated when we finish out the
-        error definitions.
+        The following will need to be updated when we finish out the error
+        definitions.
       </div>
-
       <p>The following interface is defined for cases when an
       OverconstrainedError is raised as an event:</p>
-
       <dl class="idl" data-merge="OverconstrainedErrorEventInit" title=
       "[Exposed=Window] interface OverconstrainedErrorEvent : Event">
         <dt>Constructor(DOMString type, OverconstrainedErrorEventInit
         eventInitDict)</dt>
-
         <dd>
-          <p>Constructs a
-          new <code><a>OverconstrainedErrorEvent</a></code>.</p>
+          <p>Constructs a new
+          <code><a>OverconstrainedErrorEvent</a></code>.</p>
         </dd>
-
         <dt>readonly attribute OverconstrainedError? error</dt>
-
         <dd>
-          <p>The <code><a>OverconstrainedError</a></code> describing
-          the error that triggered the event (if any).</p>
+          <p>The <code><a>OverconstrainedError</a></code> describing the error
+          that triggered the event (if any).</p>
         </dd>
       </dl>
-
-      <dl class="idl"
-          title="dictionary OverconstrainedErrorEventInit : EventInit">
+      <dl class="idl" title=
+      "dictionary OverconstrainedErrorEventInit : EventInit">
         <dt>OverconstrainedError? error = null</dt>
-
         <dd>
           <p>The <code><a>OverconstrainedError</a></code> describing the error
           associated with the event (if any)</p>
         </dd>
       </dl>
     </section>
-
     <section>
       <h3>ErrorEvent</h3>
-      <p>The following interface is defined for cases when an event
-      is raised that could have been caused by an error:</p>
-
+      <p>The following interface is defined for cases when an event is raised
+      that could have been caused by an error:</p>
       <p><dfn data-lt="Fire an error event">Firing an error event named
-      <var>e</var></dfn> with an <code>Error</code>
-      <var>error</var> means that an event with the name <var>e</var>, which
-      does not bubble (except where otherwise stated) and is not cancelable
-      (except where otherwise stated), and which uses the
-      <code><a>ErrorEvent</a></code> interface with the
-      <code><a href="#widl-ErrorEvent-error">error</a></code>
-      attribute set to <var>error</var>, MUST be created and dispatched at the
-      given target. If no <code>Error</code> object is specified, the
-      <code><a href="#widl-ErrorEvent-error">error</a></code> attribute defaults
-      to null.</p>
-
+      <var>e</var></dfn> with an <code>Error</code> <var>error</var> means that
+      an event with the name <var>e</var>, which does not bubble (except where
+      otherwise stated) and is not cancelable (except where otherwise stated),
+      and which uses the <code><a>ErrorEvent</a></code> interface with the
+      <code><a href="#widl-ErrorEvent-error">error</a></code> attribute set to
+      <var>error</var>, MUST be created and dispatched at the given target. If
+      no <code>Error</code> object is specified, the <code><a href=
+      "#widl-ErrorEvent-error">error</a></code> attribute defaults to null.</p>
       <dl class="idl" data-merge="ErrorEventInit" title=
       "[Exposed=Window] interface ErrorEvent : Event">
-        <dt>Constructor(DOMString type, ErrorEventInit
-        eventInitDict)</dt>
-
+        <dt>Constructor(DOMString type, ErrorEventInit eventInitDict)</dt>
         <dd>
           <p>Constructs a new <code><a>ErrorEvent</a></code>.</p>
         </dd>
-
         <dt>readonly attribute Error? error</dt>
-
         <dd>
-          <p>If the event was raised because of
-          an error, this attribute may be set to that error object.</p>
+          <p>If the event was raised because of an error, this attribute may be
+          set to that error object.</p>
         </dd>
       </dl>
-
-      <dl class="idl"
-          title="dictionary ErrorEventInit : EventInit">
+      <dl class="idl" title="dictionary ErrorEventInit : EventInit">
         <dt>Error? error = null</dt>
-
         <dd>
-          <p>If the event was raised because of
-          an error, this attribute may be set to that error object.</p>
+          <p>If the event was raised because of an error, this attribute may be
+          set to that error object.</p>
         </dd>
       </dl>
     </section>
-
     <section>
       <h3>Error names</h3>
-
-      <p class="note">There is a known issue with this table of error
-      names, because <code>MediaStreamError</code> has been removed
-      but is still needed in the legacy, callback-based getUserMedia
-      interface.  This issue will be fixed through resolution
-      of <a href="https://github.com/w3c/mediacapture-main/pull/216">PR
-      #216</a>.
-      </p>
-
+      <p class="note">There is a known issue with this table of error names,
+      because <code>MediaStreamError</code> has been removed but is still
+      needed in the legacy, callback-based getUserMedia interface. This issue
+      will be fixed through resolution of <a href=
+      "https://github.com/w3c/mediacapture-main/pull/216">PR #216</a>.</p>
       <p>The table below lists the error names defined in this
       specification.</p>
-
       <table>
         <caption>
           Error names
@@ -2586,137 +2084,104 @@
         <thead>
           <tr>
             <th>Name</th>
-
             <th>Description</th>
-
             <th>Note</th>
           </tr>
         </thead>
-
         <tbody>
           <tr>
             <th><code>OverconstrainedError</code></th>
-
-            <td>One of the mandatory <a>Constraints</a> could not be
-            satisfied.</td>
-
-            <td>The <code>constraint</code> attribute is set to the name
-            of any one of the constraints that caused the error, if any,
-            as described in the <a>SelectSettings</a> algorithm</td>
+            <td>
+              One of the mandatory <a>Constraints</a> could not be satisfied.
+            </td>
+            <td>
+              The <code>constraint</code> attribute is set to the name of any
+              one of the constraints that caused the error, if any, as
+              described in the <a>SelectSettings</a> algorithm
+            </td>
           </tr>
         </tbody>
       </table>
     </section>
   </section>
-
   <section class="informative">
     <h2>Event summary</h2>
-
     <p>The following events fire on <code><a>MediaStream</a></code>
     objects:</p>
-
     <table>
       <tr>
         <th>Event name</th>
-
         <th>Interface</th>
-
         <th>Fired when...</th>
       </tr>
-
       <tbody>
         <tr>
           <td><dfn id=
           "event-mediastream-addtrack"><code>addtrack</code></dfn></td>
-
           <td><code><a>MediaStreamTrackEvent</a></code></td>
-
           <td>A new <code><a>MediaStreamTrack</a></code> has been added to this
           stream. Note that this event is not fired when the script directly
           modifies the tracks of a <code><a>MediaStream</a></code>.</td>
         </tr>
-
         <tr>
           <td><dfn id=
           "event-mediastream-removetrack"><code>removetrack</code></dfn></td>
-
           <td><code><a>MediaStreamTrackEvent</a></code></td>
-
           <td>A <code><a>MediaStreamTrack</a></code> has been removed from this
           stream. Note that this event is not fired when the script directly
           modifies the tracks of a <code><a>MediaStream</a></code>.</td>
         </tr>
       </tbody>
     </table>
-
     <p>The following events fire on <code><a>MediaStreamTrack</a></code>
     objects:</p>
-
     <table>
       <tr>
         <th>Event name</th>
-
         <th>Interface</th>
-
         <th>Fired when...</th>
       </tr>
-
       <tbody>
         <tr>
           <td><dfn id=
           "event-mediastreamtrack-mute"><code>mute</code></dfn></td>
-
           <td><code>Event</code></td>
-
           <td>The <code><a>MediaStreamTrack</a></code> object's source is
           temporarily unable to provide data.</td>
         </tr>
-
         <tr>
           <td><dfn id=
           "event-mediastreamtrack-unmute"><code>unmute</code></dfn></td>
-
           <td><code>Event</code></td>
-
           <td>The <code><a>MediaStreamTrack</a></code> object's source is live
           again after having been temporarily unable to provide data.</td>
         </tr>
-
         <tr>
           <td><dfn id=
           "event-mediastreamtrack-overconstrained"><code>overconstrained</code></dfn></td>
-
           <td><code><a>OverconstrainedErrorEvent</a></code></td>
-
           <td>
             <p>This error event fires for each affected track (when multiple
             tracks share the same source) after the User Agent has evaluated
-            the current constraints against a given
-            source and is not able to configure the
-            source within the limitations established by the intersection of
-            imposed constraints.</p>
-
+            the current constraints against a given source and is not able to
+            configure the source within the limitations established by the
+            intersection of imposed constraints.</p>
             <p>Due to being over-constrained, the User Agent must mute each
             affected track.</p>
-
             <p>The affected track(s) will remain <a href=
             "#track-muted">muted</a> until the application adjusts the
             constraints to accommodate the source's current effective
             capabilities.</p>
           </td>
         </tr>
-
         <tr>
           <td><code id="event-mediastreamtrack-ended">ended</code></td>
-
           <td><code><a>ErrorEvent</a></code></td>
-
           <td>
             <p>The <code><a>MediaStreamTrack</a></code> object's source will no
             longer provide any data, either because the user revoked the
             permissions, or because the source device has been ejected, or
             because the remote peer permanently stopped sending data.</p>
-
             <p>When the end of MediaStreamTrack is the result of an error, the
             <code>error</code> attribute of the event object is set to describe
             the said error.</p>
@@ -2724,26 +2189,19 @@
         </tr>
       </tbody>
     </table>
-
     <p>The following events fire on <code><a>MediaDevices</a></code>
     objects:</p>
-
     <table>
       <tr>
         <th>Event name</th>
-
         <th>Interface</th>
-
         <th>Fired when...</th>
       </tr>
-
       <tbody>
         <tr>
           <td><dfn id=
           "event-mediadevices-devicechange"><code>devicechange</code></dfn></td>
-
           <td><code>Event</code></td>
-
           <td>The set of media devices, available to the User Agent, has
           changed. The current list devices can be retrieved with the
           <code><a href=
@@ -2753,20 +2211,16 @@
       </tbody>
     </table>
   </section>
-
   <section id="enumerating-devices">
     <h2>Enumerating Local Media Devices</h2>
-
     <p>This section describes an API that the script can use to query the User
     Agent about connected media input and output devices (for example a web
     camera or a headset).</p>
-
     <section>
       <h3>NavigatorUserMedia</h3>
-
-      <dl class="idl" title="[Exposed=Window, NoInterfaceObject] interface NavigatorUserMedia">
+      <dl class="idl" title=
+      "[Exposed=Window, NoInterfaceObject] interface NavigatorUserMedia">
         <dt>[SameObject] readonly attribute MediaDevices mediaDevices</dt>
-
         <dd>
           <p>Returns the <code>MediaDevices</code> object associated with this
           <code>Navigator</code> object.</p>
@@ -2774,64 +2228,51 @@
       </dl>
       <div class="idl" title="Navigator implements NavigatorUserMedia"></div>
     </section>
-
     <section>
       <h3>MediaDevices</h3>
-
-      <p>The <code>MediaDevices</code> object is the entry point to the
-      API used to examine and get access to media devices available to the User
+      <p>The <code>MediaDevices</code> object is the entry point to the API
+      used to examine and get access to media devices available to the User
       Agent.</p>
-
       <p>When a new media input or output device is made available, the User
       Agent MUST queue a task that fires a simple event named <code><a href=
       "#event-mediadevices-devicechange">devicechange</a></code> at the
       <code><a>MediaDevices</a></code> object.</p>
-
-      <dl class="idl" title="[Exposed=Window] interface MediaDevices : EventTarget">
+      <dl class="idl" title=
+      "[Exposed=Window] interface MediaDevices : EventTarget">
         <dt>attribute EventHandler ondevicechange</dt>
-
         <dd>
           <p>The event type of this event handler is <code><a href=
           "#event-mediadevices-devicechange">devicechange</a></code>.</p>
         </dd>
-
         <dt>Promise&lt;sequence&lt;MediaDeviceInfo&gt;&gt; enumerateDevices
         ()</dt>
-
         <dd>
           <p>Collects information about the User Agent's available media input
           and output devices.</p>
-
-          <p>This method returns a promise. The promise will be fulfilled with a sequence
-          of <code><a>MediaDeviceInfo</a></code> dictionaries representing the
-          User Agent's available media input and output devices if enumeration
-          is successful.</p>
-
-          <p>Elements of this sequence that represent input devices will be of type
-          <code><a>InputDeviceInfo</a></code> which extends <code><a>MediaDeviceInfo</a></code>.</p>
-
+          <p>This method returns a promise. The promise will be fulfilled with
+          a sequence of <code><a>MediaDeviceInfo</a></code> dictionaries
+          representing the User Agent's available media input and output
+          devices if enumeration is successful.</p>
+          <p>Elements of this sequence that represent input devices will be of
+          type <code><a>InputDeviceInfo</a></code> which extends
+          <code><a>MediaDeviceInfo</a></code>.</p>
           <p>Camera and microphone sources <em class="rfc2119">should</em> be
           enumerable. Specifications that add additional types of source will
           provide recommendations about whether the source type should be
           enumerable.</p>
-
           <p>When the <dfn id=
           "dom-mediadevices-enumeratedevices"><code>enumerateDevices()</code></dfn>
           method is called, the User Agent must run the following steps:</p>
-
           <ol>
             <li>
               <p>Let <var>p</var> be a new promise.</p>
             </li>
-
             <li>
               <p>Run the following steps in parallel:</p>
-
               <ol>
                 <li>
                   <p>Let <var>resultList</var> be an empty list.</p>
                 </li>
-
                 <li>
                   <p>If this method has been called previously within this
                   browsing session, let <var>oldList</var> be the list of
@@ -2839,12 +2280,10 @@
                   at that call (<var>resultList</var>); otherwise, let
                   <var>oldList</var> be an empty list.</p>
                 </li>
-
                 <li>
                   <p>Probe the User Agent for available media devices, and run
                   the following sub steps for each discovered device,
                   <var>device</var>:</p>
-
                   <ol>
                     <li>
                       <p>If <var>device</var> is represented by a
@@ -2853,13 +2292,11 @@
                       <var>resultList</var>, abort these steps and continue
                       with the next device (if any).</p>
                     </li>
-
                     <li>
                       <p>Let <var>deviceInfo</var> be a new
                       <code><a>MediaDeviceInfo</a></code> object to represent
                       <var>device</var>.</p>
                     </li>
-
                     <li>
                       <p>If <var>device</var> belongs to the same physical
                       device as a device already represented in
@@ -2874,26 +2311,22 @@
                       "#widl-MediaDeviceInfo-groupId">groupId</a></code> member
                       be a newly generated unique identifier.</p>
                     </li>
-
                     <li>
                       <p>Append <var>deviceInfo</var> to
                       <var>resultList</var>.</p>
                     </li>
                   </ol>
                 </li>
-
                 <li>
                   <p>If none of the local devices are attached to an active
                   <code><a>MediaStreamTrack</a></code> in the current browsing
                   context, and if no <a href="#stored-permissions">persistent
-                  permission</a> to access these local devices has been
-                  granted to the page's origin, let <var>filteredList</var> be
-                  a copy of <var>resultList</var>, and all its elements, where
-                  the <code><a href=
-                  "#widl-MediaDeviceInfo-label">label</a></code> member is the
-                  empty string.</p>
+                  permission</a> to access these local devices has been granted
+                  to the page's origin, let <var>filteredList</var> be a copy
+                  of <var>resultList</var>, and all its elements, where the
+                  <code><a href="#widl-MediaDeviceInfo-label">label</a></code>
+                  member is the empty string.</p>
                 </li>
-
                 <li>
                   <p>If <var>filteredList</var> is a non-empty list, then
                   resolve <var>p</var> with <var>filteredList</var>. Otherwise,
@@ -2901,126 +2334,99 @@
                 </li>
               </ol>
             </li>
-
             <li>
               <p>Return <var>p</var>.</p>
             </li>
           </ol>
-
           <p class="fingerprint">Since this method returns persistent
           information across browsing sessions and origins via the number and
           grouping of media capture devices, it adds to the fingerprinting
           surface exposed by the user agent.</p>
-
           <p class="fingerprint">Once authorization has been granted to one of
           the capture devices, it provides additional persistent cross-origin
           information via the human readable labels associated with available
-          capture devices, which furhter adds to the fingerprinting surface.</p>
+          capture devices, which furhter adds to the fingerprinting
+          surface.</p>
         </dd>
       </dl>
-
       <section>
         <h2>Access control model</h2>
-
         <p>The algorithm described above means that the access to media device
         information depends on whether or not permission has been granted to
         the page's origin to use media devices.</p>
-
         <p>If no such access has been granted, the
         <code><a>MediaDeviceInfo</a></code> dictionary will contain the
         deviceId, kind, and groupId.</p>
-
         <p>If access has been granted for a media device, the
         <code><a>MediaDeviceInfo</a></code> dictionary will contain the
         deviceId, kind, label, and groupId.</p>
       </section>
     </section>
-
     <section>
       <h2>Device Info</h2>
-
       <dl class="idl" title="[Exposed=Window] interface MediaDeviceInfo">
         <dt>readonly attribute DOMString deviceId</dt>
-
         <dd>
           <p>A unique identifier for the represented device.</p>
-
           <p>All enumerable devices have an identifier that MUST be unique to
           the page's origin. As long as no local device has been attached to an
-          active MediaStreamTrack in a page from this origin, and no
-          <a href="#stored-permissions">persistent permission</a> to access
-          local devices has been granted to this origin, then this identifier
-          MUST NOT be reusable after the end of the current browsing session.</p>
-
+          active MediaStreamTrack in a page from this origin, and no <a href=
+          "#stored-permissions">persistent permission</a> to access local
+          devices has been granted to this origin, then this identifier MUST
+          NOT be reusable after the end of the current browsing session.</p>
           <p>However, if any local devices have been attached to an active
-          MediaStreamTrack in a page from this origin, or
-          <a href="#stored-permissions">persistent permission</a> to access
-          local devices has been granted to this origin, then this identifier
-          MUST be persisted across browsing sessions.</p>
-
-          <p>Unique and stable identifiers let the application save, identify the
-          availability of, and directly request specific sources.</p>
-
+          MediaStreamTrack in a page from this origin, or <a href=
+          "#stored-permissions">persistent permission</a> to access local
+          devices has been granted to this origin, then this identifier MUST be
+          persisted across browsing sessions.</p>
+          <p>Unique and stable identifiers let the application save, identify
+          the availability of, and directly request specific sources.</p>
           <p>This identifier MUST be un-guessable by applications of other
           origins to prevent the identifier being used to correlate the same
           user across different origins.</p>
-
-          <p class="fingerprint">Since <code>deviceId</code> may persist across browsing sessions and to reduce
-          its potential as a fingerprinting mechanism, <code>deviceId</code> is
-          to be treated as other persistent storage mechanisms such as cookies
-          [[COOKIES]]. User agents MUST reset per-origin device identifiers when
-          other persistent storages are
-          cleared.</p>
+          <p class="fingerprint">Since <code>deviceId</code> may persist across
+          browsing sessions and to reduce its potential as a fingerprinting
+          mechanism, <code>deviceId</code> is to be treated as other persistent
+          storage mechanisms such as cookies [[COOKIES]]. User agents MUST
+          reset per-origin device identifiers when other persistent storages
+          are cleared.</p>
         </dd>
-
         <dt>readonly attribute MediaDeviceKind kind</dt>
-
         <dd>
           <p>Describes the kind of the represented device.</p>
         </dd>
-
         <dt>readonly attribute DOMString label</dt>
-
         <dd>
           <p>A label describing this device (for example "External USB
           Webcam"). If the device has no associated label, then this attribute
           MUST return the empty string.</p>
         </dd>
-
         <dt>readonly attribute DOMString groupId</dt>
-
         <dd>
           <p>Returns the group identifier of the represented device. Two
           devices have the same group identifier if they belong to the same
           physical device; for example a monitor with a built-in camera and
-            microphone.</p>
-
-          <p class="fingerprint">Since <code>groupId</code> may persist across browsing sessions and to reduce
-          its potential as a fingerprinting mechanism, <code>groupId</code> is
-          to be treated as other persistent storage mechanisms such as cookies
-          [[COOKIES]]. User agents MUST reset per-origin device identifiers when
-          other persistent storages are
-          cleared.</p>
+          microphone.</p>
+          <p class="fingerprint">Since <code>groupId</code> may persist across
+          browsing sessions and to reduce its potential as a fingerprinting
+          mechanism, <code>groupId</code> is to be treated as other persistent
+          storage mechanisms such as cookies [[COOKIES]]. User agents MUST
+          reset per-origin device identifiers when other persistent storages
+          are cleared.</p>
         </dd>
-
         <dt>serializer = { attribute }</dt>
       </dl>
       <dl class="idl" title="enum MediaDeviceKind">
         <dt>audioinput</dt>
-
         <dd>
           <p>Represents an audio input device; for example a microphone.</p>
         </dd>
-
         <dt>audiooutput</dt>
-
         <dd>
           <p>Represents an audio output device; for example a pair of
           headphones.</p>
         </dd>
-
         <dt>videoinput</dt>
-
         <dd>
           <p>Represents a video input device; for example a webcam.</p>
         </dd>
@@ -3030,32 +2436,32 @@
       <h2>Input-specific Device Info</h2>
       <dl class="idl" title="interface InputDeviceInfo : MediaDeviceInfo">
         <dt>MediaTrackCapabilities getCapabilities()</dt>
-
         <dd>
-          <p>Returns a <code><a>MediaTrackCapabilities</a></code> object describing the primary
-          audio or video track of a device's <code><a>MediaStream</a></code>
-          (according to its <code>kind</code> value), in the absence of any user-supplied constraints.
-          These capabilities MUST be identical to those that would have been obtained by calling
-          <code>getCapabilities()</code> on the first <code><a>MediaStreamTrack</a></code> of this type in a
-          <code><a>MediaStream</a></code> returned by <code>getUserMedia({deviceId: <i>id</i>})</code>
-          where <i>id</i> is the value of the <code>deviceId</code> attribute
-          of this <code>MediaDeviceInfo</code>.</p>
-          <p>If no access has been granted to any local devices and this <code>InputDeviceInfo</code>
-          has been filtered with respect to unique identifying information (see above description of <code>
-          enumerateDevices()</code> result), then this method returns <code>null</code>.
+          <p>Returns a <code><a>MediaTrackCapabilities</a></code> object
+          describing the primary audio or video track of a device's
+          <code><a>MediaStream</a></code> (according to its <code>kind</code>
+          value), in the absence of any user-supplied constraints. These
+          capabilities MUST be identical to those that would have been obtained
+          by calling <code>getCapabilities()</code> on the first
+          <code><a>MediaStreamTrack</a></code> of this type in a
+          <code><a>MediaStream</a></code> returned by
+          <code>getUserMedia({deviceId: <i>id</i>})</code> where <i>id</i> is
+          the value of the <code>deviceId</code> attribute of this
+          <code>MediaDeviceInfo</code>.</p>
+          <p>If no access has been granted to any local devices and this
+          <code>InputDeviceInfo</code> has been filtered with respect to unique
+          identifying information (see above description of
+          <code>enumerateDevices()</code> result), then this method returns
+          <code>null</code>.</p>
         </dd>
       </dl>
-
     </section>
   </section>
-
   <section id="local-content">
     <h2>Obtaining local multimedia content</h2>
-
     <p>This section extends <code><a>NavigatorUserMedia</a></code> and
     <code><a>MediaDevices</a></code> with APIs to request permission to access
     media input devices available to the User Agent.</p>
-
     <p>When on an insecure origin [[mixed-content]], User Agents are encouraged
     to warn about usage of <code>navigator.mediaDevices.getUserMedia</code>,
     <code>navigator.getUserMedia</code>, and any prefixed variants in their
@@ -3063,99 +2469,82 @@
     Agents to remove these APIs entirely when on an insecure origin, as long as
     they remove all of them at once (e.g., they should not leave just the
     prefixed version available on insecure origins).</p>
-
     <section>
       <h3>NavigatorUserMedia Interface Extensions</h3>
-
       <div class="note">
         The definition of getUserMedia() in this section reflects two major
         changes from the method definition that has existed here for many
         months.
-
         <p>First, the official definition for the getUserMedia() method, and
         the one which developers are encouraged to use, is now at <a href=
-        "#dom-mediadevices-getusermedia">MediaDevices</a>. This
-        decision reflected consensus as long as the original API remained
-        available here under the Navigator object for backwards compatibility
-        reasons, since the working group acknowledges that early users of these
-        APIs have been encouraged to define getUserMedia as "var getUserMedia =
+        "#dom-mediadevices-getusermedia">MediaDevices</a>. This decision
+        reflected consensus as long as the original API remained available here
+        under the Navigator object for backwards compatibility reasons, since
+        the working group acknowledges that early users of these APIs have been
+        encouraged to define getUserMedia as "var getUserMedia =
         navigator.getUserMedia || navigator.webkitGetUserMedia ||
         navigator.mozGetUserMedia;" in order for their code to be functional
         both before and after official implementations of getUserMedia() in
         popular browsers. To ensure functional equivalence, the getUserMedia()
         method here is defined in terms of the method under MediaDevices.</p>
-
         <p>Second, the decision to change all other callback-based methods in
         the specification to be based on Promises instead required that the
         navigator.getUserMedia() definition reflect this in its use of
-        navigator.mediaDevices.getUserMedia(). Because navigator.getUserMedia() is
-        now the only callback-based method remaining in the specification,
+        navigator.mediaDevices.getUserMedia(). Because navigator.getUserMedia()
+        is now the only callback-based method remaining in the specification,
         there is ongoing discussion as to a) whether it still belongs in the
         specification, and b) if it does, whether its syntax should remain
         callback-based or change in some way to use Promises. Input on these
         questions is encouraged, particularly from developers actively using
         today's implementations of this functionality.</p>
-
         <p>Note that the other methods that changed from a callback-based
         syntax to a Promises-based syntax were not considered to have been
         implemented widely enough in any form to have to consider legacy
         usage.</p>
       </div>
-
       <dl class="idl" title="partial interface NavigatorUserMedia">
         <dt>void getUserMedia(MediaStreamConstraints constraints,
         NavigatorUserMediaSuccessCallback successCallback,
         NavigatorUserMediaErrorCallback errorCallback)</dt>
-
         <dd>
           <p>Prompts the user for permission to use their Web cam or other
           video or audio input.</p>
-
           <p>The <var>constraints</var> argument is a dictionary of type
           <code><a>MediaStreamConstraints</a></code>.</p>
-
           <p>The <var>successCallback</var> will be invoked with a suitable
           <code><a>MediaStream</a></code> object as its argument if the user
           accepts valid tracks as described in <a href=
           "#dom-mediadevices-getusermedia">getUserMedia()</a> on
           <code><a>MediaDevices</a></code>.</p>
-
           <p>The <var>errorCallback</var> will be invoked if there is a failure
           in finding valid tracks or if the user denies permission, as
           described in <a href=
           "#dom-mediadevices-getusermedia">getUserMedia()</a> on
           <code><a>MediaDevices</a></code>.</p>
-
           <p>When the <code id=
           "dom-navigatorusermedia-getusermedia">getUserMedia()</code> method is
           called, the User Agent MUST run the following steps:</p>
-
           <ol>
             <li>
               <p>Let <var>constraints</var> be the method's first argument.</p>
             </li>
-
             <li>
               <p>Let <var>successCallback</var> be the callback indicated by
               the method's second argument.</p>
             </li>
-
             <li>
               <p>Let <var>errorCallback</var> be the callback indicated by the
               method's third argument.</p>
             </li>
-
             <li>
               <p>Run the steps specified by the <a href=
               "#dom-mediadevices-getusermedia">getUserMedia() algorithm</a>
               with <var>constraints</var> as the argument, and let <var>p</var>
               be the resulting promise.</p>
             </li>
-
             <li>
               <p>Upon fulfillment of <var>p</var> with value <var>stream</var>,
               run the following step:</p>
-
               <ol>
                 <li>
                   <p>Invoke <var>successCallback</var> with <var>stream</var>
@@ -3163,11 +2552,9 @@
                 </li>
               </ol>
             </li>
-
             <li>
               <p>Upon rejection of <var>p</var> with reason <var>r</var>, run
               the following step:</p>
-
               <ol>
                 <li>
                   <p>Invoke <var>errorCallback</var> with <var>r</var> as the
@@ -3179,15 +2566,12 @@
         </dd>
       </dl>
     </section>
-
     <section>
       <h3>MediaDevices Interface Extensions</h3>
-
       <div class="note">
         The definition of getUserMedia() in this section reflects two major
         changes from the method definition that has existed under
         NavigatorUserMedia for many months.
-
         <p>First, the official definition for the getUserMedia() method, and
         the one which developers are encouraged to use, is now the one defined
         here under MediaDevices. This decision reflected consensus as long as
@@ -3202,21 +2586,17 @@
         popular browsers. To ensure functional equivalence, the getUserMedia()
         method under NavigatorUserMedia is defined in terms of the method
         here.</p>
-
         <p>Second, the method defined here is Promises-based, while the one
         defined under NavigatorUserMedia is currently still callback-based.
         Developers expecting to find getUserMedia() defined under
         NavigatorUserMedia are strongly encouraged to read the detailed Note
         given there.</p>
       </div>
-
       <p>The <code>getSupportedConstraints</code> method is provided to allow
       the application to determine which constraints the User Agent
       recognizes.</p>
-
       <dl class="idl" title="partial interface MediaDevices">
         <dt>MediaTrackSupportedConstraints getSupportedConstraints()</dt>
-
         <dd>
           <p>Returns a dictionary whose members are the constrainable
           properties known to the User Agent. A supported constrainable
@@ -3226,83 +2606,65 @@
           returned dictionary. The values returned represent what the browser
           implements and will not change during a browsing session.</p>
         </dd>
-
         <dt>Promise&lt;MediaStream&gt; getUserMedia( MediaStreamConstraints
         constraints)</dt>
-
         <dd>
           <p>Prompts the user for permission to use their Web cam or other
           video or audio input.</p>
-
           <p>The <var>constraints</var> argument is a dictionary of type
           <code><a>MediaStreamConstraints</a></code>.</p>
-
-          <p>This method returns a promise. The promise will be fulfilled with a suitable
-          <code><a>MediaStream</a></code> object if the user accepts valid
-          tracks as described below.</p>
-
+          <p>This method returns a promise. The promise will be fulfilled with
+          a suitable <code><a>MediaStream</a></code> object if the user accepts
+          valid tracks as described below.</p>
           <p>The promise will be rejected if there is a failure in finding
           valid tracks or if the user denies permission, as described
           below.</p>
-
           <p>When the <dfn id=
           "dom-mediadevices-getusermedia"><code>getUserMedia()</code></dfn>
           method is called, the User Agent MUST run the following steps:</p>
-
           <ol>
             <li>
               <p>Let <var>constraints</var> be the method's first argument.</p>
             </li>
-
             <li>
-              <p>Let <var>requestedMediaTypes</var> be the set of media
-              types in <var>constraints</var> with either a dictionary
-              value or a value of "true".</p>
+              <p>Let <var>requestedMediaTypes</var> be the set of media types
+              in <var>constraints</var> with either a dictionary value or a
+              value of "true".</p>
             </li>
-
             <li>
               <p>If <var>requestedMediaTypes</var> is the empty set, return a
               promise rejected with a <code>TypeError</code>.</p>
             </li>
-
             <li>
               <p>Let <var>p</var> be a new promise.</p>
             </li>
-
             <li>
               <p>Run the following steps in parallel:</p>
-
               <ol>
                 <li>
                   <p>Let <var>finalSet</var> be an (initially) empty set.</p>
                 </li>
-
                 <li>
                   <p>For each media type <var>T</var> in
                   <var>requestedMediaTypes</var>,</p>
-
                   <ol>
                     <li>
                       <p>For each possible source for that media type,
                       construct an unconstrained MediaStreamTrack with that
                       source as its source.</p>
-
                       <p>Call this set of tracks the
                       <var>candidateSet</var>.</p>
-
-                      <p>If <var>candidateSet</var> is the empty set,  reject
-                      <var>p</var> with a new
-                      <code><a>DOMException</a></code> object whose
-                      <code><a>name</a></code> attribute has the value
-                      <code>NotFoundError</code> and abort these steps.</p>
+                      <p>If <var>candidateSet</var> is the empty set, reject
+                      <var>p</var> with a new <code><a>DOMException</a></code>
+                      object whose <code><a>name</a></code> attribute has the
+                      value <code>NotFoundError</code> and abort these
+                      steps.</p>
                     </li>
-
                     <li>If the value of the <var>T</var> entry of
                     <var>constraints</var> is "true", set CS to the empty
                     constraint set (no constraint). Otherwise, continue with
                     <var>CS</var> set to the value of the <var>T</var> entry of
                     <var>constraints</var>.</li>
-
                     <li>
                       <p>Run the <code><a>SelectSettings</a></code> algorithm
                       on each track in <var>CandidateSet</var> with
@@ -3314,40 +2676,32 @@
                       constraints.</p>
                     </li>
                   </ol>
-
-                  <p>If <var>finalSet</var> is the empty set,
-                  let <var>constraint</var> be any required constraint
-                  whose fitness distance was infinity for all settings
-                  dictionaries examined while executing
-                  the <code><a>SelectSettings</a></code> algorithm,
-                  let <var>message</var> be
-                  either <code>undefined</code> or an informative
-                  human-readable message, and reject <var>p</var> with
-                  a new <code><a>OverconstrainedError</a></code>
-                  created by calling
-                  <code>OverconstrainedError(<var>constraint</var>,
-                  <var>message</var>)</code>, then
-                  abort these steps.</p>
-
+                  <p>If <var>finalSet</var> is the empty set, let
+                  <var>constraint</var> be any required constraint whose
+                  fitness distance was infinity for all settings dictionaries
+                  examined while executing the
+                  <code><a>SelectSettings</a></code> algorithm, let
+                  <var>message</var> be either <code>undefined</code> or an
+                  informative human-readable message, and reject <var>p</var>
+                  with a new <code><a>OverconstrainedError</a></code> created
+                  by calling <code>OverconstrainedError(<var>constraint</var>,
+                  <var>message</var>)</code>, then abort these steps.</p>
                   <p class="fingerprint">This error gives information about
                   what the underlying device is not capable of producing,
                   before the user has given any authorization to any device,
                   and can thus be used as a fingerprinting surface.</p>
                 </li>
-
                 <li>
                   <p>Optionally, e.g., based on a previously-established user
                   preference, for security reasons, or due to platform
                   limitations, jump to the step labeled <em>Permission
                   Failure</em> below.</p>
                 </li>
-
                 <li>
                   <p>Prompt the user in a User Agent specific manner for
                   permission to provide the entry script's origin with a
                   <code><a>MediaStream</a></code> object representing a media
                   stream.</p>
-
                   <p>The provided media MUST include precisely one track of
                   each media type in requestedMediaTypes from the
                   <var>finalSet</var>. The decision of which tracks to choose
@@ -3355,91 +2709,75 @@
                   Agent and may be determined by asking the user. Once
                   selected, the source of a
                   <code><a>MediaStreamTrack</a></code> MUST NOT change.</p>
-
                   <p>The User Agent MAY use the value of the computed "fitness
                   distance" from the <a>SelectSettings</a> algorithm, or any
                   other internally-available information about the devices, as
                   an input to the selection algorithm.</p>
-
                   <p>User Agents are encouraged to default to using the user's
                   primary or system default camera and/or microphone (when
                   possible) to generate the media stream. User Agents MAY allow
                   users to use any media source, including pre-recorded media
                   files.</p>
-
                   <p>If the user grants permission to use local recording
                   devices, User Agents are encouraged to include a prominent
                   indicator that the devices are "hot" (i.e. an "on-air" or
                   "recording" indicator), as well as a "device accessible"
                   indicator indicating that the page has been granted access to
                   the source.</p>
-
                   <p>If the user denies permission, jump to the step labeled
                   <em>Permission Failure</em> below. If the user never
                   responds, this algorithm stalls on this step.</p>
-
                   <p>If the user grants permission but a hardware error such as
                   an OS/program/webpage lock prevents access, reject
                   <var>p</var> with a new <code><a>DOMException</a></code>
                   object whose <code><a>name</a></code> attribute has the value
                   <code>NotReadableError</code> and abort these steps.</p>
-
                   <p>If the user grants permission but device access fails for
                   any reason other than those listed above, reject <var>p</var>
                   with a new <code><a>DOMException</a></code> object whose
                   <code><a>name</a></code> attribute has the value
                   <code>AbortError</code> and abort these steps.</p>
                 </li>
-
                 <li>
                   <p>Let <var>stream</var> be the
                   <code><a>MediaStream</a></code> object for which the user
                   granted permission.</p>
                 </li>
-
                 <li>
                   <p>Run the <code>ApplyConstraints()</code> algorithm on all
                   tracks in <var>stream</var> with the appropriate
                   constraints.</p>
                 </li>
-
                 <li>
                   <p>Resolve <var>p</var> with <var>stream</var> and abort
                   these steps.</p>
                 </li>
-
                 <li>
-                  <p><em>Permission Failure</em>: Reject <var>p</var> with a new
-                  <code><a>DOMException</a></code> object whose
+                  <p><em>Permission Failure</em>: Reject <var>p</var> with a
+                  new <code><a>DOMException</a></code> object whose
                   <code><a>name</a></code> attribute has the value
                   <code>SecurityError</code>.</p>
                 </li>
               </ol>
             </li>
-
             <li>
               <p>Return <var>p</var>.</p>
             </li>
           </ol>
         </dd>
       </dl>
-
       <div class="note">
         <p>In the algorithm above, constraints are checked twice - once at
         device selection, and once after access approval. Time may have passed
         between those checks, so it is conceivable that the selected device is
-        no longer suitable. In this case, a NotReadableError will
-        result.</p>
+        no longer suitable. In this case, a NotReadableError will result.</p>
       </div>
     </section>
-
     <section>
       <h2>MediaStreamConstraints</h2>
-
       <p>The <code>MediaStreamConstraints</code> dictionary is used to instruct
       the User Agent what sort of <a>MediaStreamTrack</a>s to include in the
       <a>MediaStream</a> returned by <a>getUserMedia()</a>.</p>
-
       <dl class="idl" title="dictionary MediaStreamConstraints">
         <!--        <dt>boolean audio</dt>
 
@@ -3453,9 +2791,7 @@
           <p>Set to true if a video track is requested, default is false</p>
         </dd>
 -->
-
         <dt>(boolean or MediaTrackConstraints) video = false</dt>
-
         <dd>
           <p>If <code>true</code>, it requests that the returned
           <a>MediaStream</a> contain a video track. If a <a>Constraints</a>
@@ -3463,9 +2799,7 @@
           of the video Track. If <code>false</code>, the <a>MediaStream</a>
           MUST NOT contain a video Track.</p>
         </dd>
-
         <dt>(boolean or MediaTrackConstraints) audio = false</dt>
-
         <dd>
           <p>If <code>true</code>, it requests that the returned
           <a>MediaStream</a> contain an audio track. If a <a>Constraints</a>
@@ -3475,43 +2809,40 @@
         </dd>
       </dl>
     </section>
-
     <section>
       <h2>NavigatorUserMediaSuccessCallback</h2>
-
       <dl class="idl" title=
       "callback NavigatorUserMediaSuccessCallback = void">
         <dt>MediaStream stream</dt>
-
         <dd>
-          <code><a>MediaStream</a></code> object representing the stream to which the user granted permission as described in the <a href="#widl-NavigatorUserMedia-getUserMedia-void-MediaStreamConstraints-constraints-NavigatorUserMediaSuccessCallback-successCallback-NavigatorUserMediaErrorCallback-errorCallback"><code>navigator.getUserMedia()</code></a> algorithm.
+          <code><a>MediaStream</a></code> object representing the stream to
+          which the user granted permission as described in the <a href=
+          "#widl-NavigatorUserMedia-getUserMedia-void-MediaStreamConstraints-constraints-NavigatorUserMediaSuccessCallback-successCallback-NavigatorUserMediaErrorCallback-errorCallback">
+          <code>navigator.getUserMedia()</code></a> algorithm.
         </dd>
       </dl>
     </section>
-
     <section>
       <h2>NavigatorUserMediaErrorCallback</h2>
-
       <dl class="idl" title="callback NavigatorUserMediaErrorCallback = void">
         <dt>MediaStreamError error</dt>
-
         <dd>
-          Error in obtaining a <code><a>MediaStream</a></code> as described in the failure steps of the <a href="#widl-NavigatorUserMedia-getUserMedia-void-MediaStreamConstraints-constraints-NavigatorUserMediaSuccessCallback-successCallback-NavigatorUserMediaErrorCallback-errorCallback"><code>navigator.getUserMedia()</code></a> algorithm.
+          Error in obtaining a <code><a>MediaStream</a></code> as described in
+          the failure steps of the <a href=
+          "#widl-NavigatorUserMedia-getUserMedia-void-MediaStreamConstraints-constraints-NavigatorUserMediaSuccessCallback-successCallback-NavigatorUserMediaErrorCallback-errorCallback">
+          <code>navigator.getUserMedia()</code></a> algorithm.
         </dd>
       </dl>
       <div class="idl" title="typedef object MediaStreamError">
-          A MediaStreamError object is either a <code><a>DOMException</a></code>
-          object or an <code><a>OverconstrainedError</a></code> object.
+        A MediaStreamError object is either a <code><a>DOMException</a></code>
+        object or an <code><a>OverconstrainedError</a></code> object.
       </div>
     </section>
-
     <section>
       <h2>Implementation Suggestions</h2>
-
       <div class="practice">
         <span class="practicelab" id="resource-reservation">Resource
         reservation</span>
-
         <p class="practicedesc">The User Agent is encouraged to reserve
         resources when it has determined that a given call to <a href=
         "#dom-mediadevices-getusermedia">getUserMedia()</a> will be successful.
@@ -3525,7 +2856,6 @@
         provide a stream sourced from a busy source but only to a page whose
         origin matches the owner of the original stream that is keeping the
         source busy.</p>
-
         <p class="practicedesc">This document recommends that in the permission
         grant dialog or device selection interface (if one is present), the
         user be allowed to select any available hardware as a source for the
@@ -3535,7 +2865,6 @@
         the ability to substitute a video or audio source with local files and
         other media. A file picker may be used to provide this functionality to
         the user.</p>
-
         <p class="practicedesc">This document also recommends that the user be
         shown all resources that are currently busy as a result of prior calls
         to <a href="#dom-mediadevices-getusermedia">getUserMedia()</a> (in this
@@ -3547,49 +2876,41 @@
         corresponding to the resource that was provided to the page whose
         stream was affected must be removed.</p>
       </div>
-
       <div class="practice">
         <span id="stored-permissions" class="practicelab">Stored
         Permissions</span>
-
         <p class="practicedesc">When permission is requested for a device, the
         User Agent may choose to store that permission, if granted, for later
         use by the same origin, so that the user does not need to grant
-        permission again at a later time.  [[!RTCWEB-SECURITY-ARCH]]
-        Section 5.2 requires that such storing MUST only be done when
-        the page is secure (served over HTTPS and having no mixed content). It
-        is a User Agent choice whether it offers functionality to store
-        permission to each device separately, all devices of a given class, or
-        all devices; the choice needs to be apparent to the user, and
-        permission must have been granted for the entire set whose permission
-        is being stored, e.g., to store permission to use all cameras the user
-        must have given permission to use all cameras and not just one.</p>
-
+        permission again at a later time. [[!RTCWEB-SECURITY-ARCH]] Section 5.2
+        requires that such storing MUST only be done when the page is secure
+        (served over HTTPS and having no mixed content). It is a User Agent
+        choice whether it offers functionality to store permission to each
+        device separately, all devices of a given class, or all devices; the
+        choice needs to be apparent to the user, and permission must have been
+        granted for the entire set whose permission is being stored, e.g., to
+        store permission to use all cameras the user must have given permission
+        to use all cameras and not just one.</p>
         <p class="practicedesc">When permission is not stored, permission
         should last only until such time as all MediaStreamTracks sourced from
         that device have been stopped.</p>
       </div>
-
       <div class="practice">
         <span class="practicelab" id="handling-devices">Handling multiple
         devices</span>
-
         <p class="practicedesc">A <a>MediaStream</a> may contain more than one
         video and audio track. This makes it possible to include video from two
         or more webcams in a single stream object, for example. However, the
         current API does not allow a page to express a need for multiple video
         streams from independent sources.</p>
-
         <p class="practicedesc">It is recommended for multiple calls to
         <a href="#dom-mediadevices-getusermedia">getUserMedia()</a> from the
         same page to be allowed as a way for pages to request multiple discrete
         video and/or audio streams.</p>
-
         <p class="practicedesc">Note also that if multiple <a href=
         "#dom-mediadevices-getusermedia">getUserMedia()</a> calls are done by a
         page, the order in which they request resources, and the order in which
         they complete, is not constrained by this specification.</p>
-
         <p class="practicedesc">A single call to <a href=
         "#dom-mediadevices-getusermedia">getUserMedia()</a> will always return
         a stream with either zero or one audio tracks, and either zero or one
@@ -3603,10 +2924,8 @@
       </div>
     </section>
   </section>
-
   <section id="constrainable-interface">
     <h2>Constrainable Pattern</h2>
-
     <p>The Constrainable pattern allows applications to inspect and adjust the
     properties of objects implementing it. It is broken out as a separate set
     of definitions so that it can be referred to by other specifications. The
@@ -3618,7 +2937,6 @@
     user, away from the user, or to the left or right of the user (an
     enumerated set). The application can examine a constrainable property's
     supported Capabilities via the <code>getCapabilities()</code> accessor.</p>
-
     <p>The application can select the (range of) values it wants for an
     object's Capabilities by means of basic and/or advanced ConstraintSets and
     the <code>applyConstraints()</code> method. A ConstraintSet consists of the
@@ -3645,7 +2963,6 @@
     constraints or a constraint given as a bare value for the property. Of
     these properties, it MUST satisfy the largest number that it can, in any
     order. Finally, the User Agent MUST resolve the returned promise.</p>
-
     <div class="note">
       Any constraint provided via this API will only be considered if the given
       constrainable property is supported by the browser. JavaScript
@@ -3661,7 +2978,6 @@
       browsers that do not support the constrainable property will not generate
       an error.
     </div>
-
     <p>The following examples may help to understand how constraints work. The
     first shows a basic Constraint structure. Three constraints are given, each
     of which the User Agent will attempt to satisfy individually. Depending
@@ -3684,16 +3000,16 @@ if(!supports["aspectRatio"]) {
     aspectRatio: 1.5
   };
 </pre>
-
     <p>This next example adds a small bit of complexity. The ideal values are
     still given for width and height, but this time with minimum requirements
-    on each as well as a minimum frameRate that must be satisfied. If it cannot satisfy the
-    frameRate, width or height minimum it will reject the promise. Otherwise, it will try
-    to satisfy the width, height, and aspectRatio target values as well and
-    then resolve the promise.  Note that the frameRate minimum might be 
-    within the capabilities of the camera and satisfiable in ideal lighting conditions, 
-    but not in low light, and could therefore result in firing of the 
-    <code>onoverconstrained</code> event handler under poor lighting conditions.</p>
+    on each as well as a minimum frameRate that must be satisfied. If it cannot
+    satisfy the frameRate, width or height minimum it will reject the promise.
+    Otherwise, it will try to satisfy the width, height, and aspectRatio target
+    values as well and then resolve the promise. Note that the frameRate
+    minimum might be within the capabilities of the camera and satisfiable in
+    ideal lighting conditions, but not in low light, and could therefore result
+    in firing of the <code>onoverconstrained</code> event handler under poor
+    lighting conditions.</p>
     <pre class="example highlight">
 var supports = navigator.mediaDevices.getSupportedConstraints();
 if(!supports["aspectRatio"] || !supports["frameRate"]) {
@@ -3707,7 +3023,6 @@ if(!supports["aspectRatio"] || !supports["frameRate"]) {
     aspectRatio: 1.5
   };
 </pre>
-
     <p>This example illustrates the full control possible with the Constraints
     structure by adding the 'advanced' property. In this case, the User Agent
     behaves the same way with respect to the required constraints, but before
@@ -3733,7 +3048,6 @@ if(!supports["width"] || !supports["height"]) {
                {aspectRatio: 1.3333333333}]
   };
 </pre>
-
     <p>The ordering of advanced ConstraintSets is significant. In the preceding
     example it is impossible to satisfy both the 1920x1280 ConstraintSet and
     the 4x3 aspect ratio ConstraintSet at the same time. Since the 1920x1280
@@ -3745,16 +3059,15 @@ if(!supports["width"] || !supports["height"]) {
     frame rate greater than 400, and the third asking for one greater than 300.
     If the User Agent is capable of setting a frame rate greater than 500, it
     will (and the subsequent two ConstraintSets will be trivially satisfied).
-    However, if the User Agent cannot set the frame rate above 500, it will skip
-    that ConstraintSet and attempt to set the frame rate above 400. If that
-    fails, it will then try to set it above 300. If the User Agent cannot
+    However, if the User Agent cannot set the frame rate above 500, it will
+    skip that ConstraintSet and attempt to set the frame rate above 400. If
+    that fails, it will then try to set it above 300. If the User Agent cannot
     satisfy any of the three ConstraintSets, it will set the frame rate to any
     value it can get. If the developers wanted to insist on 300 as a lower
     bound, they could provide that as a 'min' value in the basic ConstraintSet.
     In that case, the User Agent would fail altogether if it couldn't get a
     value over 300, but would choose a value over 500 if possible, then try for
     a value over 400.</p>
-
     <p>Note that, unlike basic constraints, the constraints within a
     ConstraintSet in the advanced list must be satisfied together or skipped
     together. Thus, {width: 1920, height: 1280} is a request for that specific
@@ -3764,7 +3077,6 @@ if(!supports["width"] || !supports["height"]) {
     individual constraints in the ConstraintSet. An application may inspect the
     full set of Constraints currently in effect via the
     <code>getConstraints()</code> accessor.</p>
-
     <p>The specific value that the User Agent chooses for a constrainable
     property is referred to as a Setting. For example, if the application
     applies a ConstraintSet specifying that the frameRate must be at least 30
@@ -3772,10 +3084,8 @@ if(!supports["width"] || !supports["height"]) {
     intermediate value, e.g., 32, 35, or 37 frames per second. The application
     can query the current settings of the object's constrainable properties via
     the <code><a>getSettings()</a></code> accessor.</p>
-
     <section>
       <h2>Interface Definition</h2>
-
       <p>Due to the limitations of the interface definition language used in
       this specification, it is not possible for other interfaces to inherit or
       implement ConstrainablePattern. Therefore the WebIDL definitions given
@@ -3785,61 +3095,49 @@ if(!supports["width"] || !supports["height"]) {
       refer to the semantics defined here, which will not change. See <a href=
       "#media-stream-track-interface-definition">MediaStreamTrack Interface
       Definition</a> for an example of this.</p>
-
-          <p>When the User Agent is no longer able to satisfy the
-          <var>requiredConstraints</var> from the currently valid
-          Constraints, the User Agent MUST queue a task that fires
-          an <code>OverconstrainedErrorEvent</code>, initialized
-          as described in the following paragraph, at the constrainable object.
-          The event firing task MAY also be used to update the
-          constrainable object as a result of the overconstrained
-          situation.</p>
-
-          <p>The <code>OverconstrainedErrorEvent</code>
-          references an
-          <code><a>OverconstrainedError</a></code> whose
-          <code>constraint</code> attribute is set to one of the
-          <var>requiredConstraints</var> that can no longer be satisfied. The
-          <code>message</code> attribute of
-          the <code>OverconstrainedError</code> SHOULD contain a
-          string that is useful for debugging. The conditions under
-          which this error might occur are platform and
-          application-specific. For example, the user might physically
-          manipulate a camera in a way that makes it impossible to
-          provide a resolution or frameRate that satisfies the constraints. The
-          User Agent MAY take other actions as a result of the
-          overconstrained situation.</p>
-
+      <p>When the User Agent is no longer able to satisfy the
+      <var>requiredConstraints</var> from the currently valid Constraints, the
+      User Agent MUST queue a task that fires an
+      <code>OverconstrainedErrorEvent</code>, initialized as described in the
+      following paragraph, at the constrainable object. The event firing task
+      MAY also be used to update the constrainable object as a result of the
+      overconstrained situation.</p>
+      <p>The <code>OverconstrainedErrorEvent</code> references an
+      <code><a>OverconstrainedError</a></code> whose <code>constraint</code>
+      attribute is set to one of the <var>requiredConstraints</var> that can no
+      longer be satisfied. The <code>message</code> attribute of the
+      <code>OverconstrainedError</code> SHOULD contain a string that is useful
+      for debugging. The conditions under which this error might occur are
+      platform and application-specific. For example, the user might physically
+      manipulate a camera in a way that makes it impossible to provide a
+      resolution or frameRate that satisfies the constraints. The User Agent
+      MAY take other actions as a result of the overconstrained situation.</p>
       <dl class="idl" title=
       "[NoInterfaceObject] interface ConstrainablePattern">
         <dt>Capabilities getCapabilities()</dt>
-
         <dd>
           <p>The <dfn>getCapabilities()</dfn> method returns the dictionary of
           the names of the constrainable properties that the object
           supports.</p>
-
           <div class="note">
             <p>It is possible that the underlying hardware may not exactly map
-            to the range defined for the constrainable property. Where this is possible,
-            the entry SHOULD define how to translate and scale the hardware's
-            setting onto the values defined for the property. For example, suppose
-            that a hypothetical fluxCapacitance
-            property ranges from -10 (min) to 10 (max), but there are
-            common hardware devices that support only values of "off" "medium"
-            and "full". The constrainable property definition might specify that for such
+            to the range defined for the constrainable property. Where this is
+            possible, the entry SHOULD define how to translate and scale the
+            hardware's setting onto the values defined for the property. For
+            example, suppose that a hypothetical fluxCapacitance property
+            ranges from -10 (min) to 10 (max), but there are common hardware
+            devices that support only values of "off" "medium" and "full". The
+            constrainable property definition might specify that for such
             hardware, the User Agent should map the range value of -10 to
             "off", 10 to "full", and 0 to "medium". It might also indicate that
             given a ConstraintSet imposing a strict value of 3, the User Agent
-            should attempt to set the value of "medium" on the hardware, 
-            and that <code><a>getSettings()</a></code> should return a
+            should attempt to set the value of "medium" on the hardware, and
+            that <code><a>getSettings()</a></code> should return a
             fluxCapacitance of 0, since that is the value defined as
             corresponding to "medium".</p>
           </div>
         </dd>
-
         <dt>Constraints getConstraints()</dt>
-
         <dd>
           <p>The <dfn>getConstraints</dfn> method returns the Constraints that
           were the argument to the most recent successful call of
@@ -3849,9 +3147,7 @@ if(!supports["width"] || !supports["height"]) {
           ConstraintSets are currently in effect, the application should use
           <code>getSettings</code>.</p>
         </dd>
-
         <dt>Settings getSettings()</dt>
-
         <dd>
           <p>The <dfn>getSettings()</dfn> method returns the current settings
           of all the constrainable properties of the object, whether they are
@@ -3859,49 +3155,38 @@ if(!supports["width"] || !supports["height"]) {
           <code>applyConstraints()</code>. Note that the actual setting of a
           property MUST be a single value.</p>
         </dd>
-
         <dt>Promise&lt;void&gt; applyConstraints()</dt>
-
         <dd>
           <dl class="parameters">
             <dt>optional Constraints constraints</dt>
-
             <dd>
               <p>A new constraint structure to apply to this object.</p>
             </dd>
           </dl>
-
           <p>The <dfn>applyConstraints()</dfn> algorithm for applying
           constraints is stated below. Here are some preliminary definitions
           that are used in the statement of the algorithm:</p>
-
           <p>We use the term <dfn>settings dictionary</dfn> for the set of
           values that might be applied as settings to the object.</p>
-
           <p>For string valued constraints, we define "==" below to be true if
           one of the values in the sequence is exactly the same as the value
           being compared against.</p>
-
           <p>We define the <dfn>fitness distance</dfn> between a <a>settings
           dictionary</a> and a constraint set <var>CS</var> as the sum, for
           each constraint provided for a constraint name in <var>CS</var>, of
           the following values:</p>
-
           <ol>
             <li>
               <p>If the constraint is not supported by the browser, the fitness
               distance is 0.</p>
             </li>
-
             <li>
               <p>If the constraint is required ('min', 'max', or 'exact'), and
               the <a>settings dictionary</a>'s value for the constraint does
               not satisfy the constraint, the fitness distance is positive
               infinity.</p>
             </li>
-
             <li>If no ideal value is specified, the fitness distance is 0.</li>
-
             <li>For all positive numeric non-required constraints (such as
             height, width, frameRate, aspectRatio, sampleRate and sampleSize),
             the fitness distance is the result of the formula
@@ -3910,7 +3195,6 @@ if(!supports["width"] || !supports["height"]) {
                   ideal|/max(|actual|,|ideal|)
 </pre>
             </li>
-
             <li>For all string and enum non-required constraints (sourceId,
             groupId, facingMode, echoCancellation), the fitness distance is the
             result of the formula
@@ -3919,9 +3203,7 @@ if(!supports["width"] || !supports["height"]) {
 </pre>
             </li>
           </ol>
-
           <p>More definitions:</p>
-
           <ul>
             <li>We refer to each element of a ConstraintSet (other than the
             special term 'advanced') as a 'constraint' since it is intended to
@@ -3929,7 +3211,6 @@ if(!supports["width"] || !supports["height"]) {
             full list or range given in the corresponding Capability of the
             ConstrainablePattern object to a value that is within the range or
             list of values it specifies.</li>
-
             <li>We refer to the "effective Capability" C of an object O as the
             possibly proper subset of the possible values of C (as returned by
             getCapabilities) taking into consideration environmental
@@ -3941,23 +3222,18 @@ if(!supports["width"] || !supports["height"]) {
             resource-limited device it may not be possible to set properties P1
             and P2 both to 'high', while on another less limited device, this
             may be possible.</li>
-
             <li>A settings dictionary, which is a set of values for the
             constrainable properties of an object O, satisfies ConstraintSet CS
             if the fitness distance between the set and CS is less than
             infinity.</li>
-
             <li>A set of ConstraintSets CS1...CSn (n &gt;= 1) can be satisfied
             by an object O if it is possible to find a settings dictionary of O
             that satisfies CS1...CSn simultaneously.</li>
-
             <li>To apply a set of ConstraintSets CS1...CSn to object O is to
             choose such a sequence of values that satisfy CS1...CSn and assign
             them as the settings for the properties of O.</li>
           </ul>
-
           <p>We define the <dfn>SelectSettings</dfn> algorithm as follows:</p>
-
           <ol>
             <li>Each <a data-lt="constraints">constraint</a> specifies one or
             more values (or a range of values) for its property. A property MAY
@@ -3965,7 +3241,6 @@ if(!supports["width"] || !supports["height"]) {
             an empty object or list has been given as the value for a
             constraint, it MUST be interpreted as if the constraint were not
             specified (in other words, an empty constraint == no constraint).
-
               <p>Note that unknown properties are discarded by WebIDL, which
               means that unknown/unsupported required constraints will silently
               disappear. To avoid this being a surprise, application authors
@@ -3973,13 +3248,11 @@ if(!supports["width"] || !supports["height"]) {
               <code>getSupportedConstraints()</code> method as shown in the
               Examples below.</p>
             </li>
-
             <li>Let <var>object</var> be the
             <code><a>ConstrainablePattern</a></code> object on which this
             algorithm is applied. Let <var>copy</var> be an unconstrained copy
             of <var>object</var> (i.e., <var>copy</var> should behave as if it
             were <var>object</var> with all ConstraintSets removed.)</li>
-
             <li>
               <p>For every possible <a>settings dictionary</a> of
               <var>copy</var> compute its <a>fitness distance, treating bare
@@ -3988,105 +3261,82 @@ if(!supports["width"] || !supports["height"]) {
               "settings dictionary">settings dictionaries</a> for which the
               <a>fitness distance</a> is finite.</p>
             </li>
-
             <li>
               <p>If <var>candidates</var> is empty, return
               <code>undefined</code> as the result of the
               <code>SelectSettings()</code> algorithm.</p>
             </li>
-
             <li>Iterate over the 'advanced' ConstraintSets in
             <var>newConstraints</var> in the order in which they were
             specified. For each ConstraintSet:
-
               <ol>
                 <li>
                   <p>compute the fitness distance between it and each settings
                   dictionary in <var>candidates</var>, treating bare values of
                   properties as exact.</p>
                 </li>
-
                 <li>
                   <p>If the fitness distance is finite for one or more settings
                   dictionaries in <var>candidates</var>, keep those settings
                   dictionaries in <var>candidates</var>, discarding others.</p>
-
                   <p>If the fitness distance is infinite for all settings
                   dictionaries in <var>candidates</var>, ignore this
                   ConstraintSet.</p>
                 </li>
               </ol>
             </li>
-
             <li>
-              <p>Select one settings dictionary from <var>candidates</var>,
-              and return it as the result of the
-              <code>SelectSettings()</code> algorithm. The UA SHOULD use the
-              one with the smallest <code>fitness distance</code>, as
-              calculated in step 3.</p>
+              <p>Select one settings dictionary from <var>candidates</var>, and
+              return it as the result of the <code>SelectSettings()</code>
+              algorithm. The UA SHOULD use the one with the smallest
+              <code>fitness distance</code>, as calculated in step 3.</p>
             </li>
           </ol>
-
           <p>When <code>applyConstraints</code> is called, the User Agent MUST
           run the following steps:</p>
-
           <ol>
             <li>
               <p>Let <var>p</var> be a new promise.</p>
             </li>
-
             <li>
               <p>Let <var>newContraints</var> be the argument to this
               function.</p>
             </li>
-
             <li>
               <p>Run the following steps in parallel:</p>
-
               <ol>
                 <li>
                   <p>Let <var>successfulSettings</var> be the result of running
                   the <a>SelectSettings</a> algorithm with
                   <var>newConstraints</var> as the constraint set.</p>
                 </li>
-
                 <li>
                   <p>If <var>successfulSettings</var> is
-                  <code>undefined</code>,
-                  let <var>failedConstraint</var> be any required constraint
-                  whose fitness distance was infinity for all settings
-                  dictionaries examined while executing
-                  the <code><a>SelectSettings</a></code> algorithm,
-                  let <var>message</var> be
-                  either <code>undefined</code> or an informative
-                  human-readable message, reject <var>p</var> with
-                  a new
-                  <code>OverconstrainedError</code> created by
-                  calling
+                  <code>undefined</code>, let <var>failedConstraint</var> be
+                  any required constraint whose fitness distance was infinity
+                  for all settings dictionaries examined while executing the
+                  <code><a>SelectSettings</a></code> algorithm, let
+                  <var>message</var> be either <code>undefined</code> or an
+                  informative human-readable message, reject <var>p</var> with
+                  a new <code>OverconstrainedError</code> created by calling
                   <code>OverconstrainedError(<var>failedConstraint</var>,
-                  <var>message</var>)</code>, and abort these steps.  The
+                  <var>message</var>)</code>, and abort these steps. The
                   existing constraints remain in effect in this case.</p>
                 </li>
-
-                <li>In a single operation, remove
-                the existing constraints from <var>object</var>, apply
-                <var>newConstraints</var>, and apply
+                <li>In a single operation, remove the existing constraints from
+                <var>object</var>, apply <var>newConstraints</var>, and apply
                 <var>successfulSettings</var> as the current settings.</li>
-
                 <li>Finally, resolve <var>p</var>. From this point on until
                 applyConstraints() is called successfully again,
                 getConstraints() <em class="rfc2119" title="must">must</em>
                 return the <var>newConstraints</var> that were passed as an
-                argument to this call.
-                </li>
+                argument to this call.</li>
               </ol>
             </li>
-
             <li>
               <p>Return <var>p</var>.</p>
             </li>
           </ol>
-
           <div class="note">
             <p>Any implementation that has the same result as the algorithm
             above is an allowed implementation. For instance, the
@@ -4095,7 +3345,6 @@ if(!supports["width"] || !supports["height"]) {
             rather than keeping track of all possible values for the
             setting.</p>
           </div>
-
           <div class="note">
             <p>When picking a settings dictionary, the UA can use any
             information available to it. Examples of such information may be
@@ -4104,25 +3353,20 @@ if(!supports["width"] || !supports["height"]) {
             the settings dictionaries, or whether using a settings dictionary
             will cause the device driver to apply resampling.</p>
           </div>
-
           <p>The User Agent MAY choose new settings for the constrainable
           properties of the object at any time. When it does so it MUST attempt
           to satisfy the current Constraints, in the manner described in the
           algorithm above.</p>
         </dd>
-
         <dt>attribute EventHandler onoverconstrained</dt>
-
-        <dd>
-          The event type of this event handler is <code><a>overconstrained</a></code>.
-        </dd>
+        <dd>The event type of this event handler is
+        <code><a>overconstrained</a></code>.</dd>
       </dl>
-
       <p>An example of Constraints that could be passed into
       <code><a>applyConstraints()</a></code> or returned as a value of
-      <code><a>constraints</a></code> is below. It uses the
-      <a href="#constrainable-properties">constrainable properties defined for
-        <code>MediaStreamTrack</code></a>.</p>
+      <code><a>constraints</a></code> is below. It uses the <a href=
+      "#constrainable-properties">constrainable properties defined for
+      <code>MediaStreamTrack</code></a>.</p>
       <pre class="example highlight">
 var supports = navigator.mediaDevices.getSupportedConstraints();
 if(!supports["facingMode"]) {
@@ -4152,7 +3396,6 @@ var constraints = {
     }]
 };
 </pre>
-
       <p>Here is another example, specifically for a video track where I must
       have a particular camera and have separate preferences for the width and
       height:</p>
@@ -4175,7 +3418,6 @@ var constraints = {
     }]
 };
 </pre>
-
       <p>And here's one for an audio track:</p>
       <pre class="example highlight">
 var supports = navigator.mediaDevices.getSupportedConstraints();
@@ -4190,7 +3432,6 @@ var constraints = {
     }]
 };
 </pre>
-
       <p>Here's an example of use of ideal:</p>
       <pre class="example highlight">
 var supports = navigator.mediaDevices.getSupportedConstraints();
@@ -4206,7 +3447,6 @@ var gotten = navigator.mediaDevices.getUserMedia({
     facingMode: {exact: "environment"}
   }});
 </pre>
-
       <p>Here's an example of "I want 720p, but I can accept up to 1080p and
       down to VGA.":</p>
       <pre class="example highlight">
@@ -4219,7 +3459,6 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
   height: {min: 480, ideal: 720, max: 1080},
 }});
 </pre>
-
       <p>Here's an example of "I want a front-facing camera and it must be
       VGA.":</p>
       <pre class="example highlight">
@@ -4234,14 +3473,12 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
 }});
 </pre>
     </section>
-
     <section>
       <h2>Types for Constrainable Properties</h2>
       <p>The syntax for the specification of the set of legal values depends on
       the type of the values. In addition to the standard atomic types
       (boolean, long, double, DOMString), legal values include lists of any of
       the atomic types, plus min-max ranges, as defined below.</p>
-
       <p>List values MUST be interpreted as disjunctions. For example, if a
       property 'facingMode' for a camera is defined as having legal values
       ["left", "right", "user", "environment"], this means that 'facingMode'
@@ -4252,86 +3489,62 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
       "left", or "right". This Constraint would thus request that the camera
       not be facing away from the user, but would allow the User Agent to allow
       the user to choose other directions.</p>
-
       <dl class="idl" title="dictionary DoubleRange">
         <dt>double max</dt>
-
         <dd>
           <p>The maximum legal value of this property.</p>
         </dd>
-
         <dt>double min</dt>
-
         <dd>
           <p>The minimum value of this Property.</p>
         </dd>
       </dl>
-
       <dl class="idl" title="dictionary ConstrainDoubleRange : DoubleRange">
         <dt>double exact</dt>
-
         <dd>
           <p>The exact required value for this property.</p>
         </dd>
-
         <dt>double ideal</dt>
-
         <dd>
           <p>The ideal (target) value for this property.</p>
         </dd>
       </dl>
-
       <dl class="idl" title="dictionary LongRange">
         <dt>long max</dt>
-
         <dd>
           <p>The maximum legal value of this property.</p>
         </dd>
-
         <dt>long min</dt>
-
         <dd>
           <p>The minimum value of this property.</p>
         </dd>
       </dl>
-
       <dl class="idl" title="dictionary ConstrainLongRange : LongRange">
         <dt>long exact</dt>
-
         <dd>
           <p>The exact required value for this property.</p>
         </dd>
-
         <dt>long ideal</dt>
-
         <dd>
           <p>The ideal (target) value for this property.</p>
         </dd>
       </dl>
-
       <dl class="idl" title="dictionary ConstrainBooleanParameters">
         <dt>boolean exact</dt>
-
         <dd>
           <p>The exact required value for this property.</p>
         </dd>
-
         <dt>boolean ideal</dt>
-
         <dd>
           <p>The ideal (target) value for this property.</p>
         </dd>
       </dl>
-
       <dl class="idl" title="dictionary ConstrainDOMStringParameters">
         <dt>(DOMString or sequence&lt;DOMString&gt;) exact</dt>
-
         <dd>
           <p>The exact required value for this property.</p>
         </dd>
-
         <dt>(DOMString or sequence&lt;DOMString&gt;) ideal</dt>
-
         <dd>
           <p>The ideal (target) value for this property.</p>
         </dd>
@@ -4343,27 +3556,24 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
       <div class="idl" title=
       "typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean"></div>
       <div class="idl" title=
-      "typedef (DOMString or sequence&lt;DOMString&gt; or ConstrainDOMStringParameters) ConstrainDOMString"></div>
+      "typedef (DOMString or sequence&lt;DOMString&gt; or ConstrainDOMStringParameters) ConstrainDOMString">
+      </div>
     </section>
-
     <section id="capabilities">
       <h3>Capabilities</h3>
-
       <p><dfn>Capabilities</dfn> is a dictionary containing one or more
-      key-value pairs, where each key MUST be a constrainable property,
-      and each value MUST be a subset of the set of values
-      allowed for that property. The exact syntax of the value
-      expression depends on the type of the property.
-      The Capabilities dictionary
-      specifies the subset of the constrainable properties and values
-      that the User Agent supports. Note that a User Agent MAY support
-      only a subset of the properties defined in the Web platform, and MAY
-      support a subset of the set values for those properties that it does
-      support. Note that Capabilities are returned from the User Agent to the
-      application, and cannot be specified by the application. However, the
-      application can control the Settings that the User Agent chooses for
-      constrainable properties by means of Constraints.</p>
-
+      key-value pairs, where each key MUST be a constrainable property, and
+      each value MUST be a subset of the set of values allowed for that
+      property. The exact syntax of the value expression depends on the type of
+      the property. The Capabilities dictionary specifies the subset of the
+      constrainable properties and values that the User Agent supports. Note
+      that a User Agent MAY support only a subset of the properties defined in
+      the Web platform, and MAY support a subset of the set values for those
+      properties that it does support. Note that Capabilities are returned from
+      the User Agent to the application, and cannot be specified by the
+      application. However, the application can control the Settings that the
+      User Agent chooses for constrainable properties by means of
+      Constraints.</p>
       <p>An example of a Capabilities dictionary is shown below. This example
       is not very realistic in that a browser would actually be required to
       support more constrainable properties than just these.</p>
@@ -4376,7 +3586,6 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
   facingMode: [ "user", "left" ]
 }
 </pre>
-
       <p>The next example below points out that capabilities for range values
       provide ranges for individual constrainable properties, not combinations.
       This is particularly relevant for video width and height, since the
@@ -4396,22 +3605,16 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
   aspectRatio: 1.3333333333
 }
 </pre>
-
       <p>Note in the example above that the aspectRatio would make clear that
       arbitrary combination of widths and heights are not possible, although it
-      would still suggest that more than two resolutions were available.</p>
-
-      A specification using the Constrainable Pattern should not subclass the
+      would still suggest that more than two resolutions were available.</p>A
+      specification using the Constrainable Pattern should not subclass the
       below dictionary, but instead provide its own definition. See
       <code><a>MediaTrackCapabilities</a></code> for an example.
-
       <dl class="idl" title="dictionary Capabilities"></dl>
-
     </section>
-
     <section>
       <h3>Settings</h3>
-
       <p><dfn>Settings</dfn> is a dictionary containing one or more key-value
       pairs. It MUST contain each key returned in
       <code>getCapabilities()</code>. There MUST be a single value for each key
@@ -4420,10 +3623,8 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
       contains the actual values that the User Agent has chosen for the
       object's constrainable properties. The exact syntax of the value depends
       on the type of the property.</p>
-
       <p>A conforming User Agent MUST support all the constrainable properties
       defined in this specification.</p>
-
       <p>An example of a Settings dictionary is shown below. This example is
       not very realistic in that a browser would actually be required to
       support more constrainable properties than just these.</p>
@@ -4432,28 +3633,20 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
   frameRate: 30.0,
   facingMode: "user"
 }
-</pre>
-
-      A specification using the Constrainable Pattern should not subclass the
-      below dictionary, but instead provide its own definition. See
-      <code><a>MediaTrackSettings</a></code> for an example.
-
+</pre>A specification using the Constrainable Pattern should not subclass the
+below dictionary, but instead provide its own definition. See
+<code><a>MediaTrackSettings</a></code> for an example.
       <dl class="idl" title="dictionary Settings"></dl>
-
     </section>
-
     <section id="constraints">
       <h3><dfn>Constraints and ConstraintSet</dfn></h3>
-
       <p>Due to the limitations of WebIDL, interfaces implementing the
       Constrainable Pattern cannot simply subclass Constraints and
       ConstraintSet as they are defined here. Instead they must provide their
       own definitions that follow this pattern. See <a href=
       "#media-track-constraints">MediaTrackConstraints</a> for an example of
       this.</p>
-
       <dl class="idl" title="dictionary ConstraintSet"></dl>
-
       <p>Each member of a ConstraintSet corresponds to a constrainable property
       and specifies a subset of the property's legal Capability values.
       Applying a ConstraintSet instructs the User Agent to restrict the
@@ -4461,33 +3654,30 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
       values or ranges of values. A given property MAY occur both in the basic
       Constraints set and in the advanced ConstraintSets list, and MAY occur at
       most once in each ConstraintSet in the advanced list.</p>
-
       <dl class="idl" title="dictionary Constraints : ConstraintSet">
         <dt>sequence&lt;ConstraintSet&gt; advanced</dt>
-
         <dd>
-          <p>This is the list of ConstraintSets that the User Agent MUST attempt to
-          satisfy, in order, skipping only those that cannot be satisfied. The
-          order of these ConstraintSets is significant. In particular, when
-          they are passed as an argument to <code>applyConstraints</code>, the
-          User Agent MUST try to satisfy them in the order that is specified.
-          Thus if optional ConstraintSets C1 and C2 can be satisfied
-          individually, but not together, then whichever of C1 and C2 is first
-          in this list will be satisfied, and the other will not. The User
-          Agent MUST attempt to satisfy all optional ConstraintSets in the
-          list, even if some cannot be satisfied. Thus, in the preceding
-          example, if optional constraint C3 is specified after C1 and C2, the
-          User Agent will attempt to satisfy C3 even though C2 cannot be
-          satisfied. Note that a given property name may occur only once in
-          each ConstraintSet but may occur in more than one ConstraintSet.</p>
+          <p>This is the list of ConstraintSets that the User Agent MUST
+          attempt to satisfy, in order, skipping only those that cannot be
+          satisfied. The order of these ConstraintSets is significant. In
+          particular, when they are passed as an argument to
+          <code>applyConstraints</code>, the User Agent MUST try to satisfy
+          them in the order that is specified. Thus if optional ConstraintSets
+          C1 and C2 can be satisfied individually, but not together, then
+          whichever of C1 and C2 is first in this list will be satisfied, and
+          the other will not. The User Agent MUST attempt to satisfy all
+          optional ConstraintSets in the list, even if some cannot be
+          satisfied. Thus, in the preceding example, if optional constraint C3
+          is specified after C1 and C2, the User Agent will attempt to satisfy
+          C3 even though C2 cannot be satisfied. Note that a given property
+          name may occur only once in each ConstraintSet but may occur in more
+          than one ConstraintSet.</p>
         </dd>
       </dl>
     </section>
   </section>
-
   <section>
     <h2>Examples</h2>
-
     <div>
       <p>This sample code exposes a button. When clicked, the button is
       disabled and the user is prompted to offer a stream. The user can cause
@@ -4587,7 +3777,6 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
 &lt;/script&gt;
 </pre>
     </div>-->
-
     <div>
       <p>This example allows people to take photos of themselves from the local
       video camera. Note that the Image Capture specification [[image-capture]]
@@ -4632,902 +3821,634 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
 </pre>
     </div>
   </section>
-
   <section>
     <h1>Privacy and Security Considerations</h1>
-
     <p>This section is non-normative; it specifies no new behavior, but instead
     summarizes information already present in other parts of the
     specification.</p>
-
     <p>This document extends the Web platform with the ability to manage input
     devices for media - in this iteration, microphones, and cameras. It also
-    allows the manipulation of audio output devices (speakers and
-    headphones). Capturing audio and video exposes personally-identifiable
-    information to applications, and this specification requires obtaining
-    explicit user consent before sharing it.</p>
-
+    allows the manipulation of audio output devices (speakers and headphones).
+    Capturing audio and video exposes personally-identifiable information to
+    applications, and this specification requires obtaining explicit user
+    consent before sharing it.</p>
     <p>Without authorization (to the "drive-by web"), it offers the ability to
     tell how many devices there are of each class, and how they are grouped
     together (e.g. a microphone and camera belonging to a single Web cam). The
-    identifiers for the
-    devices are designed to not be useful for a fingerprint that can track the
-    user between origins, but the number and grouping of devices adds to the
-    fingerprint
-    surface. It recommends to treat the per-origin persistent identifier
-    <code>deviceId</code> and <code>groupId</code> as other persistent
-    storages (e.g. cookies) are treated.</p>
-
+    identifiers for the devices are designed to not be useful for a fingerprint
+    that can track the user between origins, but the number and grouping of
+    devices adds to the fingerprint surface. It recommends to treat the
+    per-origin persistent identifier <code>deviceId</code> and
+    <code>groupId</code> as other persistent storages (e.g. cookies) are
+    treated.</p>
     <p>When authorization is given, this document describes how to get access
     to, and use, media data from the devices mentioned. This data may be
     sensitive; advice is given that indicators should be supplied to indicate
     that devices are in use, but both the nature of authorization and the
     indicators of in-use devices are platform decisions.</p>
-
     <p>Authorization may be given on a case-by-case basis, or be persistent. In
     the case of a case-by-case authorization, it is important that the user be
     able to say "no" in a way that prevents the UI from blocking user
     interaction until permission is given - either by offering a way to say a
     "persistent NO" or by not using a modal permissions dialog.</p>
-
-    <p>When authorization to any media device is given, application developers gain access to the
-    labels of all available media capture devices. In most cases, the labels
-    are persistent across browsing sessions and across origins that have also
-    been granted authorization, and thus potentially provide a way to track a
-    given device across time and origins.</p>
-
+    <p>When authorization to any media device is given, application developers
+    gain access to the labels of all available media capture devices. In most
+    cases, the labels are persistent across browsing sessions and across
+    origins that have also been granted authorization, and thus potentially
+    provide a way to track a given device across time and origins.</p>
     <p>Once a developer gains access to a media stream from a capture device,
     the developer also gains access to detailed information about the device,
     including its range of operating capabilities (e.g. available resolutions
     for a camera). These operating capabilities are for the most part
     persistent across browsing sessions and origins, and thus provide a way to
     track a given device across time and origins.</p>
-
     <p>Once access to a video stream from a capture device is obtained, that
-    stream can most likely be used to fingerprint uniquely the said device (e.g.
-    via dead pixel detection).</p>
-
+    stream can most likely be used to fingerprint uniquely the said device
+    (e.g. via dead pixel detection).</p>
     <p>It is possible to use constraints so that the failure of a getUserMedia
     call will return information about devices on the system without prompting
     the user, which increases the surface available for fingerprinting. The
     User Agent should consider limiting the rate at which failed getUserMedia
     calls are allowed in order to limit this additional surface.</p>
-
     <p>In the case of persistent authorization, it is important that it is easy
     to find the list of granted permissions and revoke permissions that the
     user wishes to revoke.</p>
-
     <p>Once permission has been granted, the User Agent should make two things
     readily apparent to the user:</p>
-
     <ul>
       <li>That the page has access to the devices for which permission is
       given</li>
-
       <li>Whether or not any of the devices are presently recording ("on air")
       indicator</li>
     </ul>
-
     <div class="note">
       <p>Developers of sites with persistent permissions should be careful that
       these permissions not be abused.</p>
-
       <p>In particular, they should not make it possible to automatically send
       audio or video streams from authorized media devices to an end point that
       a third party can select.</p>
-
       <p>Indeed, if a site offered URLs such as
       <code>https://webrtc.example.org/?call=<var>user</var></code> that would
       automatically set up calls and transmit audio/video to
       <code><var>user</var></code>, it would be open for instance to the
       following abuse:</p>
-
       <p>Users who have granted permanent permissions to
       <code>https://webrtc.example.org/</code> could be tricked to send their
       audio/video streams to an attacker <code>EvilSpy</code> by following a
       link or being redirected to
       <code>https://webrtc.example.org/?user=EvilSpy</code>.</p>
-
-      <p>Although [[!RTCWEB-SECURITY-ARCH]] Section 5.2 indicates that 
-      implementations may refuse all access permissions for HTTP origins,
-      it recommends that implementations allow one-time camera/microphone 
-      access. While allowing one-time access for HTTP origins is 
-      convenient, this makes it possible for an attacker to obtain access
-      to the camera/microphone of an unsuspecting user.</p>
+      <p>Although [[!RTCWEB-SECURITY-ARCH]] Section 5.2 indicates that
+      implementations may refuse all access permissions for HTTP origins, it
+      recommends that implementations allow one-time camera/microphone access.
+      While allowing one-time access for HTTP origins is convenient, this makes
+      it possible for an attacker to obtain access to the camera/microphone of
+      an unsuspecting user.</p>
     </div>
   </section>
-
   <section class="informative">
     <h2>Extensibility</h2>
-
-    <p>Although new versions of this specification may be produced in
-    the future, it is also expected that other standards will need to
-    define new capabilities that build upon those in this
-    specification.  The purpose of this section is to provide guidance
-    to creators of such extensions.</p>
-
+    <p>Although new versions of this specification may be produced in the
+    future, it is also expected that other standards will need to define new
+    capabilities that build upon those in this specification. The purpose of
+    this section is to provide guidance to creators of such extensions.</p>
     <p>Any WebIDL-defined interfaces, methods, or attributes in the
-    specification may be extended.  Two likely extension points are
-    defining a new media type and defining a new constrainable
-    property.</p>
-
+    specification may be extended. Two likely extension points are defining a
+    new media type and defining a new constrainable property.</p>
     <section>
-      <h2> Defining a new media type (beyond the existing Audio and
-      Video types)</h2>
-
+      <h2>Defining a new media type (beyond the existing Audio and Video
+      types)</h2>
       <p>At a minimum, defining a new media type would require</p>
       <ul>
         <li>adding a new getXXXXTracks() method for the type to the
         <code><a>MediaStream</a></code> interface,</li>
-        <li>describing what a muted or disabled track of that type
-        will render (see <a href="#life-cycle-and-media-flow"></a>),</li>
+        <li>describing what a muted or disabled track of that type will render
+        (see <a href="#life-cycle-and-media-flow"></a>),
+        </li>
         <li>adding the new type as an additional legal value for the
-        <code><a href="#dom-mediastreamtrack-kind">kind</a></code> attribute
-        on the <code><a>MediaStreamTrack</a></code> interface,</li>
-        <li>updating the description of the
-        <code><a href="#dom-mediastreamtrack-readonly">readonly</a></code>
-        attribute on the <code><a>MediaStreamTrack</a></code> interface,</li>
+        <code><a href="#dom-mediastreamtrack-kind">kind</a></code> attribute on
+        the <code><a>MediaStreamTrack</a></code> interface,</li>
+        <li>updating the description of the <code><a href=
+        "#dom-mediastreamtrack-readonly">readonly</a></code> attribute on the
+        <code><a>MediaStreamTrack</a></code> interface,</li>
         <li>adding at least one track source type
         (<code><a>SourceTypeEnum</a></code>),</li>
-        <li>defining any constrainable properties (see
-        <a href="#constrainable-properties"></a>) that are applicable
-        to the media type,</li>
-        <li>updating how the <code>HTMLMediaElement</code> works with a
-        <code><a>MediaStream</a></code> containing a track of the new media
-        type (see <a href="#mediastreams-in-media-elements"></a>),</li>
+        <li>defining any constrainable properties (see <a href=
+        "#constrainable-properties"></a>) that are applicable to the media
+        type,
+        </li>
+        <li>updating how the <code>HTMLMediaElement</code> works with a <code>
+          <a>MediaStream</a></code> containing a track of the new media type
+          (see <a href="#mediastreams-in-media-elements"></a>),
+        </li>
         <li>updating <code><a>MediaDeviceKind</a></code>,</li>
-        <li>updating the <code>getCapabilities()</code> and <code>getUserMedia()</code>
-        descriptions,</li>
-        <li>adding the new type to the <code><a>MediaStreamConstraints</a></code>
-        dictionary, and</li>
+        <li>updating the <code>getCapabilities()</code> and
+        <code>getUserMedia()</code> descriptions,</li>
+        <li>adding the new type to the
+        <code><a>MediaStreamConstraints</a></code> dictionary, and</li>
         <li>describing any new security and/or privacy considerations (see
-        <a href="#privacy-and-security-considerations"></a>)
-        introduced by the new type.</li>
+        <a href="#privacy-and-security-considerations"></a>) introduced by the
+        new type.
+        </li>
       </ul>
-
       <p>Additionally, it should include updating</p>
       <ul>
-        <li>the <a>source</a> definition,</li>
-        <li>the list of media stream <a>consumer</a>s,</li>
-        <li>the description of the
-         <code><a href="#dom-mediastreamtrack-label">label</a></code> attribute
-        on the <code><a>MediaStreamTrack</a></code> interface,</li>
-        <li>the list of sinks
-        (see <a href="#the-model-sources-sinks-constraints-and-settings"></a>), and</li>
-        <li>the best practice statements referring to video and
-        audio (see <a href="#implementation-suggestions"></a>).</li>
+        <li>the <a>source</a> definition,
+        </li>
+        <li>the list of media stream <a>consumer</a>s,
+        </li>
+        <li>the description of the <code><a href=
+        "#dom-mediastreamtrack-label">label</a></code> attribute on the
+        <code><a>MediaStreamTrack</a></code> interface,</li>
+        <li>the list of sinks (see <a href=
+        "#the-model-sources-sinks-constraints-and-settings"></a>), and
+        </li>
+        <li>the best practice statements referring to video and audio (see
+        <a href="#implementation-suggestions"></a>).
+        </li>
       </ul>
-
       <p>It might also include</p>
       <ul>
-        <li>explaining how the media is expected to be used by
-        potential <a>consumer</a>s, and</li>
+        <li>explaining how the media is expected to be used by potential
+        <a>consumer</a>s, and
+        </li>
         <li>giving examples in <code><a>MediaStreamTrackState</a></code> of how
         such a track might become ended.</li>
       </ul>
     </section>
-
     <section>
       <h2>Defining a new constrainable property</h2>
-
-      <p>This will require thinking through and defining how
-      Constraints, Capabilities, and Settings for the property
-      (see <a href="#terminology"></a>) will
-      work.  The relevant text in <code><a>MediaTrackSupportedConstraints</a></code>,
+      <p>This will require thinking through and defining how Constraints,
+      Capabilities, and Settings for the property (see <a href=
+      "#terminology"></a>) will work. The relevant text in
+      <code><a>MediaTrackSupportedConstraints</a></code>,
       <code><a>MediaTrackCapabilities</a></code>,
       <code><a>MediaTrackConstraints</a></code>,
-      <code><a>MediaTrackSettings</a></code>,
-      <a href="#constrainable-properties"></a>, and
-      <code><a>MediaStreamConstraints</a></code> are the model
-      to use.</p>
-
-      <p>Creators of extension specifications are strongly encouraged
-      to notify the Media Capture Task Force of their extension by
-      emailing the list at public-media-capture@w3.org.<br/>
-      Future versions of this specification and others created by the
-      Media Capture Task Force will take into consideration all
-      extensions they are aware of in an attempt to reduce potential
-      usage conflicts.</p>
+      <code><a>MediaTrackSettings</a></code>, <a href=
+      "#constrainable-properties"></a>, and
+      <code><a>MediaStreamConstraints</a></code> are the model to use.</p>
+      <p>Creators of extension specifications are strongly encouraged to notify
+      the Media Capture Task Force of their extension by emailing the list at
+      public-media-capture@w3.org.<br>
+      Future versions of this specification and others created by the Media
+      Capture Task Force will take into consideration all extensions they are
+      aware of in an attempt to reduce potential usage conflicts.</p>
     </section>
   </section>
-
   <section>
     <h2>Change Log</h2>
-
     <p>This section will be removed before publication.</p>
-
     <h2>Changes since September 25, 2015</h2>
-
     <ol>
       <li>[#259] Specify that groupId is to be cleared when cookies are</li>
-
       <li>[#261, #255] Warn against UUID fingerprinting</li>
-
-      <li>[#260] Update privacy section with lessons from TAG questionnaire</li>
-
+      <li>[#260] Update privacy section with lessons from TAG
+      questionnaire</li>
       <li>[#262] Mark sources of fingerprinting</li>
-
       <li>[#258] Reorganize definition of constrainable properties without a
       registry</li>
-
       <li>[#266] Add detailed steps for removeTrack() and fix a security
       considerations issue</li>
-
       <li>[#272] Fix applyConstraints steps to avoid unused var and bail on
       reject</li>
-
       <li>[#273] Add exception for stored permissions in text about stopped
       sources and revoked permissions</li>
-
       <li>[#278, #250] PING: Refer to security-arch on the MUST inside Best
       Practice for HTTPS</li>
-
       <li>[#280] Let removeTrack() reference the 'remove a track' steps</li>
-
       <li>[#282] Clarify equality for string constraints</li>
-
       <li>[#279, #193] Used frame rate for generic concept</li>
     </ol>
-
     <h2>Changes since August 26, 2015</h2>
-
     <ol>
-        <li>[#226] Typedef MediaStreamError to be an object.</li>
-
-        <li>[#253] Clarify in section 5 that tracks don't request changes,
-            but they can want different settings based on application
-            use of applyConstraints.</li>
-
-        <li>[#239] Reject gUM promise with a TypeError if no media
-            types are given.</li>
-
-        <li>[#240] Specify that groupid is origin-unique.</li>
-
-        <li>[#241] Reference WebIDL-1.</li>
-
-        <li>[#245] Make applyConstraints argument optional.</li>
-
-        <li>[#247] Clean up language in SelectSettings.</li>
+      <li>[#226] Typedef MediaStreamError to be an object.</li>
+      <li>[#253] Clarify in section 5 that tracks don't request changes, but
+      they can want different settings based on application use of
+      applyConstraints.</li>
+      <li>[#239] Reject gUM promise with a TypeError if no media types are
+      given.</li>
+      <li>[#240] Specify that groupid is origin-unique.</li>
+      <li>[#241] Reference WebIDL-1.</li>
+      <li>[#245] Make applyConstraints argument optional.</li>
+      <li>[#247] Clean up language in SelectSettings.</li>
     </ol>
-
     <h2>Changes since June 29, 2015</h2>
-
     <ol>
-        <li>[#204] Use WebIDL [SameObject] extended attribute</li>
-
-        <li>[#209] Once you implement a MediaTrackSupportedConstraints member,
-        you support it</li>
-
-        <li>[#215] MediaStreamErrorEvent -> OverconstrainedErrorEvent</li>
-
-        <li>[#214] Create new ErrorEvent</li>
-
-        <li>[#208] Add WebIDL definitions to Constrainable Pattern section to
-        pass WebIDL validator</li>
-
-        <li>[#201, #207] Specify order of add/removetrack and active/inactive
-        events</li>
-
-        <li>[#194, #162] New Overconstrainederror</li>
-
-        <li>[#213] Fix Not Found Error in gUM algorithm</li>
-
-        <li>[#181] Remove text about firing event handlers (from event handler
-        attribute descriptions)</li>
+      <li>[#204] Use WebIDL [SameObject] extended attribute</li>
+      <li>[#209] Once you implement a MediaTrackSupportedConstraints member,
+      you support it</li>
+      <li>[#215] MediaStreamErrorEvent -&gt; OverconstrainedErrorEvent</li>
+      <li>[#214] Create new ErrorEvent</li>
+      <li>[#208] Add WebIDL definitions to Constrainable Pattern section to
+      pass WebIDL validator</li>
+      <li>[#201, #207] Specify order of add/removetrack and active/inactive
+      events</li>
+      <li>[#194, #162] New Overconstrainederror</li>
+      <li>[#213] Fix Not Found Error in gUM algorithm</li>
+      <li>[#181] Remove text about firing event handlers (from event handler
+      attribute descriptions)</li>
     </ol>
-
     <h2>Changes since May 23, 2015</h2>
-
     <ol>
-        <li>[LC-3016, #171] Referring to html5.1 for describing srcObject in
-        media elements</li>
-
-        <li>[LC-3011, #196, #200] Replace 'invoke MediaDevices.getUserMedia()'
-        with a reference to the algorithm</li>
-
-        <li>[LC-3017, #188] Changed SourceAvailableError to a NotReadableError
-        DOMException</li>
-
-        <li>[LC-3017, #187] Changed PermissionDeniedError to a SecurityError
-        DOMException</li>
-
-        <li>[LC-3017, #185] Changed NotSupportedError from a MediaStreamError
-        to a DOMException</li>
-
-        <li>[LC-3017, #184] Changed AbortError from a MediaStreamError to a
-        DOMException</li>
-
-        <li>[#180, #195] Replaced asynchronously with in parallel</li>
-
-        <li>[LC-3017, #186] Change NotFoundError from a MediaStreamError to a
-        DOMException</li>
-
-        <li>[#174, #182] Tidy up getUserMedia() algorithm</li>
-
-        <li>[LC-3022, #177] Add latency constraint</li>
-
-        <li>[#178, #179] Add serializer to MediaDeviceInfo.</li>
-
-        <li>[LC-3025, #175] Add note about addtrack and removetrack not being
-        used by this spec</li>
-
-        <li>[LC-3018, #163, #172] Use [Exposed]</li>
+      <li>[LC-3016, #171] Referring to html5.1 for describing srcObject in
+      media elements</li>
+      <li>[LC-3011, #196, #200] Replace 'invoke MediaDevices.getUserMedia()'
+      with a reference to the algorithm</li>
+      <li>[LC-3017, #188] Changed SourceAvailableError to a NotReadableError
+      DOMException</li>
+      <li>[LC-3017, #187] Changed PermissionDeniedError to a SecurityError
+      DOMException</li>
+      <li>[LC-3017, #185] Changed NotSupportedError from a MediaStreamError to
+      a DOMException</li>
+      <li>[LC-3017, #184] Changed AbortError from a MediaStreamError to a
+      DOMException</li>
+      <li>[#180, #195] Replaced asynchronously with in parallel</li>
+      <li>[LC-3017, #186] Change NotFoundError from a MediaStreamError to a
+      DOMException</li>
+      <li>[#174, #182] Tidy up getUserMedia() algorithm</li>
+      <li>[LC-3022, #177] Add latency constraint</li>
+      <li>[#178, #179] Add serializer to MediaDeviceInfo.</li>
+      <li>[LC-3025, #175] Add note about addtrack and removetrack not being
+      used by this spec</li>
+      <li>[LC-3018, #163, #172] Use [Exposed]</li>
     </ol>
-
     <h2>Changes since April 10, 2015</h2>
-
     <ol>
-        <li>[PR #156] Fix broken fragment</li>
-
-        <li>[Issue #164] Removed detach source from descriptions</li>
-
-        <li>[PR #166] Added steps describing the procedure to update a
-        track's muted state.</li>
-
-        <li>[PR #167] Refer to internal algorithms for track adding and
-        cloning instead of API layer methods</li>
-
-        <li>[PR #168] Remove setting the active state in MediaStream
-        constructor</li>
-
-        <li>[PR #169] Use required dictionary track dictionary member
-        on MediaStreamTrackEventInit</li>
-
-        <li>[Issue #180] Switch terminology from "asynchronously" to
-        "in parallel" to follow the HTML standard</li>
+      <li>[PR #156] Fix broken fragment</li>
+      <li>[Issue #164] Removed detach source from descriptions</li>
+      <li>[PR #166] Added steps describing the procedure to update a track's
+      muted state.</li>
+      <li>[PR #167] Refer to internal algorithms for track adding and cloning
+      instead of API layer methods</li>
+      <li>[PR #168] Remove setting the active state in MediaStream
+      constructor</li>
+      <li>[PR #169] Use required dictionary track dictionary member on
+      MediaStreamTrackEventInit</li>
+      <li>[Issue #180] Switch terminology from "asynchronously" to "in
+      parallel" to follow the HTML standard</li>
     </ol>
-
     <h2>Changes since March 24, 2015</h2>
-
     <ol>
-        <li>[PR #151] Remove outdated issues in the doc</li>
-
-        <li>[PR #152] using "browsing session" instead of "session"</li>
-
-        <li>[PR #153] short descriptions of arguments to callbacks in
-        callback-based gUM</li>
+      <li>[PR #151] Remove outdated issues in the doc</li>
+      <li>[PR #152] using "browsing session" instead of "session"</li>
+      <li>[PR #153] short descriptions of arguments to callbacks in
+      callback-based gUM</li>
     </ol>
-
     <h2>Changes since February 2, 2015</h2>
-
     <ol>
       <li>Added getUserMedia() implementation suggestion as discussed in issue
       #67</li>
-
       <li>Issue 139: Clarified in SelectSettings algorithm that an empty
       constraint is to be treated as no constraint.</li>
-
       <li>Issue 128: Clarified in SelectSettings that bare values mean exact in
       the advanced array and ideal otherwise.</li>
-
       <li>[PR#37/Bug 26654] Webidl in Constrainable</li>
-
       <li>[Issue #141] MediaDeviceInfo.label and .groupId should not be
       nullable</li>
-
       <li>[PR #150] Update text for how constraint dictionaries get
       extended</li>
     </ol>
-
     <h2>Changes since October 27, 2014</h2>
-
     <ol>
       <li>Bug 26953: Added more detail to the definition of volume.</li>
-
       <li>Clarified in section 4.1 that synchronization is only an intention
       because some tracks cannot be synchronized.</li>
-
       <li>Introduced and made consistent use of the term 'constrainable
       property' everywhere we refer to a property which can have Capabilities,
       Constraints, and Settings.</li>
-
       <li>Changed constraint definition text using concepts and some direct
       text from PR 61.</li>
-
       <li>Bug 113 (old 25771): Explanation of constraints in GUM call. Rewrote
       algorithm with separate SelectSettings step, used both in GUM and in
       applyConstraints.</li>
     </ol>
-
     <h2>Changes since September 24, 2014</h2>
-
     <ol>
       <li>Bug 25809: Added note warning about abuse of call-me URLs.</li>
-
       <li>Bug 26918: Added note on clearing deviceId when clearing
       cookies.</li>
-
       <li>Bug 25777: Added example of capabilities when only two video sizes
       are available.</li>
-
       <li>Bug 26654: Added ConstrainBoolean.</li>
-
       <li>Bug 26810: All callback-based methods have been converted to use
       Promises, except for the version of getUserMedia() defined under
       NavigatorUserMedia.</li>
     </ol>
-
     <h2>Changes since September 9, 2014</h2>
-
     <ol>
       <li>Bug 22214: How long do permissions persist?</li>
-
       <li>Define algorithm for processing non-required constraints.</li>
-
       <li>Bug 24933: deviceId is not registered as constraints, so apps can't
       choose device based on the device enumeration</li>
-
       <li>Bug 25609: MediaStreamErrorEvent is incomplete</li>
     </ol>
-
     <h2>Changes since August 17, 2014</h2>
-
     <ol>
       <li>Bug 25988: Need a list of MediaStreamError "name" values</li>
-
       <li>Bug 26623: Use commonest spelling of "cancellation"</li>
-
       <li>Bug 25767: Missing Ref to Image Capture spec</li>
-
       <li>Bug 22271: Terminology section should not have conformance
       requirements</li>
     </ol>
-
     <h2>Changes since July 4, 2014</h2>
-
     <ol>
       <li>Bug 22251: Added new NotFoundError, AbortError, SourceUnavailable
       errors to gUM call.</li>
-
       <li>Bug 25786: User Agent allowance of files to be substituted for any
       input device is now permitted but not listed as best practice, i.e., no
       longer specifically recommended.</li>
     </ol>
-
     <h2>Changes since June 19, 2014</h2>
-
     <ol>
       <li>Bug 22354: Added privacy and security section.</li>
-
       <li>Bug 25784: "on air" indication is underspecified - separated "access
       granted" and "on air" indicators.</li>
-
       <li>Bug 26192: add onoverconstrained to MediaStreamTrack</li>
-
       <li>Bug 25776: add groupID to MediaTrackConstraintSet</li>
-
       <li>Bug 25780: Clarify step 3 of MediaStream.clone</li>
-
       <li>Bug 25804: Change 'remote' attribute definition</li>
-
       <li>Bug 25650: In getUserMedia algorithm if user denies permission spec
       is wrongly redirecting to Constraint Failure.</li>
-
       <li>Bug 25605: Definition of MediaStreamTrackEvent is not complete</li>
-
       <li>Bug 25651: All the links in spec should redirect to specified
       contents without failure.</li>
-
       <li>Bug 25725: getUserMedia constraints should be non-nullable</li>
-
       <li>Bug 25763: does the ID really have to be exactly 36 char long?</li>
-
       <li>Bug 24934: invalid definition for the "seekable" attribute when
       MediaStream is set to srcObject.</li>
-
       <li>Removed MediaStreamTrack new state (sourceType none removed as a
       consequence) (as discussed in bug 25787).</li>
-
       <li>Bug 25801: Remove getNativeSettings()</li>
     </ol>
-
     <h2>Changes since May 7, 2014</h2>
-
     <ol>
       <li>Clarified that skipping of optional/advanced ConstraintSets is only
       permitted if they cannot be satisfied, not merely because the User Agent
       wishes to.</li>
-
       <li>Bug 25855: Clarification about conformance requirements phrased as
       algorithms</li>
-
       <li>Bug 25803: Mark section entitled "The model: sources, sinks,
       constraints, and settings" as non-normative</li>
-
       <li>Bug 24015: Add callback to indicate when available media devices
       change (introduced Navigator.mediaDevices)</li>
-
       <li>Bug 25860: make sure we have a bug to have a getTracks that gives you
       all the tracks</li>
-
       <li>Bug 25884: applied constraint syntax consensus as realized in June 9
       WG email from Peter Thatcher.</li>
-
       <li>Moved getSupportedConstraints() method to MediaDevices object.</li>
-
       <li>Added stricter requirements on the getSupportedConstraints() return
       value.</li>
-
       <li>Added issue note in Constrainable Pattern section that ideal is not
       yet defined.</li>
-
       <li>Added issue note for applyConstraints that how multiple
       unorderedConstraints are to be satisfied together is not yet
       defined.</li>
-
       <li>Added informative notes that WebIDL discards unknown required
       properties and that application authors need to use the
       <code>getSupportedConstraints()</code> method.</li>
-
       <li>Cleaned up the MediaStream API intro section (mainly MediaStream
       behavior that have moved to MediaStreamTrack).</li>
-
       <li>The concept of MediaStreamTrack with a detachable source is now used
       throughout the spec (removed language saying that a MST could be
       disassociated from its track).</li>
-
       <li>Moved peerIdentity related text to WebRTC.</li>
     </ol>
-
     <h2>Changes since March 21, 2014</h2>
-
     <ol>
       <li>New webIDL for Constrainable and Constraints.</li>
-
       <li>Bug 24931: changed MediaError to MediaStreamError.</li>
-
-      <li>Bug 23817: Redundant TOC headers 8.1 &amp; 9.1</li>
-
+      <li>Bug 23817: Redundant TOC headers 8.1 & 9.1</li>
       <li>Bug 25230: readyState attribute must be inherited while cloning a
       MediaStreamTrack</li>
-
       <li>Bug 25249: Source should be detached when a MediaStreamTrack stops
       for any reason other than stop</li>
-
       <li>Updated Event Summary section to match the spec regarding
       MediaStreamTrack.stop() (as discussed in bug 25248)</li>
-
       <li>Made the MediaStream() constructor behave like addTrack() WRT adding
       ended tracks (as discussed in bug 25250).</li>
-
       <li>Bug 25262: MediaStream Constructor algorithm must also check for
       MediaStreamTracks "ended" state while initializing "active" state.</li>
-
       <li>Bug 25276: Initialization for VideoTrack.selected attribute is
       missing while specifying steps for "Loading and Playing a MediaStream in
       a Media Element"</li>
-
       <li>Changed syntax of constraints to use 'require' and 'advanced' and
       support non-required, non-advanced constraints.</li>
-
       <li>Bug 25360: MediaStreamTrack should not be considered as ended just
       because remote peer stopped sending data.</li>
-
       <li>Bug 25275: VideoTrackList.selectedIndex initialization conflicts with
       HTML5 spec, "if no track is selected".</li>
-
       <li>Removed mentioning of MediaStream received from other peer (as
       discussed in bug 25361).</li>
-
       <li>Bug 22263: Clarify synchronization of tracks in a MediaStream</li>
-
       <li>Bug 25441: Overconstrained muted state should not link with
       MediaStreamTrack.readyState</li>
     </ol>
-
     <h2>Changes since February 18, 2014</h2>
-
     <ol>
       <li>Bug 24928: Remove MediaStream state check from addTrack()
       algorithm.</li>
-
       <li>Bug 24930: Remove MediaStream state check from the removeTrack()
       algorithm.</li>
-
       <li>Added native settings to tracks.</li>
-
       <li>Removed videoMediaStreamTrack and audioMediaStreamTrack since they
       are no longer necessary.</li>
     </ol>
-
     <h2>Changes since December 25, 2013</h2>
-
     <ol>
       <li>Make optional constraints a list of ConstraintSets. Make
       ConstraintSet an object.</li>
-
       <li>Remove noaccess, move peerIdentity</li>
-
       <li>Add constraints for sampleRate, sampleSize, and
       echoCancellation.</li>
-
       <li>Aligned text in remainder of document with Constrainable
       changes.</li>
-
       <li>Removed statements that constraints are not applied to read-only
       sources</li>
     </ol>
-
     <h2>Changes since November 5, 2013</h2>
-
     <ol>
       <li>ACTION-25: Switch mediastream.inactive to mediastream.active.</li>
-
       <li>ACTION-26: Rewrite stop to only detach the track's source.</li>
-
       <li>Bug 22338: Arbitrary changing of tracks.</li>
-
       <li>Bug 23125: Use double rather than float.</li>
-
       <li>Bug 22712: VideoFacingMode enum needs an illustration.</li>
-
       <li>Moved constraints into a separate Constrainable interface.</li>
-
       <li>Created a separate section on error handling.</li>
     </ol>
-
     <h2>Changes since October 17, 2013</h2>
-
     <ol>
       <li>Bug 23263: Add output device enumeration to GetSources</li>
-
       <li>Introduced the Constrainable interface.</li>
-
       <li>Change consensus note on constraints in IANA section.</li>
-
       <li>Removed createObjectURL.</li>
-
       <li>Bug 22209: Should not use MUST requirements on values provided by the
       developer.</li>
     </ol>
-
     <h2>Changes since August 24, 2013</h2>
-
     <ol>
       <li>Bug 22269: Renamed getSourceInfos() to getSources() and made the
       result async.</li>
-
       <li>Bug 22229: Editorial input</li>
-
       <li>Bug 22243: Clarify readonly track</li>
-
       <li>Bug 22259: Disabled mediastreamtrack and state of media element</li>
-
       <li>Bug 22226: Remove check of same source from MediaStream constructor
       algorithm</li>
-
       <li>Replaced ended with inactive for MediaStream (resolves bug
       21618).</li>
-
       <li>Bug 22264: MediaStream.ended set to true on creation</li>
-
       <li>Bug 22272: Permission revocation via MediaStreamTrack.stop()</li>
-
       <li>Bug 22248: Relationship between MediaStreamTrack and HTML5
       VideoTrack/AudioTrack after MediaStream assignment</li>
-
       <li>Bug 22247: Setting loop attribute on a media element reading from a
       MediaStream</li>
     </ol>
-
     <h2>Changes since July 4, 2013</h2>
-
     <ol>
       <li>Bug 21967: Added paragraph on MediaStreamTrack enabled state and
       updated cloning algorithm.</li>
-
       <li>Bug 22210: Make getUserMedia() algorithm use all numbered items.</li>
-
       <li>Bug 22250: Fixed accidentally overridden error.</li>
-
       <li>Bug 22211: Added async error when no valid media type is
       requested.</li>
-
       <li>Bug 22216: Made NavigatorUserMediaError extend DOMError.</li>
-
       <li>Bug 22249: Throw on attempts to set currentTime on media elements
       playing MediaStream objects.</li>
-
       <li>Bug 22246: Made media.buffered have length 0.</li>
-
       <li>Bug 22692: Updated media element to use HAVE_NOTHING state before
       media arrives on the played MediaStream and HAVE_ENOUGH_DATA as soon as
       media arrives.</li>
     </ol>
-
     <h2>May 29, 2013</h2>
-
     <ol>
       <li>Bug 22252: fixed usage of MUST in MediaStream() constructor
       description.</li>
-
       <li>Bug 22215: made MediaStream.ended readonly.</li>
-
       <li>Bug 21967: clarified MediaStreamTrack.enabled state initial
       value.</li>
-
       <li>Added aspectRatio constraint, capability, and state.</li>
-
       <li>Updated usage of MediaStreams in media elements.</li>
     </ol>
-
     <h2>May 15, 2013</h2>
-
     <ol>
       <li>Added explanatory section for constraints, capabilities, and
       states.</li>
-
       <li>Added VideoFacingModeEnum (including left and right options).</li>
-
       <li>Added getSourceInfos() and SourceInfo dictionary.</li>
-
       <li>Added isolated streams.</li>
     </ol>
-
     <h2>April 29, 2013</h2>
-
     <ol>
       <li>Removed remaining photo APIs and references (since we have a separate
       Image Capture Spec).</li>
     </ol>
-
     <h2>March 20, 2013</h2>
-
     <ol>
       <li>Added readonly and remote attributes to MediaStreamTrack</li>
-
       <li>Removed getConstraint(), setConstraint(), appendConstraint(), and
       prependConstraint().</li>
-
       <li>Added source states. Added states() method on tracks. Moved
       sourceType and sourceId to be states.</li>
-
       <li>Added source capabilities. Added capabilities() method on
       tracks.</li>
-
       <li>Added clarifying text about MediaStreamTrack lifecycle and
       mediaflow.</li>
-
       <li>Made MediaStreamTrack cloning explicit.</li>
-
       <li>Removed takePhoto() and friends from VideoStreamTrack (we have a
       separate Image Capture Spec).</li>
-
       <li>Made getUserMedia() error callback mandatory.</li>
     </ol>
-
     <h2>December 12, 2012</h2>
-
     <ol>
       <li>Changed error code to be string instead of number.</li>
-
       <li>Added core of settings proposal allowing for constraint changes after
       stream/track creation.</li>
     </ol>
-
     <h2>November 15 2012</h2>
-
     <ol>
       <li>Introduced new representation of tracks in a stream (removed
       MediaStreamTrackList).</li>
-
       <li>Updated MediaStreamTrack.readyState to use an enum type (instad of
       unsigned short constants).</li>
-
       <li>Renamed MediaStream.label to MediaStream.id (the definition needs
       some more work).</li>
     </ol>
-
     <h2>October 1 2012</h2>
-
     <ol>
       <li>Limited the track kind values to "audio" and "video" only (could
       previously be user defined as well).</li>
-
       <li>Made MediaStream extend EventTarget.</li>
-
       <li>Simplified the MediaStream constructor.</li>
     </ol>
-
     <h2>June 23 2012</h2>
-
     <ol>
       <li>Rename title to "Media Capture and Streams".</li>
-
       <li>Update document to comply with HTML5.</li>
-
       <li>Update image describing a MediaStream.</li>
-
       <li>Add known issues and various other editorial changes.</li>
     </ol>
-
     <h2>June 22 2012</h2>
-
     <ol>
       <li>Update wording for constraints algorithm.</li>
     </ol>
-
     <h2>June 19 2012</h2>
-
     <ol>
       <li>Added "Media Streams as Media Elements section".</li>
     </ol>
-
     <h2>June 12 2012</h2>
-
     <ol>
       <li>Switch to respec v3.</li>
     </ol>
-
     <h2>June 5 2012</h2>
-
     <ol>
       <li>Added non-normative section "Implementation Suggestions".</li>
-
       <li>Removed stray whitespace.</li>
     </ol>
-
     <h2>June 1 2012</h2>
-
     <ol>
       <li>Added media constraint algorithm.</li>
     </ol>
-
     <h2>Apr 23 2012</h2>
-
     <ol>
       <li>Remove MediaStreamRecorder.</li>
     </ol>
-
     <h2>Apr 20 2012</h2>
-
     <ol>
       <li>Add definitions of MediaStreams and related objects.</li>
     </ol>
-
     <h2>Dec 21 2011</h2>
-
     <ol>
       <li>Changed to make wanted media opt in (rather than opt out). Minor
       edits.</li>
     </ol>
-
     <h2>Nov 29 2011</h2>
-
     <ol>
       <li>Changed examples to use MediaStreamOptions objects rather than
       strings. Minor edits.</li>
     </ol>
-
     <h2>Nov 15 2011</h2>
-
     <ol>
       <li>Removed MediaStream stuff. Refers to webrtc 1.0 spec for that part
       instead.</li>
     </ol>
-
     <h2>Nov 9 2011</h2>
-
     <ol>
       <li>Created first version by copying the webrtc spec and ripping out
       stuff. Put it on github.</li>
     </ol>
   </section>
-
   <section class="appendix">
     <h2>Acknowledgements</h2>
-
     <p>The editors wish to thank the Working Group chairs and Team Contact,
     Harald Alvestrand, Stefan Håkansson, and Dominique Hazaël-Massieux, for
     their support. Substantial text in this specification was provided by many
     people including 
     <!-- tag 1 to reduce merge conflicts when adding names to list  -->
      Jim Barnett, <!-- tag 2 --> Harald Alvestrand, <!-- tag 3 --> Travis
-    Leithead, <!-- tag 4 --> Josh Soref, <!-- tag 5 --> Martin Thomson, <!-- tag 6 --> Jan-Ivar Bruaroey, <!-- tag 7 --> Peter Thatcher, 
-     <!-- tag 8 --> Dominique Hazaël-Massieux, <!-- tag 9 --> and
-     Stefan Håkansson.  Dan Burnett would like to acknowledge the
-     significant support received from Voxeo and Aspect during the
-     development of this specification.</p>
+    Leithead, <!-- tag 4 --> Josh Soref, <!-- tag 5 --> Martin Thomson, 
+    <!-- tag 6 --> Jan-Ivar Bruaroey, <!-- tag 7 --> Peter Thatcher, 
+    <!-- tag 8 --> Dominique Hazaël-Massieux, <!-- tag 9 --> and Stefan
+    Håkansson. Dan Burnett would like to acknowledge the significant support
+    received from Voxeo and Aspect during the development of this
+    specification.</p>
   </section>
 </body>
 </html>


### PR DESCRIPTION
When this is merged, Travis CI will complain on pull requests that aren't line-wrapped at 80 characters.

To do proper line-wrapping, this idea is to:
* commit your changes without line-wrap
* rewrap the content using webrtc-respec-ci/Makefile with `make linewrap LINEWRAPLENGTH=80`
* do a commit for the linewrap