### PR TITLE
Ignore ideal values that don't belong on the device

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4291,6 +4291,13 @@ interface ConstrainablePattern {
                   does not satisfy the constraint, the fitness distance is
                   positive infinity.</p>
                 </li>
+                <li>
+                  <p>
+                    If the constraint is not required, and does not apply for
+                    this type of device, the fitness distance is 0 (that is,
+                    the constraint does not influence the fitness distance).
+                  </p>
+                </li>
                 <li>If no ideal value is specified, the fitness distance is
                 0.</li>
                 <li>For all positive numeric non-required constraints (such as


### PR DESCRIPTION
Ideal values (like height for an audio device) should be ignored
when calculating fitness distance. They still matter when exact.

Closes #409