### PR TITLE
Remove default values from MediaTrackSupportedConstraints (fixes: #293)

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -984,31 +984,31 @@
         dictionary by defining a partial dictionary with dictionary members of
         type boolean.</p>
         <dl class="idl" title="dictionary MediaTrackSupportedConstraints">
-          <dt>boolean width = true</dt>
+          <dt>boolean width</dt>
           <dd></dd>
-          <dt>boolean height = true</dt>
+          <dt>boolean height</dt>
           <dd></dd>
-          <dt>boolean aspectRatio = true</dt>
+          <dt>boolean aspectRatio</dt>
           <dd></dd>
-          <dt>boolean frameRate = true</dt>
+          <dt>boolean frameRate</dt>
           <dd></dd>
-          <dt>boolean facingMode = true</dt>
+          <dt>boolean facingMode</dt>
           <dd></dd>
-          <dt>boolean volume = true</dt>
+          <dt>boolean volume</dt>
           <dd></dd>
-          <dt>boolean sampleRate = true</dt>
+          <dt>boolean sampleRate</dt>
           <dd></dd>
-          <dt>boolean sampleSize = true</dt>
+          <dt>boolean sampleSize</dt>
           <dd></dd>
-          <dt>boolean echoCancellation = true</dt>
+          <dt>boolean echoCancellation</dt>
           <dd></dd>
-          <dt>boolean latency = true</dt>
+          <dt>boolean latency</dt>
           <dd></dd>
-          <dt>boolean channelCount = true</dt>
+          <dt>boolean channelCount</dt>
           <dd></dd>
-          <dt>boolean deviceId = true</dt>
+          <dt>boolean deviceId</dt>
           <dd></dd>
-          <dt>boolean groupId = true</dt>
+          <dt>boolean groupId</dt>
           <dd></dd>
         </dl>
       </section>


### PR DESCRIPTION
The getSupportedConstraints() method already has prose that describes that the values must be set to true so no more changes are needed.