### PR TITLE
format & fixup Example code

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4659,7 +4659,7 @@ startBtn.onclick = async () =&gt; {
       track.onended = () =&gt; {
         startBtn.disabled = stream.getTracks().some(t =&gt; t.readyState == 'live');
       }
-    }
+    };
   } catch(err) {
     console.error(err)
   }

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4286,7 +4286,7 @@ const supports = navigator.mediaDevices.getSupportedConstraints();
 if (!supports["width"] || !supports["height"]) {
   // Treat like an error.
 }
-const gotten = navigator.mediaDevices.getUserMedia({
+const stream = await navigator.mediaDevices.getUserMedia({
   video: {
     width: {min: 640, ideal: 1280, max: 1920},
     height: {min: 480, ideal: 720, max: 1080},

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4273,8 +4273,8 @@ const stream = await navigator.mediaDevices.getUserMedia({
     height: { min: 240, ideal: 720, max: 1080 },
     frameRate: 30, // Shorthand for ideal.
     facingMode: {
-      // facingMode: "environment" would be optional.
       exact: "environment"
+      // facingMode: "environment" would be optional.
     }
   }
 });

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4746,12 +4746,12 @@ window.onload = async () =&gt; {
 
   try {
     video.srcObject = await navigator.mediaDevices.getUserMedia({video: true});
-    video.addEventListener('loadedmetadata', () =&gt; {
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      document.getElementById('splash').hidden = true;
-      document.getElementById('app').hidden = false;
-    });
+
+    await new Promise(resolve =&gt; video.onloadedmetadata = resolve);
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    document.getElementById('splash').hidden = true;
+    document.getElementById('app').hidden = false;
 
     shutter.onclick = () =&gt; {
       canvas.getContext('2d').drawImage(video, 0, 0);

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4300,11 +4300,13 @@ const supports = navigator.mediaDevices.getSupportedConstraints();
 if (!supports["width"] || !supports["height"] || !supports["facingMode"]) {
   // Treat like an error.
 }
-const stream = navigator.mediaDevices.getUserMedia({video: {
-  facingMode: {exact: "user"},
-  width: {exact: 640},
-  height: {exact: 480}
-}});
+const stream = await navigator.mediaDevices.getUserMedia({
+  video: {
+    facingMode: {exact: "user"},
+    width: {exact: 640},
+    height: {exact: 480}
+  }
+});
       </pre>
     </section>
     <section>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4646,12 +4646,12 @@ const startBtn = document.getElementById('startBtn');
 startBtn.addEventListener('click', async () =&gt; {
   try {
     startBtn.disabled = true;
-    const constraint = {
+    const constraints = {
       audio: true,
       video: true
     };
 
-    const stream = await navigator.mediaDevices.getUserMedia(constraint);
+    const stream = await navigator.mediaDevices.getUserMedia(constraints);
 
     stream.getTracks().forEach((track) =&gt; {
       track.onended = () =&gt; {

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4267,7 +4267,7 @@ const supports = navigator.mediaDevices.getSupportedConstraints();
 if (!supports["aspectRatio"] || !supports["facingMode"]) {
   // Treat like an error.
 }
-await navigator.mediaDevices.getUserMedia({
+const stream = await navigator.mediaDevices.getUserMedia({
   video: {
     width: { min: 320, ideal: 1280, max: 1920 },
     height: { min: 240, ideal: 720, max: 1080 },

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3804,7 +3804,7 @@ interface MediaDeviceInfo {
     choose.</p>
     <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["aspectRatio"]) {
+if (!supports.aspectRatio) {
   // Treat like an error.
 }
 const constraints = {
@@ -3825,7 +3825,7 @@ const constraints = {
     lighting conditions.</p>
     <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["aspectRatio"] || !supports["frameRate"]) {
+if (!supports.aspectRatio || !supports.frameRate) {
   // Treat like an error.
 }
 const constraints = {
@@ -3849,7 +3849,7 @@ const constraints = {
     possible, give me a resolution as close to 1280x720 as possible."</p>
     <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["width"] || !supports["height"]) {
+if (!supports.width || !supports.height) {
   // Treat like an error.
 }
 const constraints = {
@@ -4217,7 +4217,7 @@ interface ConstrainablePattern {
       <code>MediaStreamTrack</code></a>.</p>
       <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["facingMode"]) {
+if (!supports.facingMode) {
   // Treat like an error.
 }
 const constraints = {
@@ -4237,7 +4237,7 @@ const constraints = {
       height:</p>
       <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["deviceId"]) {
+if (!supports.deviceId) {
   // Treat like an error.
 }
 const constraints = {
@@ -4251,7 +4251,7 @@ const constraints = {
       <p>And here's one for an audio track:</p>
       <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["deviceId"] || !supports["volume"]) {
+if (!supports.deviceId || !supports.volume) {
   // Treat like an error.
 }
 const constraints = {
@@ -4264,7 +4264,7 @@ const constraints = {
       <p>Here's an example of use of ideal:</p>
       <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["aspectRatio"] || !supports["facingMode"]) {
+if (!supports.aspectRatio || !supports.facingMode) {
   // Treat like an error.
 }
 const stream = await navigator.mediaDevices.getUserMedia({
@@ -4283,7 +4283,7 @@ const stream = await navigator.mediaDevices.getUserMedia({
       down to VGA.":</p>
       <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["width"] || !supports["height"]) {
+if (!supports.width || !supports.height) {
   // Treat like an error.
 }
 const stream = await navigator.mediaDevices.getUserMedia({
@@ -4297,7 +4297,7 @@ const stream = await navigator.mediaDevices.getUserMedia({
       VGA.":</p>
       <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
-if (!supports["width"] || !supports["height"] || !supports["facingMode"]) {
+if (!supports.width || !supports.height || !supports.facingMode) {
   // Treat like an error.
 }
 const stream = await navigator.mediaDevices.getUserMedia({

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3810,7 +3810,7 @@ if (!supports["aspectRatio"]) {
 const constraints = {
   width: 1280,
   height: 720,
-  aspectRatio: 1.5
+  aspectRatio: 3/2
 };
     </pre>
     <p>This next example adds a small bit of complexity. The ideal values are
@@ -3832,7 +3832,7 @@ const constraints = {
   frameRate: { min: 20 },
   width:  { min: 640, ideal: 1280 },
   height: { min: 480, ideal: 720 },
-  aspectRatio: 1.5
+  aspectRatio: 3/2
 };
     </pre>
     <p>This example illustrates the full control possible with the Constraints
@@ -3857,7 +3857,7 @@ const constraints = {
   height: { min: 480, ideal:  720 },
   advanced: [
     { width: 1920, height: 1280 },
-    { aspectRatio: 1.3333333333 }
+    { aspectRatio: 4/3 }
   ]
 };
     </pre>
@@ -4534,7 +4534,7 @@ const gotten = navigator.mediaDevices.getUserMedia({video: {
 {
   width:  { min: 640, max: 800 },
   height: { min: 480, max: 600 },
-  aspectRatio: 1.3333333333
+  aspectRatio: 4/3
 }
       </pre>
       <p>Note in the example above that the aspectRatio would make clear that

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4300,7 +4300,7 @@ const supports = navigator.mediaDevices.getSupportedConstraints();
 if (!supports["width"] || !supports["height"] || !supports["facingMode"]) {
   // Treat like an error.
 }
-const gotten = navigator.mediaDevices.getUserMedia({video: {
+const stream = navigator.mediaDevices.getUserMedia({video: {
   facingMode: {exact: "user"},
   width: {exact: 640},
   height: {exact: 480}

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3803,17 +3803,16 @@ interface MediaDeviceInfo {
     two constraints that could be satisfied. If so, the User Agent will
     choose.</p>
     <pre class="example">
-    var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["aspectRatio"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["aspectRatio"]) {
   // Treat like an error.
 }
- var constraints =
-  {
-    width: 1280,
-    height: 720,
-    aspectRatio: 1.5
-  };
-</pre>
+const constraints = {
+  width: 1280,
+  height: 720,
+  aspectRatio: 1.5
+};
+    </pre>
     <p>This next example adds a small bit of complexity. The ideal values are
     still given for width and height, but this time with minimum requirements
     on each as well as a minimum frameRate that must be satisfied. If it cannot
@@ -3825,18 +3824,17 @@ if(!supports["aspectRatio"]) {
     in firing of the <code>onoverconstrained</code> event handler under poor
     lighting conditions.</p>
     <pre class="example">
-    var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["aspectRatio"] || !supports["frameRate"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["aspectRatio"] || !supports["frameRate"]) {
   // Treat like an error.
 }
- var constraints =
-  {
-    frameRate: {min: 20},
-    width: {min: 640, ideal: 1280},
-    height: {min: 480, ideal: 720},
-    aspectRatio: 1.5
-  };
-</pre>
+const constraints = {
+  frameRate: { min: 20 },
+  width:  { min: 640, ideal: 1280 },
+  height: { min: 480, ideal: 720 },
+  aspectRatio: 1.5
+};
+    </pre>
     <p>This example illustrates the full control possible with the Constraints
     structure by adding the 'advanced' property. In this case, the User Agent
     behaves the same way with respect to the required constraints, but before
@@ -3850,18 +3848,19 @@ if(!supports["aspectRatio"] || !supports["frameRate"]) {
     give me an aspectRatio of 4x3 if at all possible. If even that is not
     possible, give me a resolution as close to 1280x720 as possible."</p>
     <pre class="example">
-    var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["width"] || !supports["height"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["width"] || !supports["height"]) {
   // Treat like an error.
 }
- var constraints =
-  {
-    width: {min: 640, ideal: 1280},
-    height: {min: 480, ideal: 720},
-    advanced: [{width: 1920, height: 1280},
-               {aspectRatio: 1.3333333333}]
-  };
-</pre>
+const constraints = {
+  width:  { min: 640, ideal: 1280 },
+  height: { min: 480, ideal:  720 },
+  advanced: [
+    { width: 1920, height: 1280 },
+    { aspectRatio: 1.3333333333 }
+  ]
+};
+    </pre>
     <p>The ordering of advanced ConstraintSets is significant. In the preceding
     example it is impossible to satisfy both the 1920x1280 ConstraintSet and
     the 4x3 aspect ratio ConstraintSet at the same time. Since the 1920x1280
@@ -4217,110 +4216,96 @@ interface ConstrainablePattern {
       "#constrainable-properties">constrainable properties defined for
       <code>MediaStreamTrack</code></a>.</p>
       <pre class="example">
-      var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["facingMode"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["facingMode"]) {
   // Treat like an error.
 }
-var constraints = {
-  width: {
-    min: 640
-  },
-  height: {
-    min: 480
-  },
-  advanced: [{
-      width: 650
-    }, {
-      width: {
-        min: 650
-      }
-    }, {
-      frameRate: 60
-    }, {
-      width: {
-        max: 800
-      }
-    }, {
-      facingMode: "user"
-    }]
+const constraints = {
+  width:  { min: 640 },
+  height: { min: 480 },
+  advanced: [
+    { width: 650 },
+    { width: { min: 650 } },
+    { frameRate: 60 },
+    { width: { max: 800 } },
+    { facingMode: "user" }
+  ]
 };
-</pre>
+      </pre>
       <p>Here is another example, specifically for a video track where I must
       have a particular camera and have separate preferences for the width and
       height:</p>
       <pre class="example">
-      var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["deviceId"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["deviceId"]) {
   // Treat like an error.
 }
-var constraints = {
-  deviceId: {exact: "20983-20o198-109283-098-09812"},
-  advanced: [{
-      width: {
-        min: 800,
-        max: 1200
-      }
-    }, {
-      height: {
-        min: 600
-      }
-    }]
+const constraints = {
+  deviceId: { exact: "20983-20o198-109283-098-09812" },
+  advanced: [
+    { width: { min: 800, max: 1200 } },
+    { height: { min: 600 } }
+  ]
 };
-</pre>
+      </pre>
       <p>And here's one for an audio track:</p>
       <pre class="example">
-      var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["deviceId"] || !supports["volume"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["deviceId"] || !supports["volume"]) {
   // Treat like an error.
 }
-var constraints = {
-  advanced: [{
-      deviceId: "64815-wi3c89-1839dk-x82-392aa"
-    }, {
-      volume: 0.5
-    }]
+const constraints = {
+  advanced: [
+    { deviceId: "64815-wi3c89-1839dk-x82-392aa" },
+    { volume: 0.5 }
+  ]
 };
-</pre>
+      </pre>
       <p>Here's an example of use of ideal:</p>
       <pre class="example">
-      var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["aspectRatio"] || !supports["facingMode"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["aspectRatio"] || !supports["facingMode"]) {
   // Treat like an error.
 }
-var gotten = navigator.mediaDevices.getUserMedia({
+await navigator.mediaDevices.getUserMedia({
   video: {
-    width: {min: 320, ideal: 1280, max: 1920},
-    height: {min: 240, ideal: 720, max: 1080},
-    frameRate: 30,     // Shorthand for ideal.
-    // facingMode: "environment" would be optional.
-    facingMode: {exact: "environment"}
-  }});
-</pre>
+    width:  { min: 320, ideal: 1280, max: 1920 },
+    height: { min: 240, ideal:  720, max: 1080 },
+    frameRate: 30, // Shorthand for ideal.
+    facingMode: {
+      // facingMode: "environment" would be optional.
+      exact: "environment"
+    }
+  }
+});
+      </pre>
       <p>Here's an example of "I want 720p, but I can accept up to 1080p and
       down to VGA.":</p>
       <pre class="example">
-      var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["width"] || !supports["height"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["width"] || !supports["height"]) {
   // Treat like an error.
 }
-var gotten = navigator.mediaDevices.getUserMedia({video: {
-  width: {min: 640, ideal: 1280, max: 1920},
-  height: {min: 480, ideal: 720, max: 1080},
-}});
-</pre>
+const gotten = navigator.mediaDevices.getUserMedia({
+  video: {
+    width:  {min: 640, ideal: 1280, max: 1920},
+    height: {min: 480, ideal:  720, max: 1080},
+  }
+});
+      </pre>
       <p>Here's an example of "I want a front-facing camera and it must be
       VGA.":</p>
       <pre class="example">
-      var supports = navigator.mediaDevices.getSupportedConstraints();
-if(!supports["width"] || !supports["height"] || !supports["facingMode"]) {
+const supports = navigator.mediaDevices.getSupportedConstraints();
+if (!supports["width"] || !supports["height"] || !supports["facingMode"]) {
   // Treat like an error.
 }
-var gotten = navigator.mediaDevices.getUserMedia({video: {
+const gotten = navigator.mediaDevices.getUserMedia({video: {
   facingMode: {exact: "user"},
-  width: {exact: 640},
+  width:  {exact: 640},
   height: {exact: 480}
 }});
-</pre>
+      </pre>
     </section>
     <section>
       <h2>Types for Constrainable Properties</h2>
@@ -4533,32 +4518,25 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
       <p>An example of a Capabilities dictionary is shown below. In this case,
       the <a>constrainable object</a> is a video source with a very limited set
       of Capabilities.</p>
-      <pre class="example">{
-  frameRate: {
-    min: 1.0,
-    max: 60.0
-  },
+      <pre class="example">
+{
+  frameRate: { min: 1.0, max: 60.0 },
   facingMode: [ "user", "left" ]
 }
-</pre>
+      </pre>
       <p>The next example below points out that capabilities for range values
       provide ranges for individual constrainable properties, not combinations.
       This is particularly relevant for video width and height, since the
       ranges for width and height are reported separately. In the example, if
       the <a>constrainable object</a> can only provide 640x480 and 800x600
       resolutions the relevant capabilities returned would be:</p>
-      <pre class="example">{
-  width: {
-    min: 640,
-    max: 800
-  },
-  height: {
-    min: 480,
-    max: 600
-  },
+      <pre class="example">
+{
+  width:  { min: 640, max: 800 },
+  height: { min: 480, max: 600 },
   aspectRatio: 1.3333333333
 }
-</pre>
+      </pre>
       <p>Note in the example above that the aspectRatio would make clear that
       arbitrary combination of widths and heights are not possible, although it
       would still suggest that more than two resolutions were available.</p>A
@@ -4588,11 +4566,12 @@ var gotten = navigator.mediaDevices.getUserMedia({video: {
       <p>An example of a Settings dictionary is shown below. This example is
       not very realistic in that a browser would actually be required to
       support more constrainable properties than just these.</p>
-      <pre class="example">{
+      <pre class="example">
+{
   frameRate: 30.0,
   facingMode: "user"
 }
-</pre>A specification using the Constrainable Pattern should not subclass the
+      </pre>A specification using the Constrainable Pattern should not subclass the
 below dictionary, but instead provide its own definition. See
 <code><a>MediaTrackSettings</a></code> for an example.
       <div>
@@ -4660,31 +4639,31 @@ below dictionary, but instead provide its own definition. See
       access to the local camera) and then disabling the stream (e.g., revoking
       that access).</p>
       <pre class="example">
-      &lt;input type="button" value="Start" onclick="start()" id="startBtn"&gt;
+&lt;button id="startBtn"&gt;Start&lt;/button&gt;
 &lt;script&gt;
- var startBtn = document.getElementById('startBtn');
+const startBtn = document.getElementById('startBtn');
 
- function start() {
-     navigator.mediaDevices.getUserMedia({
-         audio: true,
-         video: true
-     }).then(gotStream).catch(logError);
-     startBtn.disabled = true;
- }
+startBtn.addEventListener('click', async () =&gt; {
+  try {
+    startBtn.disabled = true;
+    const constraint = {
+      audio: true,
+      video: true
+    };
 
- function gotStream(stream) {
-     stream.getTracks().forEach(function (track) {
-         track.onended = function () {
-             startBtn.disabled = stream.active;
-         };
-     });
- }
+    const stream = await navigator.mediaDevices.getUserMedia(constraint);
 
- function logError(error) {
-     log(error.name + ": " + error.message);
- }
+    stream.getTracks().forEach((track) =&gt; {
+      track.onended = () =&gt; {
+        startBtn.disabled = stream.active;
+      }
+    })
+  } catch(err) {
+    console.error(err)
+  }
+});
 &lt;/script&gt;
-</pre>
+      </pre>
     </div><!-- Put back when we define MediaStreamRecorder
     <div>
 
@@ -4756,43 +4735,44 @@ below dictionary, but instead provide its own definition. See
       <p>This example allows people to take photos of themselves from the local
       video camera. Note that the Image Capture specification [[image-capture]]
       provides a simpler way to accomplish this.</p>
-      <pre class="example">&lt;article&gt;
- &lt;style scoped&gt;
-  video { transform: scaleX(-1); }
-  p { text-align: center; }
- &lt;/style&gt;
- &lt;h1&gt;Snapshot Kiosk&lt;/h1&gt;
- &lt;section id="splash"&gt;
+      <pre class="example">
+&lt;script&gt;
+window.addEventListener('load', async () =&gt; {
+  const video = document.getElementById('monitor');
+  const canvas = document.getElementById('photo');
+  const shutter = document.getElementById('shutter');
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({video: true});
+    video.srcObject = stream;
+    video.addEventListener('loadedmetadata', () =&gt; {
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      document.getElementById('splash').hidden = true;
+      document.getElementById('app').hidden = false;
+    });
+
+    shutter.addEventListener('click', () =&gt; {
+      canvas.getContext('2d').drawImage(video, 0, 0);
+    });
+  } catch (err) {
+    console.error(err)
+  }
+});
+&lt;/script&gt;
+
+&lt;h1&gt;Snapshot Kiosk&lt;/h1&gt;
+
+&lt;section id="splash"&gt;
   &lt;p id="errorMessage"&gt;Loading...&lt;/p&gt;
- &lt;/section&gt;
- &lt;section id="app" hidden&gt;
-  &lt;p&gt;&lt;video id="monitor" autoplay&gt;&lt;/video&gt; &lt;canvas id="photo"&gt;&lt;/canvas&gt;
-  &lt;p&gt;&lt;input type=button value="&amp;#x1F4F7;" onclick="snapshot()"&gt;
- &lt;/section&gt;
- &lt;script&gt;
- var video = document.getElementById('monitor');
- var canvas = document.getElementById('photo');
+&lt;/section&gt;
 
- navigator.mediaDevices.getUserMedia({
-     video: true
- }).then(function (stream) {
-     video.srcObject = stream;
-     video.onloadedmetadata = function () {
-         canvas.width = video.videoWidth;
-         canvas.height = video.videoHeight;
-         document.getElementById('splash').hidden = true;
-         document.getElementById('app').hidden = false;
-     };
- }).catch(function (reason) {
-     document.getElementById('errorMessage').textContent = 'No camera available.';
- });
-
- function snapshot() {
-     canvas.getContext('2d').drawImage(video, 0, 0);
- }
- &lt;/script&gt;
-&lt;/article&gt;
-</pre>
+&lt;section id="app" hidden&gt;
+  &lt;video id="monitor" autoplay&gt;&lt;/video&gt;
+  &lt;button id="shutter"&gt;&amp;#x1F4F7;&lt;/button&gt;
+  &lt;canvas id="photo"&gt;&lt;/canvas&gt;
+&lt;/section&gt;
+      </pre>
     </div>
   </section>
   <section>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3829,9 +3829,9 @@ if (!supports["aspectRatio"] || !supports["frameRate"]) {
   // Treat like an error.
 }
 const constraints = {
-  frameRate: { min: 20 },
-  width: { min: 640, ideal: 1280 },
-  height: { min: 480, ideal: 720 },
+  frameRate: {min: 20},
+  width: {min: 640, ideal: 1280},
+  height: {min: 480, ideal: 720},
   aspectRatio: 3/2
 };
     </pre>
@@ -3853,11 +3853,11 @@ if (!supports["width"] || !supports["height"]) {
   // Treat like an error.
 }
 const constraints = {
-  width: { min: 640, ideal: 1280 },
-  height: { min: 480, ideal: 720 },
+  width: {min: 640, ideal: 1280},
+  height: {min: 480, ideal: 720},
   advanced: [
-    { width: 1920, height: 1280 },
-    { aspectRatio: 4/3 }
+    {width: 1920, height: 1280},
+    {aspectRatio: 4/3}
   ]
 };
     </pre>
@@ -4221,14 +4221,14 @@ if (!supports["facingMode"]) {
   // Treat like an error.
 }
 const constraints = {
-  width: { min: 640 },
-  height: { min: 480 },
+  width: {min: 640},
+  height: {min: 480},
   advanced: [
-    { width: 650 },
-    { width: { min: 650 } },
-    { frameRate: 60 },
-    { width: { max: 800 } },
-    { facingMode: "user" }
+    {width: 650},
+    {width: {min: 650}},
+    {frameRate: 60},
+    {width: {max: 800}},
+    {facingMode: "user"}
   ]
 };
       </pre>
@@ -4241,10 +4241,10 @@ if (!supports["deviceId"]) {
   // Treat like an error.
 }
 const constraints = {
-  deviceId: { exact: "20983-20o198-109283-098-09812" },
+  deviceId: {exact: "20983-20o198-109283-098-09812"},
   advanced: [
-    { width: { min: 800, max: 1200 } },
-    { height: { min: 600 } }
+    {width: {min: 800, max: 1200}},
+    {height: {min: 600}}
   ]
 };
       </pre>
@@ -4256,8 +4256,8 @@ if (!supports["deviceId"] || !supports["volume"]) {
 }
 const constraints = {
   advanced: [
-    { deviceId: "64815-wi3c89-1839dk-x82-392aa" },
-    { volume: 0.5 }
+    {deviceId: "64815-wi3c89-1839dk-x82-392aa"},
+    {volume: 0.5}
   ]
 };
       </pre>
@@ -4269,8 +4269,8 @@ if (!supports["aspectRatio"] || !supports["facingMode"]) {
 }
 const stream = await navigator.mediaDevices.getUserMedia({
   video: {
-    width: { min: 320, ideal: 1280, max: 1920 },
-    height: { min: 240, ideal: 720, max: 1080 },
+    width: {min: 320, ideal: 1280, max: 1920},
+    height: {min: 240, ideal: 720, max: 1080},
     frameRate: 30, // Shorthand for ideal.
     facingMode: {
       exact: "environment"
@@ -4520,7 +4520,7 @@ const gotten = navigator.mediaDevices.getUserMedia({video: {
       of Capabilities.</p>
       <pre class="example">
 {
-  frameRate: { min: 1.0, max: 60.0 },
+  frameRate: {min: 1.0, max: 60.0},
   facingMode: [ "user", "left" ]
 }
       </pre>
@@ -4532,8 +4532,8 @@ const gotten = navigator.mediaDevices.getUserMedia({video: {
       resolutions the relevant capabilities returned would be:</p>
       <pre class="example">
 {
-  width: { min: 640, max: 800 },
-  height: { min: 480, max: 600 },
+  width: {min: 640, max: 800},
+  height: {min: 480, max: 600},
   aspectRatio: 4/3
 }
       </pre>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3830,7 +3830,7 @@ if (!supports["aspectRatio"] || !supports["frameRate"]) {
 }
 const constraints = {
   frameRate: { min: 20 },
-  width:  { min: 640, ideal: 1280 },
+  width: { min: 640, ideal: 1280 },
   height: { min: 480, ideal: 720 },
   aspectRatio: 3/2
 };
@@ -3853,8 +3853,8 @@ if (!supports["width"] || !supports["height"]) {
   // Treat like an error.
 }
 const constraints = {
-  width:  { min: 640, ideal: 1280 },
-  height: { min: 480, ideal:  720 },
+  width: { min: 640, ideal: 1280 },
+  height: { min: 480, ideal: 720 },
   advanced: [
     { width: 1920, height: 1280 },
     { aspectRatio: 4/3 }
@@ -4221,7 +4221,7 @@ if (!supports["facingMode"]) {
   // Treat like an error.
 }
 const constraints = {
-  width:  { min: 640 },
+  width: { min: 640 },
   height: { min: 480 },
   advanced: [
     { width: 650 },
@@ -4269,8 +4269,8 @@ if (!supports["aspectRatio"] || !supports["facingMode"]) {
 }
 await navigator.mediaDevices.getUserMedia({
   video: {
-    width:  { min: 320, ideal: 1280, max: 1920 },
-    height: { min: 240, ideal:  720, max: 1080 },
+    width: { min: 320, ideal: 1280, max: 1920 },
+    height: { min: 240, ideal: 720, max: 1080 },
     frameRate: 30, // Shorthand for ideal.
     facingMode: {
       // facingMode: "environment" would be optional.
@@ -4288,8 +4288,8 @@ if (!supports["width"] || !supports["height"]) {
 }
 const gotten = navigator.mediaDevices.getUserMedia({
   video: {
-    width:  {min: 640, ideal: 1280, max: 1920},
-    height: {min: 480, ideal:  720, max: 1080},
+    width: {min: 640, ideal: 1280, max: 1920},
+    height: {min: 480, ideal: 720, max: 1080},
   }
 });
       </pre>
@@ -4302,7 +4302,7 @@ if (!supports["width"] || !supports["height"] || !supports["facingMode"]) {
 }
 const gotten = navigator.mediaDevices.getUserMedia({video: {
   facingMode: {exact: "user"},
-  width:  {exact: 640},
+  width: {exact: 640},
   height: {exact: 480}
 }});
       </pre>
@@ -4532,7 +4532,7 @@ const gotten = navigator.mediaDevices.getUserMedia({video: {
       resolutions the relevant capabilities returned would be:</p>
       <pre class="example">
 {
-  width:  { min: 640, max: 800 },
+  width: { min: 640, max: 800 },
   height: { min: 480, max: 600 },
   aspectRatio: 4/3
 }

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4660,8 +4660,8 @@ startBtn.onclick = async () =&gt; {
         startBtn.disabled = stream.getTracks().some(t =&gt; t.readyState == 'live');
       }
     };
-  } catch(err) {
-    console.error(err)
+  } catch (err) {
+    console.error(err);
   }
 };
 &lt;/script&gt;
@@ -4755,7 +4755,7 @@ window.onload = async () =&gt; {
 
     shutter.onclick = () =&gt; canvas.getContext('2d').drawImage(video, 0, 0);
   } catch (err) {
-    console.error(err)
+    console.error(err);
   }
 };
 &lt;/script&gt;

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4753,9 +4753,7 @@ window.onload = async () =&gt; {
     document.getElementById('splash').hidden = true;
     document.getElementById('app').hidden = false;
 
-    shutter.onclick = () =&gt; {
-      canvas.getContext('2d').drawImage(video, 0, 0);
-    };
+    shutter.onclick = () =&gt; canvas.getContext('2d').drawImage(video, 0, 0);
   } catch (err) {
     console.error(err)
   }

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4645,7 +4645,7 @@ below dictionary, but instead provide its own definition. See
 &lt;script&gt;
 const startBtn = document.getElementById('startBtn');
 
-startBtn.addEventListener('click', async () =&gt; {
+startBtn.onclick = async () =&gt; {
   try {
     startBtn.disabled = true;
     const constraints = {
@@ -4655,15 +4655,15 @@ startBtn.addEventListener('click', async () =&gt; {
 
     const stream = await navigator.mediaDevices.getUserMedia(constraints);
 
-    stream.getTracks().forEach((track) =&gt; {
+    for (let track of stream.getTracks()) {
       track.onended = () =&gt; {
-        startBtn.disabled = stream.active;
+        startBtn.disabled = stream.getTracks().some(t =&gt; t.readyState == 'live');
       }
-    })
+    }
   } catch(err) {
     console.error(err)
   }
-});
+};
 &lt;/script&gt;
       </pre>
     </div><!-- Put back when we define MediaStreamRecorder
@@ -4739,7 +4739,7 @@ startBtn.addEventListener('click', async () =&gt; {
       provides a simpler way to accomplish this.</p>
       <pre class="example">
 &lt;script&gt;
-window.addEventListener('load', async () =&gt; {
+window.onload = async () =&gt; {
   const video = document.getElementById('monitor');
   const canvas = document.getElementById('photo');
   const shutter = document.getElementById('shutter');
@@ -4753,13 +4753,13 @@ window.addEventListener('load', async () =&gt; {
       document.getElementById('app').hidden = false;
     });
 
-    shutter.addEventListener('click', () =&gt; {
+    shutter.onclick = () =&gt; {
       canvas.getContext('2d').drawImage(video, 0, 0);
-    });
+    };
   } catch (err) {
     console.error(err)
   }
-});
+};
 &lt;/script&gt;
 
 &lt;h1&gt;Snapshot Kiosk&lt;/h1&gt;

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4743,8 +4743,7 @@ window.addEventListener('load', async () =&gt; {
   const shutter = document.getElementById('shutter');
 
   try {
-    const stream = await navigator.mediaDevices.getUserMedia({video: true});
-    video.srcObject = stream;
+    video.srcObject = await navigator.mediaDevices.getUserMedia({video: true});
     video.addEventListener('loadedmetadata', () =&gt; {
       canvas.width = video.videoWidth;
       canvas.height = video.videoHeight;


### PR DESCRIPTION
cleanup code example in HTML help us understand features more easily.
so I cleanup some code like below.

- format indent
- use basic new feature of ES6^
  - const
  - arrow function
  - async/await
- remove deprecated scoped css
- remove js from html
- simplify but save meaning and semantics

if there are some format rule or feature regulation in spec.
please mention me and I'll fix them.