### PR TITLE
Fix nonsense s/active document/responsible document/ in devicechange (editorial)

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2913,7 +2913,7 @@ interface OverconstrainedErrorEvent : Event {
         </li>
         <li>any of the input devices are attached to an active MediaStream in
         the browsing context, or</li>
-        <li>the <a data-cite="!HTML52/browsers.html#active-document">active
+        <li>The <a>current settings object</a>'s <a>responsible
         document</a> is <a data-cite="!HTML52/browsers.html#fully-active">fully
         active</a> and <a data-cite="!HTML52/editing.html#gain-focus">has
         focus.</a>


### PR DESCRIPTION
This is an editorial fix.

The intent here was always to exclude background tabs, yet this check did not accomplish that: Checking whether a browsing context's *"active document* is *"fully active"* is circular and almost always true, except for some iframes.