### PR TITLE
Remove oldList and make it clear that groupId scope is the document

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2914,13 +2914,6 @@ interface MediaDevices : EventTarget {
                       <p>Let <var>resultList</var> be an empty list.</p>
                     </li>
                     <li>
-                      <p>If this method has been called previously within this
-                      browsing session, let <var>oldList</var> be the list of
-                      <code><a>MediaDeviceInfo</a></code> objects that was
-                      produced at that call (<var>resultList</var>); otherwise,
-                      let <var>oldList</var> be an empty list.</p>
-                    </li>
-                    <li>
                       <p>Probe the User Agent for available media devices, and
                       run the following sub steps for each discovered device,
                       <var>device</var>:</p>
@@ -2942,13 +2935,6 @@ interface MediaDevices : EventTarget {
                           continue with the next device (if any).</p>
                         </li>
                         <li>
-                          <p>If <var>device</var> is represented by a
-                          <code><a>MediaDeviceInfo</a></code> object in
-                          <var>oldList</var>, append that object to
-                          <var>resultList</var>, abort these steps and continue
-                          with the next device (if any).</p>
-                        </li>
-                        <li>
                           <p>Let <var>deviceInfo</var> be a new
                           <code><a>MediaDeviceInfo</a></code> object to
                           represent <var>device</var>.</p>
@@ -2966,8 +2952,7 @@ interface MediaDevices : EventTarget {
                         </li>
                         <li>
                           <p>If <var>device</var> belongs to the same physical
-                          device as a device already represented in
-                          <var>oldList</var> or <var>resultList</var>,
+                          device as a device already represented for <var>document</var>,
                           initialize <var>deviceInfo</var>'s
                           <code><a data-link-for=
                           "MediaDeviceInfo">groupId</a></code> member to the


### PR DESCRIPTION
PR for https://github.com/w3c/mediacapture-main/issues/604.
This hopefully makes it clear that a groupId is stable for the lifetime of a document.
Previously, if a device groupId was not in oldList/resultList, it would need to be regenerated.