### PR TITLE
Add [CEReactions] annotation to allowUserMedia

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2949,7 +2949,7 @@
       <p>The iframe DOM interface is extended as described by the partial
       interface below.</p>
       <dl class="idl" title="partial interface HTMLIFrameElement">
-        <dt>attribute boolean allowUserMedia</dt>
+        <dt>[CEReactions] attribute boolean allowUserMedia</dt>
         <dd>
           <p>The allowUserMedia IDL attribute MUST [[!HTML51]] <code><a href=
           "https://www.w3.org/TR/2015/WD-html51-20150506/infrastructure.html#reflect">


### PR DESCRIPTION
Since the allowUserMedia attribute can change the DOM in ways that may impact custom elements, it needs to be annotated with the [CEReactions] attribute. This is part of the larger effort at https://github.com/w3c/webcomponents/issues/186. [CEReactions] is defined in https://html.spec.whatwg.org/multipage/scripting.html#cereactions.