### PR TITLE
Clarify getSettings() are target values.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4100,8 +4100,9 @@ interface ConstrainablePattern {
               <p>The <dfn>getSettings()</dfn> method returns the current
               settings of all the constrainable properties of the object,
               whether they are platform defaults or have been set by the
-              <a>applyConstraints algorithm</a>. Note that the actual setting
-              of a property MUST be a single value.</p>
+              <a>applyConstraints algorithm</a>. Note that a setting is a target
+              value that complies with constraints, and therefore may differ
+              from measured performance at times due to hardware delay.</p>
             </dd>
             <dt><code>applyConstraints</code></dt>
             <dd>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4102,7 +4102,7 @@ interface ConstrainablePattern {
               whether they are platform defaults or have been set by the
               <a>applyConstraints algorithm</a>. Note that a setting is a target
               value that complies with constraints, and therefore may differ
-              from measured performance at times due to hardware delay.</p>
+              from measured performance at times.</p>
             </dd>
             <dt><code>applyConstraints</code></dt>
             <dd>


### PR DESCRIPTION
Fix for https://github.com/w3c/mediacapture-main/issues/470, given https://github.com/w3c/mediacapture-main/issues/466#issuecomment-351747593.