### PR TITLE
Make the devicechange consistent with enumerateDevices wrt permissions.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -5243,7 +5243,7 @@ below dictionary, but instead provide its own definition. See
       <li>[#398] Editorial: Fix links to MediaStream's methods</li>
       <li>[#399] Unroll steps in 'add a track' and 'remove a track'</li>
       <li>[#401] Define states to be used in indicator requirements</li>
-      <li>[#410] Rename list-devices permission to device-info to</li>
+      <li>[#410] Rename list-devices permission to device-info to
       match permission spec</li>
       <li>[#412] Specify rules for when devicechange events may fire</li>
       <li>[#415] Remove unions in MediaTrackCapabilities</li>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2962,13 +2962,7 @@ interface NavigatorUserMedia {
         </li>
       </ol>
 
-      <p>When new media input and/or output devices are made available, if either the 
-      <a data-lt="retrieve the permission state">permission state</a> of the 
-      "device-info" permission is "granted", or any of the local devices are 
-      attached to an active MediaStream in the current browsing context, 
-      or the <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> 
-      in the current browsing context is <a href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active">fully active</a>
-      and <a href="https://html.spec.whatwg.org/#gains-focus">has focus</a>, then
+      <p>When new media input and/or output devices are made available, then
       the User Agent MUST run the following steps:</p>
       <ol>
         <li>


### PR DESCRIPTION
EnumerateDevices reflects changes in the set of devices when permission has not been granted. Making devicechange consistent with this adds no additional privacy issues since device changes can be detected by polling enumerateDevices.

This matches what Microsoft Edge is currently shipping and what Chromium has implemented behind a flag and intends to ship.

This PR addresses issue #414 