### PR TITLE
Rename 10.1. to Legacy Interface Extensions.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3454,7 +3454,7 @@ interface MediaDeviceInfo {
     they remove all of them at once (e.g., they should not leave just the
     prefixed version available on insecure origins).</p>
     <section>
-      <h3>NavigatorUserMedia Interface Extensions</h3>
+      <h3>Legacy Interface Extensions</h3>
       <div class="note">
         The definition of getUserMedia() in this section reflects two major
         changes from the method definition that has existed here for many


### PR DESCRIPTION
Fix for https://github.com/w3c/mediacapture-main/issues/454.