### PR TITLE
Use 'originIdentifier' in getUserMedia() steps (issue #339)

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2797,11 +2797,10 @@
                   browsing context</a>'s origin.</p>
                 </li>
                 <li>
-		  <p><a>Request permission</a> for use of the devices,
-                  while considering
-		  all devices attached to a <code>live</code> MediaStreamTrack
-		  to have permission status "granted", resulting in a set of
-		  provided media.</p>
+                  <p><a>Request permission</a> for use of the devices, while
+                  considering all devices attached to a <code>live</code>
+                  MediaStreamTrack to have permission status "granted",
+                  resulting in a set of provided media.</p>
                   <p>The provided media MUST include precisely one track of
                   each media type in requestedMediaTypes from the
                   <var>finalSet</var>. The decision of which devices to choose

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2797,7 +2797,8 @@
                   browsing context</a>'s origin.</p>
                 </li>
                 <li>
-                  <p><a>Request permission</a> for use of the devices, while
+                  <p>For the origin identified by <var>originIdentifier</var>,
+                  <a>request permission</a> for use of the devices, while
                   considering all devices attached to a <code>live</code>
                   MediaStreamTrack to have permission status "granted",
                   resulting in a set of provided media.</p>


### PR DESCRIPTION
Fix for issue #339

First commit is purely editorial so please review the second. 