### PR TITLE
MAY defer getUserMedia until page has focus.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3490,6 +3490,14 @@ interface MediaDeviceInfo {
                   <p>Run the following steps in parallel:</p>
                   <ol>
                     <li>
+                      <p>The user agent MAY wait to proceed to the next step
+                      until the <a>current settings object</a>'s <a>responsible
+                      document</a> is <a data-cite=
+                          "!HTML52/browsers.html#fully-active">fully active</a>
+                      and <a data-cite="!HTML52/editing.html#gain-focus">has
+                      focus.</a>
+                    </li>
+                    <li>
                       <p>Let <var>finalSet</var> be an (initially) empty
                       set.</p>
                     </li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/560. For consideration.