### PR TITLE
Mitigate fingerprinting from OverconstrainedError in gUM().

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3556,7 +3556,7 @@ interface MediaDeviceInfo {
                           whose fitness distance was infinity for
                           all settings dictionaries examined while executing
                           the <a>SelectSettings</a> algorithm, and jump to the
-                          step labeled <em>Constraint Failure</em> below.</p>
+                          step labeled <em>Constraint Failure</em> below.
                           The user agent SHOULD choose the constraint that
                           minimizes the amount of fingerprinting information
                           given.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3557,6 +3557,9 @@ interface MediaDeviceInfo {
                           all settings dictionaries examined while executing
                           the <a>SelectSettings</a> algorithm, and jump to the
                           step labeled <em>Constraint Failure</em> below.</p>
+                          The user agent SHOULD choose the constraint that
+                          minimizes the amount of fingerprinting information
+                          given.</p>
                           <p class="fingerprint">This error gives information
                           about what the underlying device is not capable of
                           producing, before the user has given any


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/562.