### PR TITLE
Add definition to track-ending algorithm

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -771,10 +771,11 @@ interface MediaStream : EventTarget {
         the <code><a>MediaStreamTrack</a></code> object, or because the User
         Agent has instructed the track to end for any reason) it is said to be
         <dfn id="track-ended">ended</dfn>.</p>
-        <p>When a <code><a>MediaStreamTrack</a></code> <var>track</var> ends
-        for any reason other than the <code><a href=
-        "#dom-mediastreamtrack-stop">stop()</a></code> method being invoked,
-        the User Agent MUST queue a task that runs the following steps:</p>
+        <p>When a <code><a>MediaStreamTrack</a></code> <var>track</var>
+        <dfn id="ends-nostop">ends for any reason other than the <code><a href=
+        "#dom-mediastreamtrack-stop">stop()</a></code> method being
+        invoked</dfn>, the User Agent MUST queue a task that runs the following
+        steps:</p>
         <ol>
           <li>
             <p>If the <var>track's</var> <code><a href=


### PR DESCRIPTION
The algorithm for ending tracks for reasons other than stop() doesn't
have a definition. Having one lets us reference it from this and other
specifications.

This helps w3c/mediacapture-fromelement#81.