### PR TITLE
Clarify that some device ids may not be origin-unique

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3072,15 +3072,18 @@ interface MediaDeviceInfo {
             <dt id="def-mediadeviceinfo-deviceId"><dfn><code>deviceId</code></dfn>
             of type <span class="idlAttrType">DOMString</span>, readonly</dt>
             <dd>
-              <p>A unique identifier for the represented device.</p>
-              <p>All enumerable devices have an identifier that MUST be unique
-              to the page's origin. Some sort of UUID is recommended for the
-              identifier. The same identifier MUST be valid between
-              browsing sessions of this origin, but MUST also be different for
-              other origins. In particular, this identifier MUST be un-guessable
-              by applications of other origins to prevent the identifier from
-              being used to correlate the same user across different
-              origins.</p>
+              <p>The identifier of the represented device. The device MUST be
+              uniquely identified by its identifier and its <code><a
+              href="#def-mediadeviceinfo-kind">kind</a></code>.</p>
+              <p>The same identifier MUST be valid between browsing sessions of
+              this origin. The identifier SHOULD be origin-unique,
+              in which case some sort of UUID is recommended.
+              If the identifier can uniquely identify the user, as is usually
+              the case with UUID, it MUST be un-guessable by browsing contexts
+              of other origins to prevent the identifier from being used to
+              correlate the same user across different origins. An identifier
+              can be reused across origins as long as it is not tied to the user
+              and can be guessed by other means, like the User-Agent string.</p>
               <p>If any local devices have been attached to a live
               MediaStreamTrack in a page from this origin, or <a href=
               "#stored-permissions">stored permission</a> to access local
@@ -3107,10 +3110,11 @@ interface MediaDeviceInfo {
               user agents MUST reset per-origin device identifiers when other
               persistent storage are cleared.</p>
             </dd>
-            <dt><dfn><code>kind</code></dfn> of type <span class=
-            "idlAttrType"><a>MediaDeviceKind</a></span>, readonly</dt>
+            <dt id="def-mediadeviceinfo-kind"><dfn><code>kind</code></dfn> of
+            type <span class= "idlAttrType"><a>MediaDeviceKind</a></span>,
+            readonly</dt>
             <dd>
-              <p>Describes the kind of the represented device.</p>
+              <p>The kind of the represented device.</p>
             </dd>
             <dt><dfn><code>label</code></dfn> of type <span class=
             "idlAttrType">DOMString</span>, readonly</dt>


### PR DESCRIPTION
Also refactor to make reference from deviceId/groupId constraints to MediaDeviceInfo attribute fields.
Clarify groupId lifetime.
Make reference to rfc4122 for deviceId.