### PR TITLE
Throw on getUserMedia in non-fully active documents.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3367,6 +3367,15 @@ interface MediaDeviceInfo {
                 </li>
                 <li>
                   <p>If the <a>current settings object</a>'s <a>responsible
+                  document</a> is NOT <a data-cite=
+                  "!HTML52/browsers.html#fully-active">fully active</a>,
+                  return a promise <a>rejected</a> with a
+                  <code><a>DOMException</a></code> object whose
+                  <code><a>name</a></code> attribute has the value
+                  <code> InvalidStateError</code>.</p>
+                </li>
+                <li>
+                  <p>If the <a>current settings object</a>'s <a>responsible
                   document</a> is NOT <a>allowed to use</a> the feature
                   indicated by attribute name <code>allowusermedia</code>,
                   return a promise <a>rejected</a> with a


### PR DESCRIPTION
Fix for #489.