### PR TITLE
Split out algorithm to set a track's muted state from other specs (editorial).

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -810,9 +810,13 @@ interface MediaStream : EventTarget {
         toggling a control in the operating system, the user clicking a mute
         button in the browser chrome, the User Agent (on behalf of the user)
         mutes, etc.</p>
-        <p>To <dfn id="update-track-muted">update a track's muted state</dfn>
-        to <var>newState</var>, the User Agent MUST queue a task to run the
-        following steps:</p>
+        <p>
+        Whenever the User Agent initiates such a change, it MUST queue a task,
+        using the user interaction task source, to
+        <a>set a track's muted state</a> to the state desired by the user.
+        </p>
+        <p>To <dfn id="set-track-muted">set a track's muted state</dfn>
+        to <var>newState</var>, the User Agent MUST run the following steps:</p>
         <ol>
           <li>
             <p>Let <var>track</var> be the <code>MediaStreamTrack</code> in


### PR DESCRIPTION
Partial fix for https://github.com/w3c/webrtc-pc/issues/1568.