### PR TITLE
Mark the Implementation Suggestions as non-normative.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3766,7 +3766,7 @@ interface MediaDeviceInfo {
         </div>
       </div>
     </section>
-    <section>
+    <section class="informative">
       <h2>Implementation Suggestions</h2>
       <div class="practice">
         <span class="practicelab" id="resource-reservation">Resource


### PR DESCRIPTION
Fixes #390 

@alvestrand Here's the simplest change that fixes the problem. Changing Conformance to say Best Practices are non-normative would work too, but takes more drafting.
