### PR TITLE
Clarify what happens to non-applicable constraints.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3535,11 +3535,22 @@ interface MediaDeviceInfo {
                           <code><a>name</a></code> attribute has the value
                           <code>NotFoundError</code> and abort these steps.</p>
                         </li>
-                        <li>If the value of the <var>T</var> entry of
-                        <var>constraints</var> is "true", set CS to the empty
-                        constraint set (no constraint). Otherwise, continue
-                        with <var>CS</var> set to the value of the <var>T</var>
-                        entry of <var>constraints</var>.</li>
+                        <li>
+                          If the value of the <var>T</var> entry of
+                          <var>constraints</var> is "true", set <var>CS</var> to
+                          the empty constraint set (no constraint). Otherwise,
+                          continue with <var>CS</var> set to the value of the
+                          <var>T</var> entry of <var>constraints</var>.
+                        </li>
+                        <li>
+                          Remove any constrainable property inside of
+                          <var>CS</var> that are not defined for
+                          <code><a>MediaStreamTrack</a></code> objects of type
+                          <var>T</var>. This means that audio-only constraints
+                          inside of "video" and video-only constraints inside of
+                          "audio" are simply ignored rather than causing
+                          <code>OverconstrainedError</code>.
+                        </li>
                         <li>
                           <p>Run the <a>SelectSettings</a>
                           algorithm on each track in <var>CandidateSet</var>


### PR DESCRIPTION
Fixes #533.

Some of the constrainable properties are said to be "defined to apply only to [video/audio] MediaStreamTrack objects". It is not clear whether specifying a constraint that doesn't apply for the type (e.g. {audio:{exact:640}}) would cause an OverconstrainedError or simply be ignored. Both are valid interpretations.

This PR says to ignore such constraints, because...
- This is what current implementations do.
- This requires less code to be updated when new constraints are added.
- If a constraint is not recognized by a User Agent it is ignored (because constraints are passed as dictionaries, anything not in the IDL would be ignored); this is consistent with "constraint is not implemented for this type".
- This would allow editorial changes such as splitting audio and video constrainable properties into separate dictionaries without implicitly causing change in behavior.