### PR TITLE
Add text about User Agent stream updates (fixes #276)

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -447,6 +447,72 @@
         </li>
       </ol>
 
+      <p>The User Agent may update a <code><a>MediaStream</a></code>'s <a href=
+      "#track-set">track set</a> in response to, for example, an external event.
+      This specification does not specify any such cases, but other specifications
+      using the MediaStream API may. One such example is the WebRTC 1.0
+      [[WEBRTC10]] specification where the <a href="#track-set">track set</a>
+      of a <code><a>MediaStream</a></code>, received from another peer, can be
+      updated as a result of changes to the media session.</p>
+
+      <p>When the User Agent initiates adding a track to a <code>
+      <a>MediaStream</a></code>, the User Agent MUST queue a task that runs the
+      following steps:</p>
+
+      <ol>
+        <li>
+          <p>Let <var>track</var> be the
+          <code><a>MediaStreamTrack</a></code> in question and
+          <var>stream</var> the <code><a>MediaStream</a></code>
+          object to which <var>track</var> is to be added.</p>
+        </li>
+
+        <li>
+          <p><a href="#stream-add-track">Add</a> <var>track</var> to
+          <var>stream</var>.</p>
+        </li>
+
+        <li>
+          <p>If the operation in the previous step was aborted prematurely,
+          then abort these steps.</p>
+        </li>
+
+        <li>
+          <p>Fire a track event named <code><a href=
+          "#event-mediastream-addtrack">addtrack</a></code> with
+          <var>track</var> at <var>stream</var>.</p>
+        </li>
+      </ol>
+
+      <p>When the User Agent initiates removing a track from a <code>
+      <a>MediaStream</a></code>, the User Agent MUST queue a task that runs the
+      following steps:</p>
+
+      <ol>
+        <li>
+          <p>Let <var>track</var> be the
+          <code><a>MediaStreamTrack</a></code> in question and
+          <var>stream</var> the <code><a>MediaStream</a></code>
+          object to which <var>track</var> is to be added.</p>
+        </li>
+
+        <li>
+          <p><a href="#stream-remove-track">Remove</a> <var>track</var> from
+          <var>stream</var>.</p>
+        </li>
+
+        <li>
+          <p>If the operation in the previous step was aborted prematurely,
+          then abort these steps.</p>
+        </li>
+
+        <li>
+          <p>Fire a track event named <code><a href=
+          "#event-mediastream-removetrack">removetrack</a></code> with
+          <var>track</var> at <var>stream</var>.</p>
+        </li>
+      </ol>
+
       <dl class="idl" title="[Exposed=Window] interface MediaStream : EventTarget">
         <dt>Constructor()</dt>
 
@@ -1736,12 +1802,7 @@
 
       <p>The <code>addtrack</code> and <code>removetrack</code> events notify
       the script that the <a href="#track-set">track set</a> of a
-      <code><a>MediaStream</a></code> has been updated by the User Agent. This
-      specification does not specify any such cases, but other specifications
-      using the MediaStream API may. One such example is the WebRTC 1.0
-      [[WEBRTC10]] specification where the <a href="#track-set">track set</a>
-      of a  <code><a>MediaStream</a></code>, received from another peer, can be
-      updated as a result of changes to the media session.</p>
+      <code><a>MediaStream</a></code> has been updated by the User Agent.
 
       <p><dfn data-lt="Fire a track event">Firing a track event named
       <var>e</var></dfn> with a <code><a>MediaStreamTrack</a></code>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -456,8 +456,9 @@
       updated as a result of changes to the media session.</p>
 
       <p>When the User Agent initiates adding a track to a <code>
-      <a>MediaStream</a></code>, the User Agent MUST queue a task that runs the
-      following steps:</p>
+      <a>MediaStream</a></code>, with the exception of initializing a newly
+      created <code><a>MediaStream</a></code> with tracks, the User Agent MUST
+      queue a task that runs the following steps:</p>
 
       <ol>
         <li>


### PR DESCRIPTION
The new steps references the general steps for adding/removing tracks.

Also moved text about this specification not defining any UA stream updates from the event section to the new section describing the behaviour.