### PR TITLE
Allow firing devicechange just once when inserting a camera with mic.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2870,14 +2870,17 @@ interface NavigatorUserMedia {
       <p>The <code>MediaDevices</code> object is the entry point to the API
       used to examine and get access to media devices available to the User
       Agent.</p>
-      <p>When a new media input or output device is made available, and if the
+      <p>When new media input and/or output devices are made
+      available, and if the
       <a data-lt="retrieve the permission state">permission state</a> of the
       "list-devices" permission is "granted", the User Agent MUST queue a task
       that fires a simple event named <code><a href=
       "#event-mediadevices-devicechange">devicechange</a></code> at the
-      <code><a>MediaDevices</a></code> object. These events are potentially
+      <code><a>MediaDevices</a></code> object. The User Agent MAY fire just a
+      single event when several devices are added at the same time, e.g. a
+      camera with a microphone. These events are potentially
       triggered simultaneously across browsing contexts on different origins;
-      user agents can add fuzzing on the timing of events to avoid cross-origin
+      user agents MAY add fuzzing on the timing of events to avoid cross-origin
       activity correlation.</p>
       <div>
         <pre class="idl">[Exposed=Window]

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2870,8 +2870,7 @@ interface NavigatorUserMedia {
       <p>The <code>MediaDevices</code> object is the entry point to the API
       used to examine and get access to media devices available to the User
       Agent.</p>
-      <p>When new media input and/or output devices are made
-      available, and if the
+      <p>When new media input and/or output devices are made available, and if the
       <a data-lt="retrieve the permission state">permission state</a> of the
       "list-devices" permission is "granted", the User Agent MUST queue a task
       that fires a simple event named <code><a href=


### PR DESCRIPTION
Fix for https://github.com/w3c/mediacapture-main/issues/375.