### PR TITLE
Add Henrik Boström to the list of editors.

### DIFF
--- a/getusermedia.js
+++ b/getusermedia.js
@@ -52,7 +52,8 @@ var respecConfig = {
        { w3cid: "25254", name: "Cullen Jennings", company: "Cisco" },
        { w3cid: "47326", name: "Anant Narayanan", company: "Mozilla", note: "until November 2012" },
        { w3cid: "65611", name: "Bernard Aboba", company: "Microsoft Corporation" },
-       { w3cid: "79152", name: "Jan-Ivar Bruaroey", company: "Mozilla" }
+       { w3cid: "79152", name: "Jan-Ivar Bruaroey", company: "Mozilla" },
+       { w3cid: "96936", name: "Henrik Bostr\xF6m", company: "Google" }
    ],
 
    // authors, add as many as you like.


### PR DESCRIPTION
It is my understanding that henbos is part of the editors for
mediastream-main but not listed among the editors. This commits fixes
that.