### PR TITLE
Fix compat with ReSpec19

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2802,7 +2802,7 @@ interface NavigatorUserMedia {
     </section>
     <section>
       <h3>MediaDevices</h3>
-      <p>The <dfn>MediaDevices</dfn> object is the entry point to the API used
+      <p>The <dfn data-dfn-for="">MediaDevices</dfn> object is the entry point to the API used
       to examine and get access to media devices available to the User
       Agent.</p>
       <p>On page load, run the following steps:</p>


### PR DESCRIPTION
MediaDevices' `<dfn>` needs a `data-dfn-for=""` to distinguish it from the `mediaDevices` attribute