### PR TITLE
JS should see devicechange events during active gum call.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2870,9 +2870,11 @@ interface NavigatorUserMedia {
       <p>The <code>MediaDevices</code> object is the entry point to the API
       used to examine and get access to media devices available to the User
       Agent.</p>
-      <p>When a new media input or output device is made available, and if the
+      <p>When a new media input or output device is made available, and if either the
       <a data-lt="retrieve the permission state">permission state</a> of the
-      "list-devices" permission is "granted", the User Agent MUST queue a task
+      "list-devices" permission is "granted" or any of the local devices are
+      attached to an active MediaStream in the current browsing context, then
+      the User Agent MUST queue a task
       that fires a simple event named <code><a href=
       "#event-mediadevices-devicechange">devicechange</a></code> at the
       <code><a>MediaDevices</a></code> object. These events are potentially


### PR DESCRIPTION
Partial remedy for https://github.com/w3c/mediacapture-main/issues/372.