### PR TITLE
Add pre-grant deviceId alternative.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3074,7 +3074,7 @@ interface MediaDeviceInfo {
               local devices has been granted to this origin, then this
               identifier MUST be persisted. Unique and stable identifiers let
               the application save, identify the availability of, and directly
-              request specific sources from previous visits.</p>
+              request specific sources, across multiple visits.</p>
               <p>However, as long as no local device has been attached to a live
               MediaStreamTrack in a page from this origin, and no
               <a href="#stored-permissions">stored permission</a> to access

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3065,29 +3065,32 @@ interface MediaDeviceInfo {
             <dd>
               <p>A unique identifier for the represented device.</p>
               <p>All enumerable devices have an identifier that MUST be unique
-              to the page's origin. As long as no local device has been
-              attached to a live MediaStreamTrack in a page from this origin,
-              and no <a href="#stored-permissions">stored permission</a> to
-              access local devices has been granted to this origin, then this
-              identifier MUST NOT be reusable after the end of the current
-              browsing session.</p>
-              <p>However, if any local devices have been attached to a live
-              MediaStreamTrack in a page from this origin, or <a href=
-              "#stored-permissions">stored permission</a> to access local
-              devices has been granted to this origin, then this identifier
-              MUST be persisted across browsing sessions.</p>
-              <p>Unique and stable identifiers let the application save,
-              identify the availability of, and directly request specific
-              sources.</p>
-              <p>This identifier MUST be un-guessable by applications of other
-              origins to prevent the identifier being used to correlate the
-              same user across different origins.</p>
+              to the page's origin. This identifier MUST be un-guessable by
+              applications of other origins to prevent the identifier from being
+              used to correlate the same user across different origins.</p>
+              <p>If any local devices have been attached to a live
+              MediaStreamTrack in a page from this origin, or
+              <a href="#stored-permissions">stored permission</a> to access
+              local devices has been granted to this origin, then this
+              identifier MUST be persisted. Unique and stable identifiers let
+              the application save, identify the availability of, and directly
+              request specific sources from previous visits.</p>
+              <p>However, as long as no local device has been attached to a live
+              MediaStreamTrack in a page from this origin, and no
+              <a href="#stored-permissions">stored permission</a> to access
+              local devices has been granted to this origin, then the user agent
+              MAY clear this identifier once the last browsing session from this
+              origin has been closed.  If the user agent chooses not to clear the
+              identifier in this condition, then it MUST provide for the user to
+              visibly inspect and delete the identifier, like a cookie.</p>
               <p class="fingerprint">Since <code>deviceId</code> may persist
               across browsing sessions and to reduce its potential as a
               fingerprinting mechanism, <code>deviceId</code> is to be treated
               as other persistent storage mechanisms such as cookies
-              [[COOKIES]]. User agents MUST reset per-origin device identifiers
-              when other persistent storages are cleared.</p>
+              [[COOKIES]]. User agents MUST NOT persist device identifiers for
+              sites that are blocked from using cookies, and user agents MUST
+              reset per-origin device identifiers when other persistent storages
+              are cleared.</p>
             </dd>
             <dt><dfn><code>kind</code></dfn> of type <span class=
             "idlAttrType"><a>MediaDeviceKind</a></span>, readonly</dt>


### PR DESCRIPTION
Tries to capture the alternative we discussed at the last virtual face-to-face.

With all this info, I reordered the text a bit to cover uniqueness, stability, pre-grant behavior, and cookies in that order. I also:

 * Tried to clarify that ids persist after allowing gum just once.
 * Added visible cookie requirement to the UA alternative.
 * Tried to fix clearing logic to not orphan same-origin tabs (clear when last origin tab closes).
 * Restrict persistence for sites blocked from using cookies.