### PR TITLE
Remove outdated contraints text

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -117,13 +117,15 @@
         value of the source's constrainable properties. Settings are always
         read-only.</p>
         <p>A source's settings can change dynamically over time due to
-        environmental conditions, sink configurations, or constraint changes. A
-        source's settings must always conform to the current set of mandatory
-        constraints on all attached tracks. A source that cannot conform to
-        mandatory constraints causes affected tracks to become
-        <a>overconstrained</a> and therefore <a href="#track-muted">muted</a>.
-        A <a>User Agent</a> attempts to ensure that sources adhere to optional
-        constraints as closely as possible, see <a href=
+        environmental conditions, sink configurations, or constraint
+        changes. A source's settings must always conform to the
+        current set of basic (mandatory) constraints on all attached
+        tracks. A source that cannot conform to these constraints
+        causes affected tracks to become
+        <a>overconstrained</a> and
+        therefore <a href="#track-muted">muted</a>.  A <a>User
+        Agent</a> attempts to ensure that sources adhere to advanced
+        (optional) constraints as closely as possible, see <a href=
         "#constrainable-interface"></a>.</p>
         <p>Although settings are a property of the source, they are only
         exposed to the application through the tracks attached to the source.
@@ -4131,8 +4133,8 @@ if(!supports["width"] || !supports["height"]) {
     the 4x3 aspect ratio ConstraintSet at the same time. Since the 1920x1280
     occurs first in the list, the User Agent will attempt to satisfy it first.
     Application authors can therefore implement a backoff strategy by
-    specifying multiple optional ConstraintSets for the same property. For
-    example, an application might specify three optional ConstraintSets, the
+    specifying multiple advanced ConstraintSets for the same property. For
+    example, an application might specify three advanced ConstraintSets, the
     first asking for a frame rate greater than 500, the second asking for a
     frame rate greater than 400, and the third asking for one greater than 300.
     If the User Agent is capable of setting a frame rate greater than 500, it
@@ -4150,8 +4152,8 @@ if(!supports["width"] || !supports["height"]) {
     ConstraintSet in the advanced list must be satisfied together or skipped
     together. Thus, {width: 1920, height: 1280} is a request for that specific
     resolution, not a request for that width or that height. One can think of
-    the basic constraints as requesting an or (non-exclusive) of the individual
-    constraints, while each advanced ConstraintSet is requesting an and of the
+    the basic constraints as requesting an 'or' (non-exclusive) of the individual
+    constraints, while each advanced ConstraintSet is requesting an 'and' of the
     individual constraints in the ConstraintSet. An application may inspect the
     full set of Constraints currently in effect via the
     <code>getConstraints()</code> accessor.</p>
@@ -4944,12 +4946,12 @@ below dictionary, but instead provide its own definition. See
               satisfied. The order of these ConstraintSets is significant. In
               particular, when they are passed as an argument to
               <code>applyConstraints</code>, the User Agent MUST try to satisfy
-              them in the order that is specified. Thus if optional
+              them in the order that is specified. Thus if advanced
               ConstraintSets C1 and C2 can be satisfied individually, but not
               together, then whichever of C1 and C2 is first in this list will
               be satisfied, and the other will not. The User Agent MUST attempt
-              to satisfy all optional ConstraintSets in the list, even if some
-              cannot be satisfied. Thus, in the preceding example, if optional
+              to satisfy all ConstraintSets in the list, even if some
+              cannot be satisfied. Thus, in the preceding example, if
               constraint C3 is specified after C1 and C2, the User Agent will
               attempt to satisfy C3 even though C2 cannot be satisfied. Note
               that a given property name may occur only once in each


### PR DESCRIPTION
The term "optional" for constraints is outdated.  This PR cleans that up.  Addresses issue #396.
