### PR TITLE
Have getCapabilities() return an empty dictionary instead of null

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3269,7 +3269,7 @@ interface MediaDeviceInfo {
               <code>InputDeviceInfo</code> has been filtered with respect to
               unique identifying information (see above description of
               <code>enumerateDevices()</code> result), then this method returns
-              <code>null</code>.</p>
+              an empty dictionary.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fix for https://github.com/w3c/mediacapture-main/issues/538.