### PR TITLE
s/stream/track/ in section about ended event source.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -926,7 +926,7 @@ interface MediaStream : EventTarget {
             "#event-mediastreamtrack-ended">ended</a></code> at the object.</p>
           </li>
         </ol>
-        <p>If the end of the stream was reached due to a user request, the
+        <p>If the end of the track was reached due to a user request, the
         event source for this event is the user interaction event source.</p>
         <h4>Media Flow</h4>
         <p>There are two dimensions related to the media flow for a


### PR DESCRIPTION
Old sentence. Tracks, not streams, end now.