### PR TITLE
Remove allowusermedia SecurityError check, in favor of allow=

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3482,15 +3482,6 @@ interface MediaDeviceInfo {
                   <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
-                  <p>If the <a>current settings object</a>'s <a>responsible
-                  document</a> is NOT <a>allowed to use</a> the feature
-                  indicated by attribute name <code>allowusermedia</code>,
-                  return a promise <a>rejected</a> with a
-                  <code><a>DOMException</a></code> object whose
-                  <code><a>name</a></code> attribute has the value
-                  <code>SecurityError</code>.</p>
-                </li>
-                <li>
                   <p>Let <var>originIdentifier</var> be the <a>current settings
                   object</a>'s <a data-cite=
                   "!HTML52/webappapis.html#responsible-browsing-context">responsible


### PR DESCRIPTION
... the `allow='camera;microphone'` check now implicit in the permissions spec, now that https://github.com/w3c/permissions/pull/163 has merged.

For review, ~note that~ https://w3c.github.io/permissions/#reading-current-states ~does not yet reflect github tip for some reason, so please see the merged PR's [preview](https://pr-preview.s3.amazonaws.com/raymeskhoury/permissions/pull/163.html#reading-current-states) for the new language there relevant to this PR.~

Fixes https://github.com/w3c/mediacapture-main/issues/434 and https://github.com/w3c/mediacapture-main/issues/545.

