### PR TITLE
Fix typo in sink label.

### DIFF
--- a/images/change_states_before.svg
+++ b/images/change_states_before.svg
@@ -984,7 +984,7 @@
          y="2963.7917"
          x="28155.605"
          id="tspan3219"
-         sodipodi:role="line">X</tspan></text>
+         sodipodi:role="line">Y</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:1128.98669434px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"


### PR DESCRIPTION
Fix #547

Fix the reported typo in https://www.w3.org/TR/mediacapture-streams/#the-model-sources-sinks-constraints-and-settings
where one of the sinks is incorrectly named 'X' instead of 'Y'. This
commit fixes the typo in the SVG image, so to be consistent with the
rest of the text and the other illustration.