### PR TITLE
Have deviceId follow partitioning rules for storage (such as localStorage)

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3214,8 +3214,15 @@ interface MediaDeviceInfo {
               <p>The identifier of the represented device. The device MUST be
               uniquely identified by its identifier and its <code><a
               href="#def-mediadeviceinfo-kind">kind</a></code>.</p>
-              <p>The same identifier MUST be valid between browsing sessions of
-              this origin. The identifier SHOULD be origin-unique,
+              <p>To to ensure stored identifiers are recognized, the identifier
+              MUST be the same in documents of the same origin in <a data-cite=
+              "!HTML/#top-level-browsing-context">top-level browsing contexts.</a>
+              In iframes, whether or not the identifier is the same in documents
+              of the same origin or not, MUST follow the user agents'
+              partitioning rules for <a data-cite=
+              "!HTML/#dom-localstorage"><code>localStorage</code></a>, if any,
+              to not interfere with mitigations for cross-site correlation.
+              The identifier SHOULD be origin-unique,
               in which case some sort of UUID is recommended.
               If the identifier can uniquely identify the user, as is usually
               the case with UUID, it MUST be un-guessable by browsing contexts

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3221,8 +3221,8 @@ interface MediaDeviceInfo {
               "!HTML/#nested-browsing-context">nested browsing contexts</a>,
               the decision of whether or not the identifier is the same across
               documents, MUST follow the user agents' partitioning rules for
-              <a data-cite=
-              "!HTML/#dom-localstorage"><code>localStorage</code></a>, if any,
+              storage (such as <a data-cite=
+              "!HTML/#dom-localstorage"><code>localStorage</code></a>), if any,
               to not interfere with mitigations for cross-site correlation.
               The identifier SHOULD be origin-unique,
               in which case some sort of UUID is recommended.

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3217,9 +3217,11 @@ interface MediaDeviceInfo {
               <p>To to ensure stored identifiers are recognized, the identifier
               MUST be the same in documents of the same origin in <a data-cite=
               "!HTML/#top-level-browsing-context">top-level browsing contexts.</a>
-              In iframes, whether or not the identifier is the same in documents
-              of the same origin or not, MUST follow the user agents'
-              partitioning rules for <a data-cite=
+              In <a data-cite=
+              "!HTML/#nested-browsing-context">nested browsing contexts</a>,
+              the decision of whether or not the identifier is the same across
+              documents, MUST follow the user agents' partitioning rules for
+              <a data-cite=
               "!HTML/#dom-localstorage"><code>localStorage</code></a>, if any,
               to not interfere with mitigations for cross-site correlation.
               The identifier SHOULD be origin-unique,


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/598. @annevk PTAL.