### PR TITLE
Clarify groupId persistency

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1664,17 +1664,17 @@ interface MediaStreamTrack : EventTarget {
               <td><dfn>groupId</dfn></td>
               <td>DOMString</td>
               <td>
-                The browsing session-unique group identifier for the source of
-                the <a>MediaStreamTrack</a>. Two devices have the same group
-                identifier if they belong to the same physical device; for
-                example, the audio input and output devices representing the
-                speaker and microphone of the same headset would have the same
-                groupId. Note that the setting of this property is uniquely
+                The browsing context-unique group identifier for the device
+                generating the content of the <a>MediaStreamTrack</a>.
+                It conforms with the definition of
+                <code><a>MediaDeviceInfo</a></code>.<code><a
+                href="#def-mediadeviceinfo-groupId">groupId</a></code>.
+                Note that the setting of this property is uniquely
                 determined by the source that is attached to the
                 <a>MediaStreamTrack</a>. In particular, <a data-link-for=
                 "MediaStreamTrack">getCapabilities()</a> will return only a
                 single value for groupId. Since this property is not stable
-                between browsing sessions its usefulness for initial media
+                between browsing sessions, its usefulness for initial media
                 selection with <a data-link-for=
                 "MediaDevices">getUserMedia()</a> is limited. It is not useful
                 for subsequent media control with <a data-link-for=
@@ -3098,13 +3098,16 @@ interface MediaDeviceInfo {
               Webcam"). If the device has no associated label, then this
               attribute MUST return the empty string.</p>
             </dd>
-            <dt><dfn><code>groupId</code></dfn> of type <span class=
-            "idlAttrType">DOMString</span>, readonly</dt>
+            <dt id="def-mediadeviceinfo-groupId"><dfn><code>groupId</code></dfn>
+            of type <span class="idlAttrType">DOMString</span>, readonly</dt>
             <dd>
-              <p>Returns the group identifier of the represented device. Two
-              devices have the same group identifier if they belong to the same
-              physical device; for example a monitor with a built-in camera and
-              microphone.</p>
+              <p>The group identifier of the represented device. Two devices
+              have the same group identifier if they belong to the same
+              physical device. For example, the audio input and output devices
+              representing the speaker and microphone of the same headset
+              have the same groupId.</p>
+              <p>The group identifier MUST be uniquely generated for each
+              browsing context.</p>
             </dd>
           </dl>
         </section>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1664,7 +1664,9 @@ interface MediaStreamTrack : EventTarget {
               <td><dfn>groupId</dfn></td>
               <td>DOMString</td>
               <td>
-                The browsing context-unique group identifier for the device
+                The <a data-link-type="dfn"
+                href="https://dom.spec.whatwg.org/#concept-document">
+                document</a>-unique group identifier for the device
                 generating the content of the <a>MediaStreamTrack</a>.
                 It conforms with the definition of
                 <code><a>MediaDeviceInfo</a></code>.<code><a
@@ -3107,7 +3109,8 @@ interface MediaDeviceInfo {
               representing the speaker and microphone of the same headset
               have the same groupId.</p>
               <p>The group identifier MUST be uniquely generated for each
-              browsing context.</p>
+              <a data-link-type="dfn"
+              href="https://dom.spec.whatwg.org/#concept-document">document</a>.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Make it clear groupId is per browsing context.
Refactor to have the groupId constraint refer to MediaDeviceInfo.groupId definition.