### PR TITLE
Add video latency constrainable property

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1698,6 +1698,18 @@ interface MediaStreamTrack : EventTarget {
                 <a>ConstraintSet</a>.
               </td>
             </tr>
+            <tr id="def-constraint-latency">
+              <td>latency</td>
+              <td><code><a>ConstrainDouble</a></code></td>
+              <td>The latency or latency range, in seconds. The latency is the
+              time between start of processing (for instance, when person speaks
+              or moves in the real world) to the data being available to the
+              next step in the process. Low latency is critical for some
+              applications; high latency may be acceptable for other
+              applications because it helps with power constraints. The number
+              is expected to be the target latency of the configuration; the
+              actual latency may show some variation from that.</td>
+            </tr>
           </tbody>
         </table>
         <p>The following constrainable properties are defined to apply only to
@@ -1925,18 +1937,6 @@ interface MediaStreamTrack : EventTarget {
               needed and it is desirable to turn it off so that the audio is
               not altered. This allows applications to control this
               behavior.</td>
-            </tr>
-            <tr id="def-constraint-latency">
-              <td>latency</td>
-              <td><code><a>ConstrainDouble</a></code></td>
-              <td>The latency or latency range, in seconds. The latency is the
-              time between start of processing (for instance, when sound occurs
-              in the real world) to the data being available to the next step
-              in the process. Low latency is critical for some applications;
-              high latency may be acceptable for other applications because it
-              helps with power constraints. The number is expected to be the
-              target latency of the configuration; the actual latency may show
-              some variation from that.</td>
             </tr>
             <tr id="def-constraint-channelCount">
               <td>channelCount</td>


### PR DESCRIPTION
We would like to extended existing [latency](https://www.w3.org/TR/mediacapture-streams/#def-constraint-latency) constrainable property API to the video case as well. The justification is essentially the same as for audio. There might be apps which are not sensitive for the higher latency on the video track which can open the same optimization benefits as for audio.

Another problem it might solve is audio video desynchronization. Currently you have option to only increase latency for the audio track and if it has associated video track then they would be desynced.