### PR TITLE
Use more consistent linking practices

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -46,39 +46,31 @@
     <dl>
       <dt><i>HTML Terms:</i></dt>
       <dd>
-        <p>The <code><dfn data-cite=
-        "!HTML/#eventhandler">EventHandler</dfn></code>
+        <p>The {{EventHandler}}
         interface represents a callback used for event handlers as defined in
         [[!HTML]].</p>
-        <p>The concept <dfn data-cite="!HTML/#queuing-tasks">queue
-        a task</dfn> is defined in [[!HTML]] and <dfn data-cite=
-        "!DOM/#concept-event-fire">fires a simple event</dfn> is 
+        <p>The concept [= queue
+        a task =] is defined in [[!HTML]] and [= fire an event =] is 
         defined in [[!DOM]].</p>
-        <p>The terms <dfn data-cite=
-        "!HTML/#eventhandler">event handlers</dfn>
-        and <dfn data-cite=
-        "!HTML/#responsible-document">responsible
-        document</dfn> are defined in [[!HTML]].</p>
-        <p>The term <dfn data-cite=
-        "!HTML/#current-settings-object">current settings
-        object</dfn> is defined in [[!HTML]].</p>
-        <p>The term <dfn data-cite=
-        "!HTML/#allowed-to-use">allowed to
-        use</dfn> is defined in [[!HTML]].</p>
+        <p>The terms [=event handlers=]
+        and [=environment settings object/responsible
+        document =] are defined in [[!HTML]].</p>
+        <p>The term [=current settings
+        object=] is defined in [[!HTML]].</p>
+        <p>The term [=allowed to
+        use=] is defined in [[!HTML]].</p>
         <p>The terms <dfn data-lt="fulfill|fulfillment">fulfilled</dfn>,
         <dfn data-lt="reject|rejection|rejecting">rejected</dfn> and
         <dfn data-lt="resolve">resolved</dfn> used in the context of Promises
         are defined in [[!ES6]].</p>
       </dd>
-      <dt><code><dfn>DOM</dfn></code></dt>
+      <dt>DOM</dt>
       <dd>
-	<p>The terms <dfn data-cite="!DOM#interface-event">Event</dfn>, <dfn>EventInit</dfn> and <dfn data-cite="!DOM#interface-eventtarget">EventTarget</dfn> are defined in the [[!DOM]] specification. </p>
+	<p>The terms {{Event}}, {{EventInit}} and {{EventTarget}} are defined in the [[!DOM]] specification. </p>
       </dd>
-      <dt><code><dfn>DOMException</dfn></code></dt>
+      <dt>{{DOMException}}</dt>
       <dd>
-        The term <code>DOMException</code> is defined in <a href=
-        "https://www.w3.org/TR/WebIDL-1/#idl-DOMException">WebIDL</a>
-        [[!WEBIDL-1]]
+        The term {{DOMException}} is defined in [[!WEBIDL]]
       </dd>
       <dt><dfn>source</dfn></dt>
       <dd>
@@ -100,7 +92,7 @@
         processing, such as downsampling, MAY be used to ensure that all tracks
         have appropriate media.</p>
         <p>Sources have constrainable properties which have
-        <code><a>capabilities</a></code> and <code><a>settings</a></code>
+        [=capabilities=] and [=settings=]
         exposed on tracks. While the constrainable properties are "owned" by
         the source, sources MAY be able to accomodate different demands at
         once. For this reason, capabilities are common to any (multiple) tracks
@@ -193,15 +185,15 @@
         application authors are strongly encouraged to use <a>required
         constraints</a> sparingly.</p>
       </dd>
-      <dt><code>RTCPeerConnection</code></dt>
-      <dd><dfn><code>RTCPeerConnection</code></dfn> is defined in
-      [[WEBRTC10]].</dd>
+      <dt><a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a></dt>
+      <dd><a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a> is defined in
+      [[WEBRTC]].</dd>
       <dt>Permissions</dt>
       <dd>
-        <p>The terms <dfn>permission</dfn>, <dfn>retrieve the permission
-        state</dfn>, <dfn id="request-permission-to-use">request permission to
-        use</dfn> and <dfn id="create-permission">create a permission storage
-        entry</dfn> are defined in [[!permissions]].</p>
+        <p>The terms [=permission=], [=retrieve the permission
+        state=], [=request permission to
+        use=] and [=create a permission storage
+        entry=] are defined in [[!permissions]].</p>
       </dd>
     </dl>
   </section>
@@ -211,72 +203,71 @@
       <h2>Introduction</h2>
       <p>The two main components in the MediaStream API are the
       <dfn>MediaStreamTrack</dfn> and <dfn>MediaStream</dfn> interfaces. The
-      <code><a>MediaStreamTrack</a></code> object represents media of a single
+      {{MediaStreamTrack}} object represents media of a single
       type that originates from one media source in the User Agent, e.g. video
-      produced by a web camera. A <code><a>MediaStream</a></code> is used to
-      group several <code><a>MediaStreamTrack</a></code> objects into one unit
+      produced by a web camera. A {{MediaStream}} is used to
+      group several {{MediaStreamTrack}} objects into one unit
       that can be recorded or rendered in a media element.</p>
-      <p>Each <code><a>MediaStream</a></code> can contain zero or more
-      <code><a>MediaStreamTrack</a></code> objects. All tracks in a
-      <code><a>MediaStream</a></code> are intended to be synchronized when
+      <p>Each {{MediaStream}} can contain zero or more
+      {{MediaStreamTrack}} objects. All tracks in a
+      {{MediaStream}} are intended to be synchronized when
       rendered. This is not a hard requirement, since it might not be possible
       to synchronize tracks from sources that have different clocks. Different
-      <code><a>MediaStream</a></code> objects do not need to be
+      {{MediaStream}} objects do not need to be
       synchronized.</p>
       <p class="note">While the intent is to synchronize tracks, it could be
       better in some circumstances to permit tracks to lose synchronization. In
-      particular, when tracks are remotely sourced and real-time [[WEBRTC10]],
+      particular, when tracks are remotely sourced and real-time [[WEBRTC]],
       it can be better to allow loss of synchronization than to accumulate
       delays or risk glitches and other artifacts. Implementations are expected
       to understand the implications of choices regarding synchronization of
       playback and the effect that these have on user perception.</p>
-      <p>A single <code><a>MediaStreamTrack</a></code> can represent
+      <p>A single {{MediaStreamTrack}} can represent
       multi-channel content, such as stereo or 5.1 audio or stereoscopic video,
       where the channels have a well defined relationship to each other.
       Information about channels might be exposed through other APIs, such as
       [[WEBAUDIO]], but this specification provides no direct access to
       channels.</p>
-      <p>A <code><a>MediaStream</a></code> object has an input and an output
+      <p>A {{MediaStream}} object has an input and an output
       that represent the combined input and output of all the object's tracks.
-      The output of the <code><a>MediaStream</a></code> controls how the object
+      The output of the {{MediaStream}} controls how the object
       is rendered, e.g., what is saved if the object is recorded to a file or
-      what is displayed if the object is used in a <code>video</code> element.
-      A single <code><a>MediaStream</a></code> object can be attached to
+      what is displayed if the object is used in a [^video^] element.
+      A single {{MediaStream}} object can be attached to
       multiple different outputs at the same time.</p>
-      <p>A new <code><a>MediaStream</a></code> object can be created from
+      <p>A new {{MediaStream}} object can be created from
       existing media streams or tracks using the
-      <code><a>MediaStream()</a></code> constructor. The constructor argument
-      can either be an existing <code><a>MediaStream</a></code> object, in
+      {{MediaStream/MediaStream()}} constructor. The constructor argument
+      can either be an existing {{MediaStream}} object, in
       which case all the tracks of the given stream are added to the new
-      <code><a>MediaStream</a></code> object, or an array of
-      <code><a>MediaStreamTrack</a></code> objects. The latter form makes it
+      {{MediaStream}} object, or an array of
+      {{MediaStreamTrack}} objects. The latter form makes it
       possible to compose a stream from different source streams.</p>
-      <p>Both <code><a>MediaStream</a></code> and
-      <code><a>MediaStreamTrack</a></code> objects can be cloned. A cloned
-      <code><a>MediaStream</a></code> contains clones of all member tracks from
-      the original stream. A cloned <code><a>MediaStreamTrack</a></code> has a
+      <p>Both {{MediaStream}} and
+      {{MediaStreamTrack}} objects can be cloned. A cloned
+      {{MediaStream}} contains clones of all member tracks from
+      the original stream. A cloned {{MediaStreamTrack}} has a
       <a href="#constrainable-interface">set of constraints</a> that is
       independent of the instance it is cloned from, which allows media from
       the same source to have different constraints applied for different
-      <a>consumer</a>s. The <code>MediaStream</code> object is also used in
-      contexts outside <code>getUserMedia</code>, such as [[WEBRTC10]].</p>
+      <a>consumer</a>s. The {{MediaStream}} object is also used in
+      contexts outside {{MediaDevices/getUserMedia}}, such as [[WEBRTC]].</p>
     </section>
     <section>
       <h2>MediaStream</h2>
-      <p>The <dfn><code>MediaStream()</code></dfn> constructor composes a new
+      <p id=
+      "mediastream-constructor">The MediaStream <dfn data-idl data-dfn-for=MediaStream>constructor</dfn> composes a new
       stream out of existing tracks. It takes an optional argument of type
-      <code><a>MediaStream</a></code> or an array of
-      <code><a>MediaStreamTrack</a></code> objects. <dfn id=
-      "mediastream-constructor">When the constructor is invoked</dfn>, the User
+      {{MediaStream}} or an array of
+      {{MediaStreamTrack}} objects. When the constructor is invoked, the User
       Agent must run the following steps:</p>
       <ol>
         <li>
           <p>Let <var>stream</var> be a newly constructed
-          <code><a>MediaStream</a></code> object.</p>
+          {{MediaStream}} object.</p>
         </li>
         <li>
-          <p>Initialize <var>stream's</var> <code><a href=
-          "#dom-mediastream-id">id</a></code> attribute to a newly generated
+          <p>Initialize <var>stream</var>.{{MediaStream/id}}  attribute to a newly generated
           value.</p>
         </li>
         <li>
@@ -288,23 +279,23 @@
               of argument:</p>
               <ul>
                 <li>
-                  <p>A <code><a>MediaStream</a></code> object:</p>
+                  <p>A {{MediaStream}} object:</p>
                   <p>Let <var>tracks</var> be a set containing all the
-                  <code><a>MediaStreamTrack</a></code> objects in the
-                  <code><a>MediaStream</a></code> <a href="#track-set">track
+                  {{MediaStreamTrack}} objects in the
+                  {{MediaStream}} <a href="#track-set">track
                   set</a>.</p>
                 </li>
                 <li>
-                  <p>A sequence of <code><a>MediaStreamTrack</a></code>
+                  <p>A sequence of {{MediaStreamTrack}}
                   objects:</p>
                   <p>Let <var>tracks</var> be a set containing all the
-                  <code><a>MediaStreamTrack</a></code> objects in the provided
+                  {{MediaStreamTrack}} objects in the provided
                   sequence.</p>
                 </li>
               </ul>
             </li>
             <li>
-              <p>For each <code><a>MediaStreamTrack</a></code>,
+              <p>For each {{MediaStreamTrack}},
               <var>track</var> , in <var>tracks</var>, run the following
               steps:</p>
               <ol>
@@ -325,51 +316,49 @@
           <p>Return <var>stream</var>.</p>
         </li>
       </ol>
-      <p>The tracks of a <code><a>MediaStream</a></code> are stored in a
+      <p>The tracks of a {{MediaStream}} are stored in a
       <dfn id="track-set">track set</dfn>. The track set MUST contain the
-      <code><a>MediaStreamTrack</a></code> objects that correspond to the
+      {{MediaStreamTrack}} objects that correspond to the
       tracks of the stream. The relative order of the tracks in the set is User
       Agent defined and the API will never put any requirements on the order.
-      The proper way to find a specific <code><a>MediaStreamTrack</a></code>
-      object in the set is to look it up by its <code><a href=
-      "#dom-mediastreamtrack-id">id</a></code>.</p>
+      The proper way to find a specific {{MediaStreamTrack}}
+      object in the set is to look it up by its {{MediaStreamTrack/id}}.</p>
       <p>An object that reads data from the output of a
-      <code><a>MediaStream</a></code> is referred to as a
-      <code><a>MediaStream</a></code> <dfn>consumer</dfn>. The list of
-      <code><a>MediaStream</a></code> consumers currently include media
-      elements (such as <code>&lt;video&gt;</code> and
-      <code>&lt;audio&gt;</code>) [[HTML52]], Web Real-Time Communications
-      (WebRTC; <code>RTCPeerConnection</code>) [[WEBRTC10]], media recording
-      (<code>MediaRecorder</code>) [[mediastream-recording]], image capture
-      (<code>ImageCapture</code>) [[image-capture]], and web audio
-      (<code>MediaStreamAudioSourceNode</code>) [[WEBAUDIO]].</p>
-      <p class="note"><code><a>MediaStream</a></code> consumers must be able to
+      {{MediaStream}} is referred to as a
+      {{MediaStream}} <dfn>consumer</dfn>. The list of
+      {{MediaStream}} consumers currently include media
+      elements (such as [^video^] and
+      [^audio^]) [[HTML]], Web Real-Time Communications
+      (WebRTC; <code class=fixme>RTCPeerConnection</code>) [[WEBRTC]], media recording
+      (<code class=fixme>MediaRecorder</code>) [[mediastream-recording]], image capture
+      (<code class=fixme>ImageCapture</code>) [[image-capture]], and web audio
+      ({{MediaStreamAudioSourceNode}}) [[WEBAUDIO]].</p>
+      <p class="note">{{MediaStream}} consumers must be able to
       handle tracks being added and removed. This behavior is specified per
       consumer.</p>
-      <p>A <code><a>MediaStream</a></code> object is said to be <dfn id=
+      <p>A {{MediaStream}} object is said to be <dfn id=
       "stream-active">active</dfn> when it has at least one
-      <code><a>MediaStreamTrack</a></code> that has not <a href=
-      "#track-ended">ended</a>. A <code><a>MediaStream</a></code> that does not
+      {{MediaStreamTrack}} that has not <a href=
+      "#track-ended">ended</a>. A {{MediaStream}} that does not
       have any tracks or only has tracks that are <a href=
       "#track-ended">ended</a> is <dfn id="stream-inactive">inactive</dfn>.</p>
-      <p>A <code><a>MediaStream</a></code> object is said to be <dfn id=
+      <p>A {{MediaStream}} object is said to be <dfn id=
       "stream-audible">audible</dfn> when it has at least one
-      <code><a>MediaStreamTrack</a></code> whose <code><a href=
-      "#dom-mediastreamtrack-kind">kind</a></code> is "<code>audio</code>" that
-      has not <a href="#track-ended">ended</a>. A
-      <code><a>MediaStream</a></code> that does not have any audio tracks or
-      only has audio tracks that are <a href="#track-ended">ended</a> is
+      {{MediaStreamTrack}} whose {{MediaStreamTrack/kind}} is <a>"audio"</a> that
+      has not <a data-lt="track ended state">ended</a>. A
+      {{MediaStream}} that does not have any audio tracks or
+      only has audio tracks that are <a data-lt="track ended state">ended</a> is
       <dfn id="stream-inaudible">inaudible</dfn>.</p>
-      <p>The User Agent may update a <code><a>MediaStream</a></code>'s <a href=
+      <p>The User Agent may update a {{MediaStream}}'s <a href=
       "#track-set">track set</a> in response to, for example, an external
       event. This specification does not specify any such cases, but other
       specifications using the MediaStream API may. One such example is the
-      WebRTC 1.0 [[WEBRTC10]] specification where the <a href=
-      "#track-set">track set</a> of a <code><a>MediaStream</a></code>, received
+      WebRTC 1.0 [[WEBRTC]] specification where the <a href=
+      "#track-set">track set</a> of a {{MediaStream}}, received
       from another peer, can be updated as a result of changes to the media
       session.</p>
       <p>To <dfn id="add-track">add a track</dfn> <var>track</var> to a
-      <code><a>MediaStream</a></code> <var>stream</var>, the User Agent MUST
+      {{MediaStream}} <var>stream</var>, the User Agent MUST
       run the following steps:</p>
       <ol>
         <li>
@@ -381,13 +370,12 @@
           "#track-set">track set</a>.</p>
         </li>
         <li>
-          <p>Fire a track event named <code><a href=
-          "#event-mediastream-addtrack">addtrack</a></code> with
+          <p>Fire a track event named {{addtrack}} with
           <var>track</var> at <var>stream</var>.</p>
         </li>
       </ol>
       <p>To <dfn id="remove-track">remove a track</dfn> <var>track</var> from a
-      <code><a>MediaStream</a></code> <var>stream</var>, the User Agent MUST
+      {{MediaStream}} <var>stream</var>, the User Agent MUST
       run the following steps:</p>
       <ol>
         <li>
@@ -399,8 +387,7 @@
           "#track-set">track set</a>.</p>
         </li>
         <li>
-          <p>Fire a track event named <code><a href=
-          "#event-mediastream-removetrack">removetrack</a></code> with
+          <p>Fire a track event named {{removetrack}} with
           <var>track</var> at <var>stream</var>.</p>
         </li>
       </ol>
@@ -427,7 +414,7 @@ interface MediaStream : EventTarget {
           <h2>Constructors</h2>
           <dl data-link-for="MediaStream" data-dfn-for="MediaStream" class=
           "constructors">
-            <dt><code>MediaStream</code></dt>
+            <dt>{{MediaStream}}</dt>
             <dd>
               <p>See the <a href="#mediastream-constructor">MediaStream
               constructor algorithm</a></p>
@@ -435,12 +422,12 @@ interface MediaStream : EventTarget {
                 <em>No parameters.</em>
               </div>
             </dd>
-            <dt><code>MediaStream</code></dt>
+            <dt>{{MediaStream}}</dt>
             <dd>
               <p>See the <a href="#mediastream-constructor">MediaStream
               constructor algorithm</a></p>
             </dd>
-            <dt><code>MediaStream</code></dt>
+            <dt>{{MediaStream}}</dt>
             <dd>
               <p>See the <a href="#mediastream-constructor">MediaStream
               constructor algorithm</a></p>
@@ -451,41 +438,35 @@ interface MediaStream : EventTarget {
           <h2>Attributes</h2>
           <dl data-link-for="MediaStream" data-dfn-for="MediaStream" class=
           "attributes">
-            <dt><code>id</code> of type <span class=
-            "idlAttrType">DOMString</span>, readonly</dt>
+            <dt>{{id}} of type {{DOMString}}, readonly</dt>
             <dd>
-              <p>When a <code><a>MediaStream</a></code> is created, the User
+              <p>When a {{MediaStream}} is created, the User
               Agent MUST generate an identifier string, and MUST initialize the
-              object's <code><a href="#dom-mediastream-id">id</a></code>
+              object's {{id}}
               attribute to that string, unless the object is created as part of
               a special purpose algorithm that specifies how the stream id must
               be initialized. A good practice is to use a UUID [[rfc4122]],
               which is 36 characters long in its canonical form. To avoid
               fingerprinting, implementations SHOULD use the forms in section
               4.4 or 4.5 of RFC 4122 when generating UUIDs.</p>
-              <p>The <dfn data-idl><code>id</code></dfn> attribute MUST return
+              <p>The <dfn data-idl>id</dfn> attribute MUST return
               the value to which it was initialized when the object was
               created.</p>
             </dd>
-            <dt><dfn><code>active</code></dfn> of type <span class=
-            "idlAttrType">boolean</span>, readonly</dt>
+            <dt><dfn>active</dfn> of type {{boolean}}, readonly</dt>
             <dd>
-              <p>The <code>active</code> attribute MUST return
-              <code>true</code> if this <code><a>MediaStream</a></code> is
-              <a href="#stream-active">active</a> and <code>false</code>
+              <p>The {{active}} attribute MUST return
+              <code>true</code> if this {{MediaStream}} is
+              [= active =] and <code>false</code>
               otherwise.</p>
             </dd>
-            <dt><dfn><code>onaddtrack</code></dfn> of type <span class=
-            "idlAttrType"><a>EventHandler</a></span></dt>
+            <dt><dfn>onaddtrack</dfn> of type {{EventHandler}}</dt>
             <dd>
-              <p>The event type of this event handler is <code><a href=
-              "#event-mediastream-addtrack">addtrack</a></code>.</p>
+              <p>The event type of this event handler is {{addtrack}}.</p>
             </dd>
-            <dt><dfn><code>onremovetrack</code></dfn> of type <span class=
-            "idlAttrType"><a>EventHandler</a></span></dt>
+            <dt><dfn>onremovetrack</dfn> of type {{EventHandler}}</dt>
             <dd>
-              <p>The event type of this event handler is <code><a href=
-              "#event-mediastream-removetrack">removetrack</a></code>.</p>
+              <p>The event type of this event handler is {{removetrack}}.</p>
             </dd>
           </dl>
         </section>
@@ -493,119 +474,112 @@ interface MediaStream : EventTarget {
           <h2>Methods</h2>
           <dl data-link-for="MediaStream" data-dfn-for="MediaStream" class=
           "methods">
-            <dt><dfn id="dom-mediastream-getaudiotracks"><code>getAudioTracks</code></dfn></dt>
+            <dt><dfn id="dom-mediastream-getaudiotracks">getAudioTracks</dfn></dt>
             <dd>
-              <p>Returns a sequence of <code><a>MediaStreamTrack</a></code>
+              <p>Returns a sequence of {{MediaStreamTrack}}
               objects representing the audio tracks in this stream.</p>
-              <p>The <code>getAudioTracks</code>
+              <p>The {{getAudioTracks}}
               method MUST return a sequence that represents a snapshot of all
-              the <code><a>MediaStreamTrack</a></code> objects in this stream's
-              <a href="#track-set">track set</a> whose <code><a href=
-              "#dom-mediastreamtrack-kind">kind</a></code> is equal to
-              "<code>audio</code>". The conversion from the <a href=
-              "#track-set">track set</a> to the sequence is User Agent defined
+              the {{MediaStreamTrack}} objects in this stream's
+              [=track set=] whose {{MediaStreamTrack/kind}} is equal to
+              <a>"audio"</a>. The conversion from the [=track set=] to the sequence is User Agent defined
               and the order does not have to be stable between calls.</p>
             </dd>
-            <dt><dfn id="dom-mediastream-getvideotracks"><code>getVideoTracks</code></dfn></dt>
+            <dt><dfn id="dom-mediastream-getvideotracks">getVideoTracks</dfn></dt>
             <dd>
-              <p>Returns a sequence of <code><a>MediaStreamTrack</a></code>
+              <p>Returns a sequence of {{MediaStreamTrack}}
               objects representing the video tracks in this stream.</p>
-              <p>The <code>getVideoTracks</code>
+              <p>The {{getVideoTracks}}
               method MUST return a sequence that represents a snapshot of all
-              the <code><a>MediaStreamTrack</a></code> objects in this stream's
-              <a href="#track-set">track set</a> whose <code><a href=
-              "#dom-mediastreamtrack-kind">kind</a></code> is equal to
-              "<code>video</code>". The conversion from the <a href=
-              "#track-set">track set</a> to the sequence is User Agent defined
+              the {{MediaStreamTrack}} objects in this stream's
+              [=track set=] whose {{MediaStreamTrack/kind}} is equal to
+              <a>"video"</a>. The conversion from the
+              [=track set=] to the sequence is User Agent defined
               and the order does not have to be stable between calls.</p>
             </dd>
-            <dt><dfn id="dom-mediastream-gettracks"><code>getTracks</code></dfn></dt>
+            <dt><dfn id="dom-mediastream-gettracks">getTracks</dfn></dt>
             <dd>
-              <p>Returns a sequence of <code><a>MediaStreamTrack</a></code>
+              <p>Returns a sequence of {{MediaStreamTrack}}
               objects representing all the tracks in this stream.</p>
-              <p>The <code>getTracks</code> method
+              <p>The {{getTracks}} method
               MUST return a sequence that represents a snapshot of all the
-              <code><a>MediaStreamTrack</a></code> objects in this stream's
-              <a href="#track-set">track set</a>, regardless of <code><a href=
-              "#dom-mediastreamtrack-kind">kind</a></code>. The conversion from
-              the <a href="#track-set">track set</a> to the sequence is User
+              {{MediaStreamTrack}} objects in this stream's
+              [=track set=], regardless of
+              {{MediaStreamTrack/kind}}. The conversion from
+              the [=track set=] to the sequence is User
               Agent defined and the order does not have to be stable between
               calls.</p>
             </dd>
-            <dt><dfn id="dom-mediastream-gettrackbyid"><code>getTrackById</code></dfn></dt>
+            <dt><dfn id="dom-mediastream-gettrackbyid">getTrackById</dfn></dt>
             <dd>
-              <p>The <code>getTrackById</code>
-              method MUST return either a <code><a>MediaStreamTrack</a></code>
-              object from this stream's <a href="#track-set">track set</a>
-              whose <code><a href="#dom-mediastreamtrack-id">id</a></code> is
-              equal to <var>trackId</var>, or null, if no such track
+              <p>The {{getTrackById}}
+              method MUST return either a {{MediaStreamTrack}}
+              object from this stream's [=track set=]
+              whose {{MediaStreamTrack/id}} is
+              equal to <var>trackId</var>, or <code>null</code>, if no such track
               exists.</p>
             </dd>
-            <dt><dfn id="dom-mediastream-addtrack"><code>addTrack</code></dfn></dt>
+            <dt><dfn id="dom-mediastream-addtrack">addTrack</dfn></dt>
             <dd>
-              <p>Adds the given <code><a>MediaStreamTrack</a></code> to this
-              <code><a>MediaStream</a></code>.</p>
-              <p>When the <code>addTrack</code> method is
+              <p>Adds the given {{MediaStreamTrack}} to this
+              {{MediaStream}}.</p>
+              <p>When the {{addTrack}} method is
               invoked, the User Agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>track</var> be the methods argument and
-                  <var>stream</var> the <code><a>MediaStream</a></code> object
+                  <var>stream</var> the {{MediaStream}} object
                   on which the method was called.</p>
                 </li>
                 <li>
                   <p>If <var>track</var> is already in <var>stream</var>'s
-                  <a href="#track-set">track set</a>, then abort these
+                  [=track set=], then abort these
                   steps.</p>
                 </li>
                 <li>
-                  <p>Add <var>track</var> to <var>stream</var>'s <a href=
-                  "#track-set">track set</a>.</p>
+                  <p>Add <var>track</var> to <var>stream</var>'s [=track set=].</p>
                 </li>
               </ol>
             </dd>
-            <dt><dfn id="dom-mediastream-removetrack"><code>removeTrack</code></dfn></dt>
+            <dt><dfn id="dom-mediastream-removetrack">removeTrack</dfn></dt>
             <dd>
-              <p>Removes the given <code><a>MediaStreamTrack</a></code> object
-              from this <code><a>MediaStream</a></code>.</p>
-              <p>When the <code>removeTrack</code>
+              <p>Removes the given {{MediaStreamTrack}} object
+              from this {{MediaStream}}.</p>
+              <p>When the {{removeTrack}}
               method is invoked, the User Agent MUST run the following
               steps:</p>
               <ol>
                 <li>
                   <p>Let <var>track</var> be the methods argument and
-                  <var>stream</var> the <code><a>MediaStream</a></code> object
+                  <var>stream</var> the {{MediaStream}} object
                   on which the method was called.</p>
                 </li>
                 <li>
-                  <p>If <var>track</var> is not in <var>stream's</var> <a href=
-                  "#track-set">track set</a>, then abort these steps.</p>
+                  <p>If <var>track</var> is not in <var>stream's</var> [=track set=], then abort these steps.</p>
                 </li>
                 <li>
-                  <p>Remove <var>track</var> from <var>stream</var>'s <a href=
-                  "#track-set">track set</a>.</p>
+                  <p>Remove <var>track</var> from <var>stream</var>'s [=track set=].</p>
                 </li>
               </ol>
             </dd>
-            <dt><dfn><code>clone</code></dfn></dt>
+            <dt><dfn>clone</dfn></dt>
             <dd>
-              <p>Clones the given <code><a>MediaStream</a></code> and all its
+              <p>Clones the given {{MediaStream}} and all its
               tracks.</p>
-              <p>When the <code>clone()</code> method is invoked, the User
+              <p>When the {{clone()}} method is invoked, the User
               Agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>streamClone</var> be a newly constructed
-                  <code><a>MediaStream</a></code> object.</p>
+                  {{MediaStream}} object.</p>
                 </li>
                 <li>
-                  <p>Initialize <var>streamClone</var>'s <code><a href=
-                  "#dom-mediastream-id">id</a></code> attribute to a newly
+                  <p>Initialize <var>streamClone</var>.{{MediaStream.id}} to a newly
                   generated value.</p>
                 </li>
                 <li>
                   <p><a href="#track-clone">Clone each track</a> in this
-                  <code><a>MediaStream</a></code> object and add the result to
+                  {{MediaStream}} object and add the result to
                   <var>streamClone</var>'s <a href="#track-set">track
                   set</a>.</p>
                 </li>
@@ -618,40 +592,39 @@ interface MediaStream : EventTarget {
     </section>
     <section>
       <h2>MediaStreamTrack</h2>
-      <p>A <code><a>MediaStreamTrack</a></code> object represents a media
+      <p>A {{MediaStreamTrack}} object represents a media
       source in the User Agent. An example source is a device connected to the
       User Agent. Other specifications may define sources for
-      <code><a>MediaStreamTrack</a></code> that override the behavior specified
-      here. Several <code><a>MediaStreamTrack</a></code> objects can represent
+      {{MediaStreamTrack}} that override the behavior specified
+      here. Several {{MediaStreamTrack}} objects can represent
       the same media source, e.g., when the user chooses the same camera in the
-      UI shown by two consecutive calls to <code><a data-link-for=
-      "MediaDevices">getUserMedia()</a></code> .</p>
-      <p>The data from a <code><a>MediaStreamTrack</a></code> object does not
+      UI shown by two consecutive calls to {{MediaDevices/getUserMedia()}}.</p>
+      <p>The data from a {{MediaStreamTrack}} object does not
       necessarily have a canonical binary form; for example, it could just be
       "the video currently coming from the user's video camera". This allows
       User Agents to manipulate media in whatever fashion is most suitable on
       the user's platform.</p>
-      <p>A script can indicate that a <code><a>MediaStreamTrack</a></code>
-      object no longer needs its source with the <code><a href=
-      "#dom-mediastreamtrack-stop">stop()</a></code> method. When all tracks
+      <p>A script can indicate that a {{MediaStreamTrack}}
+      object no longer needs its source with the {{MediaStreamTrack/stop()}}
+      method. When all tracks
       using a source have been stopped or ended by some other means, the source
-      is <dfn id="source-stopped">stopped</dfn>. If the source is a device
-      exposed by <a data-link-for="MediaDevices">getUserMedia()</a>, then when
+      is <dfn id="source-stopped" data-lt="source stopped state">stopped</dfn>. If the source is a device
+      exposed by {{MediaDevices/getUserMedia()}}, then when
       the source is stopped, the UA MUST run the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>deviceId</var> be the device's deviceId.</p>
+          <p>Let <var>deviceId</var> be the device's {{MediaDeviceInfo/deviceId}}.</p>
         </li>
         <li>
-          <p>Set [[\devicesLiveMap]]</a><var>[deviceId]</var> to
+          <p>Set <a>[[\devicesLiveMap]]</a>[<var>deviceId</var>] to
           <code>false</code>.</p>
         </li>
         <li>
           <p>If the result of <a data-lt=
           "retrieve the permission state">retrieving the permission state</a>
           of the permission associated with the device's kind and
-          <var>deviceId</var>, is not “granted”, then set
-          [[\devicesAccessibleMap]]</a><var>[deviceId]</var> to
+          <var>deviceId</var>, is not {{PermissionState/"granted"}}, then set
+          <a>[[\devicesAccessibleMap]]</a>[<var>deviceId</var>] to
           <code>false</code>.</p>
         </li>
       </ol>
@@ -662,24 +635,23 @@ interface MediaStream : EventTarget {
       the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>track</var> be the <code><a>MediaStreamTrack</a></code>
+          <p>Let <var>track</var> be the {{MediaStreamTrack}}
           object to be cloned.</p>
         </li>
         <li>
           <p>Let <var>trackClone</var> be a newly constructed
-          <code><a>MediaStreamTrack</a></code> object.</p>
+          {{MediaStreamTrack}} object.</p>
         </li>
         <li>
-          <p>Initialize <var>trackClone</var>'s <code><a href=
-          "#dom-mediastreamtrack-id">id</a></code> attribute to a newly
+          <p>Initialize <var>trackClone</var>.{{MediaStreamTrack/id}}
+          to a newly
           generated value.</p>
         </li>
         <li>
-          <p>Initialize <var>trackClone</var>'s <code><a href=
-          "#dom-mediastreamtrack-kind">kind</a></code>, <code><a href=
-          "#dom-mediastreamtrack-label">label</a></code>, <code><a href=
-          "#dom-mediastreamtrack-readystate">readyState</a></code>, and
-          <code><a href="#dom-mediastreamtrack-enabled">enabled</a></code>
+          <p>Initialize <var>trackClone</var>'s {{MediaStreamTrack/kind}},
+            {{MediaStreamTrack/label}},
+          {{MediaStreamTrack/readyState}}, and
+          {{MediaStreamTrack/enabled}}
           attributes by copying the corresponding values from
           <var>track</var>.</p>
         </li>
@@ -698,50 +670,49 @@ interface MediaStream : EventTarget {
       <section>
         <h3>Life-cycle and Media Flow</h3>
         <h4>Life-cycle</h4>
-        <p>A <code><a>MediaStreamTrack</a></code> has two states in its
-        life-cycle: <code>live</code> and <code>ended</code>. A newly created
-        <code><a>MediaStreamTrack</a></code> can be in either state depending
+        <p>A {{MediaStreamTrack}} has two states in its
+        life-cycle: live and ended. A newly created
+        {{MediaStreamTrack}} can be in either state depending
         on how it was created. For example, cloning an ended track results in a
         new ended track. The current state is reflected by the object's
-        <code><a href="#dom-mediastreamtrack-readystate">readyState</a></code>
+        {{MediaStreamTrack/readyState}}
         attribute.</p>
-        <p>In the <code>live</code> state, the track is active and media is
+        <p>In the live state, the track is active and media is
         available for use by consumers (but may be replaced by
-        zero-information-content if the <code><a>MediaStreamTrack</a></code> is
-        <a href="#track-muted">muted</a> or <a href=
-        "#track-enabled">disabled</a>, see below).</p>
-        <p>A muted or disabled <code><a>MediaStreamTrack</a></code> renders
+        zero-information-content if the {{MediaStreamTrack}} is
+        <a>muted</a> or <a data-lt=enabled>disabled</a>, see below).</p>
+        <p>A muted or disabled {{MediaStreamTrack}} renders
         either silence (audio), black frames (video), or a
         zero-information-content equivalent. For example, a video element
-        sourced by a muted or disabled <code><a>MediaStreamTrack</a></code>
-        (contained within a <code><a>MediaStream</a></code> ), is playing but
+        sourced by a muted or disabled {{MediaStreamTrack}}
+        (contained within a {{MediaStream}} ), is playing but
         the rendered content is the muted output.</p>
-        <p>If the source is a device exposed by <a data-link-for=
-        "MediaDevices">getUserMedia()</a>, then when a track becomes either
+        <p>If the source is a device exposed by {{MediaDevices/getUserMedia()}},
+        then when a track becomes either
         muted or disabled, and this brings all tracks connected to the device
         to be either muted, disabled, or stopped, then the UA MAY, using the
-        device's deviceId, <var>deviceId</var>, set
-        [[\devicesLiveMap]]</a><var>[deviceId]</var> to <code>false</code>,
+        device's {{MediaDeviceInfo/deviceId}}, <var>deviceId</var>, set
+        <a>[[\devicesLiveMap]]</a>[<var>deviceId</var>] to <code>false</code>,
         provided the UA sets it back to <code>true</code> as soon as any
         unstopped track connected to this device becomes un-muted or enabled
         again.</p>
-        <p>When a <code>live</code>, <a href="#track-muted">unmuted</a>, and
-        <a href="#track-enabled">enabled</a> track sourced by a device exposed
-        by <a data-link-for="MediaDevices">getUserMedia()</a> becomes either
-        <a href="#track-muted">muted</a> or <a href="#track-enabled">disabled</a>,
+        <p>When a live, <a data-lt="muted">unmuted</a>, and
+        <a>enabled</a> track sourced by a device exposed
+        by {{MediaDevices/getUserMedia()}} becomes either
+        <a>muted</a> or <a data-lt="enabled">disabled</a>,
         and this brings <em>all</em> tracks connected to the device (regardless
         of browsing context) to be either
         muted, disabled, or stopped, then the UA SHOULD relinquish the device
         within 3 seconds while allowing time for a reasonably-observant user to
         become aware of the transition. The UA SHOULD attempt to reacquire the
-        device as soon as any <code>live</code> track sourced by the device
-        becomes both <a href="#track-muted">unmuted</a> and
-        <a href="#track-enabled">enabled</a> again, provided that track's
-        <a>current settings object</a>'s <a>responsible document</a>
+        device as soon as any live track sourced by the device
+        becomes both <a data-lt=muted>unmuted</a> and
+        <a>enabled</a> again, provided that track's
+        <a>current settings object</a>'s [=environment settings object/responsible document=]
         <a data-cite="!HTML/#gains-focus">has focus</a> at that time. If the
         document does not <a data-cite="!HTML/#gains-focus">have focus</a> at that time,
-        the UA SHOULD instead queue a task to <a href="#track-muted">mute</a> the
-        track, and not queue a task to <a href="#track-muted">unmute</a> it until
+        the UA SHOULD instead queue a task to <a data-lt=muted>mute</a> the
+        track, and not queue a task to <a data-lt=muted>unmute</a> it until
         the document <a data-cite="!HTML/#gains-focus">regains focus</a>.
         If reacquiring the device fails, the UA MUST
         <a href="#ends-nostop">end the track</a> (The UA MAY end it earlier
@@ -760,9 +731,9 @@ interface MediaStream : EventTarget {
         provides any media at this moment. The enabled/disabled state is under
         application control and determines whether the track outputs media (to
         its consumers). Hence, media from the source only flows when a
-        <code><a>MediaStreamTrack</a></code> object is both unmuted and
+        {{MediaStreamTrack}} object is both unmuted and
         enabled.</p>
-        <p>A <code><a>MediaStreamTrack</a></code> is <a href=
+        <p>A {{MediaStreamTrack}} is <a href=
         "#track-muted">muted</a> when the source is temporarily unable to
         provide the track with data. A track can be muted by a user. Often this
         action is outside the control of the application. This could be as a
@@ -770,73 +741,65 @@ interface MediaStream : EventTarget {
         the operating system / browser chrome. A track can also be muted by the
         User Agent.</p>
         <p>Applications are able to <a href="#track-enabled">enable</a> or
-        disable a <code><a>MediaStreamTrack</a></code> to prevent it from
+        disable a {{MediaStreamTrack}} to prevent it from
         rendering media from the source. A muted track will however, regardless
         of the enabled state, render silence and blackness. A disabled track is
         logically equivalent to a muted track, from a consumer point of
         view.</p>
-        <p>For a newly created <code><a>MediaStreamTrack</a></code> object, the
+        <p>For a newly created {{MediaStreamTrack}} object, the
         following applies. The track is always enabled unless stated otherwise
         (for example when cloned) and the muted state reflects the state of the
         source at the time the track is created.</p>
-        <p>A <code><a>MediaStreamTrack</a></code> object is said to
+        <p>A {{MediaStreamTrack}} object is said to
         <em>end</em> when the source of the track is disconnected or
         exhausted.</p>
-        <p>If all <code><a>MediaStreamTrack</a></code>s that are using the same
-        source are <a href="#track-ended">ended</a>, the source will be
+        <p>If all {{MediaStreamTrack}}s that are using the same
+        source are <a data-lt="track ended state">ended</a>, the source will be
         <a href="#source-stopped">stopped</a>.</p>
-        <p>When a <code><a>MediaStreamTrack</a></code> object ends for any
+        <p>When a {{MediaStreamTrack}} object ends for any
         reason (e.g., because the user rescinds the permission for the page to
         use the local camera, or because the application invoked the
-        <code><a href="#dom-mediastreamtrack-stop">stop()</a></code> method on
-        the <code><a>MediaStreamTrack</a></code> object, or because the User
+        {{MediaStreamTrack/stop()}} method on
+        the {{MediaStreamTrack}} object, or because the User
         Agent has instructed the track to end for any reason) it is said to be
-        <dfn id="track-ended">ended</dfn>.</p>
-        <p>When a <code><a>MediaStreamTrack</a></code> <var>track</var>
-        <dfn id="ends-nostop">ends for any reason other than the <code><a href=
-        "#dom-mediastreamtrack-stop">stop()</a></code> method being
+        <dfn id="track-ended" data-lt="track ended state">ended</dfn>.</p>
+        <p>When a {{MediaStreamTrack}} <var>track</var>
+        <dfn id="ends-nostop">ends for any reason other than the {{MediaStreamTrack/stop()}} method being
         invoked</dfn>, the User Agent MUST queue a task that runs the following
         steps:</p>
         <ol>
           <li>
-            <p>If the <var>track's</var> <code><a href=
-            "#dom-mediastreamtrack-readystate">readyState</a></code> attribute
-            has the value <code>ended</code> already, then abort these
+            <p>If <var>track</var>.{{MediaStreamTrack/readyState}}
+            has the value {{MediaStreamTrackState/"ended"}} already, then abort these
             steps.</p>
           </li>
           <li>
-            <p>Set <var>track's</var> <code><a href=
-            "#dom-mediastreamtrack-readystate">readyState</a></code> attribute
-            to <code>ended</code>.</p>
+            <p>Set <var>track</var>.{{MediaStreamTrack/readyState}}
+            to {{MediaStreamTrackState/"ended"}}.</p>
           </li>
           <li>
             <p>Notify <var>track</var>'s source that <var>track</var> is
-            <a href="#track-ended">ended</a> so that the source may be <a href=
-            "#source-stopped">stopped</a>, unless other
-            <code><a>MediaStreamTrack</a></code> objects depend on it.</p>
+            <a data-lt="track ended state">ended</a> so that the source may be <a>stopped</a>, unless other
+            {{MediaStreamTrack}} objects depend on it.</p>
           </li>
           <li>
-            <p>Fire a simple event named <code><a href=
-            "#event-mediastreamtrack-ended">ended</a></code> at the object.</p>
+            <p>[=Fire an event=] named <a data-lt="ended event">ended</a> at the object.</p>
           </li>
         </ol>
         <p>If the end of the track was reached due to a user request, the event
         source for this event is the user interaction event source.</p>
         <h4>Media Flow</h4>
         <p>There are two dimensions related to the media flow for a
-        <code>live</code> <code><a>MediaStreamTrack</a></code> : muted / not
+        {{MediaStreamTrackState/"live"}} {{MediaStreamTrack}} : muted / not
         muted, and enabled / disabled.</p>
-        <p><dfn data-lt-nodefault="" data-lt="track-muted" id=
+        <p><dfn data-lt="track muted state" id=
         "track-muted">Muted</dfn> refers to the input to the
-        <code><a>MediaStreamTrack</a></code>. If live samples are not made
-        available to the <code><a>MediaStreamTrack</a></code> it is muted.</p>
+        {{MediaStreamTrack}}. If live samples are not made
+        available to the {{MediaStreamTrack}} it is muted.</p>
         <p>Muted is out of control for the application, but can be observed by
-        the application by reading the <code><a href=
-        "#dom-mediastreamtrack-muted">muted</a></code> attribute and listening
-        to the associated events <code><a href=
-        "#event-mediastreamtrack-mute">mute</a></code> and <code><a href=
-        "#event-mediastreamtrack-unmute">unmute</a></code>. There can be
-        several reasons for a <code><a>MediaStreamTrack</a></code> to be muted:
+        the application by reading the {{MediaStreamTrack/muted}} attribute and listening
+        to the associated events {{mute}} and {{unmute}}. There can be
+        several reasons for a {{MediaStreamTrack}} to be muted:
         the user pushing a physical mute button on the microphone, the user
         toggling a control in the operating system, the user clicking a mute
         button in the browser chrome, the User Agent (on behalf of the user)
@@ -848,44 +811,44 @@ interface MediaStream : EventTarget {
         <var>newState</var>, the User Agent MUST run the following steps:</p>
         <ol>
           <li>
-            <p>Let <var>track</var> be the <code>MediaStreamTrack</code> in
+            <p>Let <var>track</var> be the {{MediaStreamTrack}} in
             question.</p>
           </li>
           <li>
-            <p>Set <var>track</var>'s <code>muted</code> attribute to
+            <p>Set <var>track</var>.{{MediaStreamTrack/muted}} to
             <var>newState</var>.</p>
           </li>
           <li>
             <p>If <var>newState</var> is <code>true</code> let
-            <var>eventName</var> be <code>mute</code>, otherwise
-            <code>unmute</code>.</p>
+            <var>eventName</var> be {{mute}}, otherwise
+            {{unmute}}.</p>
           </li>
           <li>
-            <p>Fire a simple event named <var>eventName</var> on
+            <p>[=Fire an event=] named <var>eventName</var> on
             <var>track</var>.</p>
           </li>
         </ol>
-        <p><dfn id="track-enabled">Enabled/disabled</dfn> on the other hand is
+        <p><dfn id="track-enabled" data-lt="track enabled state|enabled" data-lt-noDefault>Enabled/disabled</dfn> on the other hand is
         available to the application to control (and observe) via the
-        <code><a href="#dom-mediastreamtrack-enabled">enabled</a></code>
+        {{MediaStreamTrack/enabled}}
         attribute.</p>
         <p>The result for the consumer is the same in the sense that whenever
-        <code><a>MediaStreamTrack</a></code> is muted or disabled (or both) the
+        {{MediaStreamTrack}} is muted or disabled (or both) the
         consumer gets zero-information-content, which means silence for audio
         and black frames for video. In other words, media from the source only
-        flows when a <code><a>MediaStreamTrack</a></code> object is both
+        flows when a {{MediaStreamTrack}} object is both
         unmuted and enabled. For example, a video element sourced by a muted or
-        disabled <code><a>MediaStreamTrack</a></code> (contained in a
-        <code><a>MediaStream</a></code> ), is playing but rendering
+        disabled {{MediaStreamTrack}} (contained in a
+        {{MediaStream}} ), is playing but rendering
         blackness.</p>
-        <p>For a newly created <code><a>MediaStreamTrack</a></code> object, the
+        <p>For a newly created {{MediaStreamTrack}} object, the
         following applies: the track is always enabled unless stated otherwise
         (for example when cloned) and the muted state reflects the state of the
         source at the time the track is created.</p>
       </section>
       <section>
         <h3>Tracks and Constraints</h3>
-        <p><code><a>MediaStreamTrack</a></code> is a <a>constrainable
+        <p>{{MediaStreamTrack}} is a <a>constrainable
         object</a> as defined in the <a href=
         "#constrainable-interface">Constrainable Pattern</a> section.
         Constraints are set on tracks and may affect sources.</p>
@@ -921,92 +884,75 @@ interface MediaStreamTrack : EventTarget {
             <h2>Attributes</h2>
             <dl data-link-for="MediaStreamTrack" data-dfn-for=
             "MediaStreamTrack" class="attributes">
-              <dt><code>kind</code> of type <span class=
-              "idlAttrType">DOMString</span>, readonly</dt>
+              <dt>{{kind}} of type {{DOMString}}, readonly</dt>
               <dd>
                 <p>The <dfn id=
-                "dom-mediastreamtrack-kind"><code>kind</code></dfn> attribute
-                MUST return the string "<code>audio</code>" if this object
-                represents an audio track or "<code>video</code>" if this
+                "dom-mediastreamtrack-kind">kind</dfn> attribute
+                MUST return the string <code><dfn>"audio"</dfn></code> if this object
+                represents an audio track or <code><dfn>"video"</dfn></code> if this
                 object represents a video track.</p>
               </dd>
-              <dt><code>id</code> of type <span class=
-              "idlAttrType">DOMString</span>, readonly</dt>
+              <dt>{{id}} of type {{DOMString}}, readonly</dt>
               <dd>
-                <p>When a <code><a>MediaStreamTrack</a></code> is created, the
+                <p>When a {{MediaStreamTrack}} is created, the
                 User Agent MUST generate an identifier string, and MUST
-                initialize the object's <code><a href=
-                "#dom-mediastreamtrack-id">id</a></code> attribute to that
+                initialize the object's {{id}} attribute to that
                 string, unless the object is created as part of a special
                 purpose algorithm that specifies how the stream id must be
-                initialized. See <code><a>MediaStream</a></code>'s
-                <code><a href="#dom-mediastream-id">id</a></code> attribute for
+                initialized. See {{MediaStream.id}}
+                attribute for
                 guidelines on how to generate such an identifier.</p>
                 <p>An example of an algorithm that specifies how the track id
                 must be initialized is the algorithm to represent an incoming
-                network component with a <code><a>MediaStreamTrack</a></code>
-                object. [[WEBRTC10]]</p>
-                <p><dfn data-idl><code>id</code></dfn> attribute MUST return the value
+                network component with a {{MediaStreamTrack}}
+                object. [[WEBRTC]]</p>
+                <p><dfn data-idl>id</dfn> attribute MUST return the value
                 to which it was initialized when the object was created.</p>
               </dd>
-              <dt><code>label</code> of type <span class=
-              "idlAttrType">DOMString</span>, readonly</dt>
+              <dt>{{label}} of type {{DOMString}}, readonly</dt>
               <dd>
                 <p>User Agents MAY label audio and video sources (e.g.,
                 "Internal microphone" or "External USB Webcam"). The <dfn id=
-                "dom-mediastreamtrack-label"><code>label</code></dfn> attribute
+                "dom-mediastreamtrack-label">label</dfn> attribute
                 MUST return the label of the object's corresponding source, if
                 any. If the corresponding source has or had no label, the
                 attribute MUST instead return the empty string.</p>
               </dd>
-              <dt><code>enabled</code> of type <span class=
-              "idlAttrType">boolean</span></dt>
+              <dt>{{enabled}} of type {{boolean}}</dt>
               <dd>
                 <p>The <dfn id=
-                "dom-mediastreamtrack-enabled"><code>enabled</code></dfn>
-                attribute controls the <code><a href=
-                "#track-enabled">enabled</a></code> state for the object.</p>
+                "dom-mediastreamtrack-enabled">enabled</dfn>
+                attribute controls the <a data-lt="track enabled state">enabled</a> state for the object.</p>
                 <p>On getting, the attribute MUST return the value to which it
                 was last set. On setting, it MUST be set to the new value.</p>
                 <p class="note">Thus, after a
-                <code><a>MediaStreamTrack</a></code> has <a href=
-                "#track-ended">ended</a>, its <code><a href=
-                "#dom-mediastreamtrack-enabled">enabled</a></code> attribute
+                {{MediaStreamTrack}} has <a data-lt="track ended state">ended</a>, its {{MediaStreaMtrack/enabled}} attribute
                 still changes value when set; it just doesn't do anything with
                 that new value.</p>
               </dd>
-              <dt><code>muted</code> of type <span class=
-              "idlAttrType">boolean</span>, readonly</dt>
+              <dt>{{muted}} of type {{boolean}}, readonly</dt>
               <dd>
-                <p>The <dfn data-idl><code>muted</code></dfn> attribute
-                MUST return <code>true</code> if the track is <a href=
-                "#track-muted">muted</a>, and <code>false</code> otherwise.</p>
+                <p>The <dfn data-idl>muted</dfn> attribute
+                MUST return <code>true</code> if the track is <a>muted</a>, and <code>false</code> otherwise.</p>
               </dd>
-              <dt><dfn><code>onmute</code></dfn> of type <span class=
-              "idlAttrType"><a>EventHandler</a></span></dt>
+              <dt><dfn>onmute</dfn> of type {{EventHandler}}</dt>
               <dd>
-                <p>The event type of this event handler is <code><a href=
-                "#event-mediastreamtrack-mute">mute</a></code>.</p>
+                <p>The event type of this event handler is <a>mute</a>.</p>
               </dd>
-              <dt><dfn><code>onunmute</code></dfn> of type <span class=
-              "idlAttrType"><a>EventHandler</a></span></dt>
+              <dt><dfn>onunmute</dfn> of type {{EventHandler}}</dt>
               <dd>
-                <p>The event type of this event handler is <code><a href=
-                "#event-mediastreamtrack-unmute">unmute</a></code>.</p>
+                <p>The event type of this event handler is <a>unmute</a>.</p>
               </dd>
-              <dt><code>readyState</code> of type <span class=
-              "idlAttrType"><a>MediaStreamTrackState</a></span>, readonly</dt>
+              <dt>{{readyState}} of type {{MediaStreamTrackState}}, readonly</dt>
               <dd>
                 <p>The <dfn id=
-                "dom-mediastreamtrack-readystate"><code>readyState</code></dfn>
+                "dom-mediastreamtrack-readystate">readyState</dfn>
                 attribute represents the state of the track. It MUST return the
                 value as most recently set by the User Agent.</p>
               </dd>
-              <dt><dfn><code>onended</code></dfn> of type <span class=
-              "idlAttrType"><a>EventHandler</a></span></dt>
+              <dt><dfn>onended</dfn> of type {{EventHandler}}</dt>
               <dd>
-                <p>The event type of this event handler is <code><a href=
-                "#event-mediastreamtrack-ended">ended</a></code>.</p>
+                <p>The event type of this event handler is <a data-lt="ended event">ended</a>.</p>
               </dd>
             </dl>
           </section>
@@ -1014,47 +960,45 @@ interface MediaStreamTrack : EventTarget {
             <h2>Methods</h2>
             <dl data-link-for="MediaStreamTrack" data-dfn-for=
             "MediaStreamTrack" class="methods">
-              <dt><dfn><code>clone</code></dfn></dt>
+              <dt><dfn>clone</dfn></dt>
               <dd>
-                <p>Clones this <code><a>MediaStreamTrack</a></code>.</p>
-                <p>When the <code>clone()</code> method is invoked, the User
-                Agent MUST return the result of <a href="#track-clone">cloning
+                <p>Clones this {{MediaStreamTrack}}.</p>
+                <p>When the {{clone()}} method is invoked, the User
+                Agent MUST return the result of <a data-lt="clone a track">cloning
                 this track</a>.</p>
               </dd>
-              <dt><dfn><code>stop</code></dfn></dt>
+              <dt>{{stop}}</dt>
               <dd>
-                <p>When a <code><a>MediaStreamTrack</a></code> object's
-                <code><dfn>stop()</dfn></code> method is invoked, the User
+                <p>When a {{MediaStreamTrack}} object's
+                <dfn>stop()</dfn> method is invoked, the User
                 Agent MUST run following steps:</p>
                 <ol>
                   <li>
                     <p>Let <var>track</var> be the current
-                    <code><a>MediaStreamTrack</a></code> object.</p>
+                    {{MediaStreamTrack}} object.</p>
                   </li>
                   <li>
-                    <p>If <var>track</var>'s <code><a href=
-                    "#dom-mediastreamtrack-readystate">readyState</a></code>
-                    attribute is ended, then abort these steps.</p>
+                    <p>If <var>track</var>.{{MediaStreamTrack/readyState}}
+                    is {{MediaStreamTrackState/"ended"}}, then abort these steps.</p>
                   </li>
                   <li>
                     <p>Notify <var>track</var>'s source that <var>track</var>
-                    is <a href="#track-ended">ended</a>.</p>
+                    is <a>ended</a>.</p>
                     <p>A source that is notified of a track ending will be
-                    <a href="#source-stopped">stopped</a>, unless other
-                    <code><a>MediaStreamTrack</a></code> objects depend on
+                    <a>stopped</a>, unless other
+                    {{MediaStreamTrack}} objects depend on
                     it.</p>
                   </li>
                   <li>
-                    <p>Set <var>track's</var> <code><a href=
-                    "#dom-mediastreamtrack-readystate">readyState</a></code>
-                    attribute to <code>ended</code>.</p>
+                    <p>Set <var>track</var>.{{MediaStreamTrack/readyState}}
+                    to {{MediaStreamTrackState/"ended"}}.</p>
                   </li>
                 </ol>
               </dd>
-              <dt><dfn><code>getCapabilities</code></dfn></dt>
+              <dt><dfn>getCapabilities</dfn></dt>
               <dd>
                 <p>Returns the capabilites of the source that this
-                <code><a>MediaStreamTrack</a></code>, the <a>constrainable
+                {{MediaStreamTrack}}, the <a>constrainable
                 object</a>, represents.</p>
                 <p>See <a href="#constrainable-interface">ConstrainablePattern
                 Interface</a> for the definition of this method.</p>
@@ -1062,30 +1006,29 @@ interface MediaStreamTrack : EventTarget {
                 persistent, cross-origin information about the underlying
                 device, it adds to the fingerprint surface of the device.</p>
               </dd>
-              <dt><dfn><code>getConstraints</code></dfn></dt>
+              <dt><dfn>getConstraints</dfn></dt>
               <dd>
                 <p>See <a href="#constrainable-interface">ConstrainablePattern
                 Interface</a> for the definition of this method.</p>
               </dd>
-              <dt><dfn><code>getSettings</code></dfn></dt>
+              <dt><dfn>getSettings</dfn></dt>
               <dd>
                 <p>See <a href="#constrainable-interface">ConstrainablePattern
                 Interface</a> for the definition of this method.</p>
               </dd>
-              <dt><dfn><code>applyConstraints</code></dfn></dt>
+              <dt><dfn>applyConstraints</dfn></dt>
               <dd>
-                <p>When a <code><a>MediaStreamTrack</a></code> object's
-                <code>applyConstraints()</code> method is invoked, the User
+                <p>When a {{MediaStreamTrack}} object's
+                {{applyConstraints()}} method is invoked, the User
                 Agent MUST run following steps:</p>
                 <ol>
                   <li>
                     <p>Let <var>track</var> be the current
-                    <code><a>MediaStreamTrack</a></code> object.</p>
+                    {{MediaStreamTrack}} object.</p>
                   </li>
                   <li>
-                    <p>If <var>track</var>'s <code><a href=
-                    "#dom-mediastreamtrack-readystate">readyState</a></code>
-                    attribute is ended, run the following sub steps:</p>
+                    <p>If <var>track</var>.{{MediaStreamTrack/readyState}}
+                    is {{MediaStreamTrackState/"ended"}}, run the following sub steps:</p>
                     <ol>
                       <li><p>Let <var>p</var> be a new promise.</p></li>
                       <li><p><a>resolve</a> <var>p</var> with <code>undefined</code>.</p></li>
@@ -1100,12 +1043,12 @@ interface MediaStreamTrack : EventTarget {
                         <ul>
                           <li>
                             <var>object</var> is the
-                            <a><code>MediaStreamTrack</code></a> on which this
+                            {{MediaStreamTrack}} on which this
                             method was called, and
                           </li>
                           <li>
                             <a>settings dictionary</a> refers to a possible
-                            instance of the <a><code>MediaTrackSettings</code></a>
+                            instance of the {{MediaTrackSettings}}
                             dictionary.
                           </li>
                         </ul>
@@ -1137,28 +1080,27 @@ interface MediaStreamTrack : EventTarget {
                 description</th>
               </tr>
               <tr>
-                <td><dfn><code id=
-                "idl-def-MediaStreamTrackState.live">live</code></dfn></td>
+                <td><dfn id=
+                "idl-def-MediaStreamTrackState.live">live</dfn></td>
                 <td>
                   <p>The track is active (the track's underlying media source
                   is making a best-effort attempt to provide data in real
                   time).</p>
-                  <p>The output of a track in the <code>live</code> state can
-                  be switched on and off with the <code><a href=
-                  "#dom-mediastreamtrack-enabled">enabled</a></code>
+                  <p>The output of a track in the {{live}} state can
+                  be switched on and off with the {{MediaStreamTrack/enabled}}
                   attribute.</p>
                 </td>
               </tr>
               <tr>
-                <td><dfn><code id=
-                "idl-def-MediaStreamTrackState.ended">ended</code></dfn></td>
+                <td><dfn data-lt="ended event" data-lt-noDefault id=
+                "idl-def-MediaStreamTrackState.ended">ended</dfn></td>
                 <td>
-                  <p>The track has <a href="#track-ended">ended</a> (the
+                  <p>The track has <a data-lt="track ended state">ended</a> (the
                   track's underlying media source is no longer providing data,
                   and will never provide more data for this track). Once a
                   track enters this state, it never exits it.</p>
                   <p>For example, a video track in a
-                  <code><a>MediaStream</a></code> ends when the user unplugs
+                  {{MediaStream}} ends when the user unplugs
                   the USB web camera that acts as the track's media source.</p>
                 </td>
               </tr>
@@ -1168,16 +1110,16 @@ interface MediaStreamTrack : EventTarget {
       </section>
       <section id="media-track-supported-constraints">
         <h2><dfn>MediaTrackSupportedConstraints</dfn></h2>
-        <p><code><a>MediaTrackSupportedConstraints</a></code> represents the
+        <p>{{MediaTrackSupportedConstraints}} represents the
         list of constraints recognized by a User Agent for controlling the
-        <a>Capabilities</a> of a <code><a>MediaStreamTrack</a></code> object.
+        <a>Capabilities</a> of a {{MediaStreamTrack}} object.
         This dictionary is used as a function return value, and never as an
         operation argument.</p>
-        <p>Future specifications can extend the MediaTrackSupportedConstraints
+        <p>Future specifications can extend the {{MediaTrackSupportedConstraints}}
         dictionary by defining a partial dictionary with dictionary members of
-        type boolean.</p>
+        type {{boolean}}.</p>
         <p class="note">The constraints specified in this specification apply
-        only to instances of <code><a>MediaStreamTrack</a></code> generated by
+        only to instances of {{MediaStreamTrack}} generated by
         <a data-link-for="MediaDevices">getUserMedia()</a>, unless stated
         otherwise in other specifications.</p>
         <div>
@@ -1204,98 +1146,83 @@ interface MediaStreamTrack : EventTarget {
             "idlType">MediaTrackSupportedConstraints</a> Members</h2>
             <dl data-link-for="MediaTrackSupportedConstraints" data-dfn-for=
             "MediaTrackSupportedConstraints" class="dictionary-members">
-              <dt><dfn><code>width</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>width</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href="#def-constraint-width">width</a></code>
+              <dd>See <a href="#def-constraint-width">width</a>
               for details.</dd>
-              <dt><dfn><code>height</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>height</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href="#def-constraint-height">height</a></code>
+              <dd>See <a href="#def-constraint-height">height</a>
               for details.</dd>
-              <dt><dfn><code>aspectRatio</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>aspectRatio</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-aspect">aspectRatio</a></code> for details.</dd>
-              <dt><dfn><code>frameRate</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dd>See <a href=
+              "#def-constraint-aspect">aspectRatio</a> for details.</dd>
+              <dt><dfn>frameRate</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-frameRate">frameRate</a></code> for
+              <dd>See <a href=
+              "#def-constraint-frameRate">frameRate</a> for
               details.</dd>
-              <dt><dfn><code>facingMode</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>facingMode</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-facingMode">facingMode</a></code> for
+              <dd>See <a href=
+              "#def-constraint-facingMode">facingMode</a> for
               details.</dd>
-              <dt><dfn><code>resizeMode</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>resizeMode</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-resizeMode">resizeMode</a></code> for
+              <dd>See <a href=
+              "#def-constraint-resizeMode">resizeMode</a> for
               details.</dd>
-              <dt><dfn><code>sampleRate</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>sampleRate</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-sampleRate">sampleRate</a></code> for
+              <dd>See <a href=
+              "#def-constraint-sampleRate">sampleRate</a> for
               details.</dd>
-              <dt><dfn><code>sampleSize</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>sampleSize</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-sampleSize">sampleSize</a></code> for
+              <dd>See <a href=
+              "#def-constraint-sampleSize">sampleSize</a> for
               details.</dd>
-              <dt><dfn><code>echoCancellation</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>echoCancellation</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-echoCancellation">echoCancellation</a></code>
+              <dd>See <a href=
+              "#def-constraint-echoCancellation">echoCancellation</a>
               for details.</dd>
-              <dt><dfn><code>autoGainControl</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>autoGainControl</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-autoGainControl">autoGainControl</a></code> for
+              <dd>See <a href=
+              "#def-constraint-autoGainControl">autoGainControl</a> for
               details.</dd>
-              <dt><dfn><code>noiseSuppression</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>noiseSuppression</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-noiseSuppression">noiseSuppression</a></code>
+              <dd>See <a href=
+              "#def-constraint-noiseSuppression">noiseSuppression</a>
               for details.</dd>
-              <dt><dfn><code>latency</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>latency</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-latency">latency</a></code> for details.</dd>
-              <dt><dfn><code>channelCount</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dd>See <a href=
+              "#def-constraint-latency">latency</a> for details.</dd>
+              <dt><dfn>channelCount</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-channelCount">channelCount</a></code> for
+              <dd>See <a href=
+              "#def-constraint-channelCount">channelCount</a> for
               details.</dd>
-              <dt><dfn><code>deviceId</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dt><dfn>deviceId</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-deviceId">deviceId</a></code> for details.</dd>
-              <dt><dfn><code>groupId</code></dfn> of type <span class=
-              "idlMemberType">boolean</span>, defaulting to
+              <dd>See <a href=
+              "#def-constraint-deviceId">deviceId</a> for details.</dd>
+              <dt><dfn>groupId</dfn> of type {{boolean}}, defaulting to
               <code>true</code></dt>
-              <dd>See <code><a href=
-              "#def-constraint-groupId">groupId</a></code> for details.</dd>
+              <dd>See <a href=
+              "#def-constraint-groupId">groupId</a> for details.</dd>
             </dl>
           </section>
         </div>
       </section>
       <section id="media-track-capabilities">
         <h2><dfn>MediaTrackCapabilities</dfn></h2>
-        <p><code><a>MediaTrackCapabilities</a></code> represents the
-        <a>Capabilities</a> of a <code><a>MediaStreamTrack</a></code>
+        <p>{{MediaTrackCapabilities}} represents the
+        <a>Capabilities</a> of a {{MediaStreamTrack}}
         object.</p>
         <p>Future specifications can extend the MediaTrackCapabilities
         dictionary by defining a partial dictionary with dictionary members of
@@ -1324,108 +1251,93 @@ interface MediaStreamTrack : EventTarget {
             Members</h2>
             <dl data-link-for="MediaTrackCapabilities" data-dfn-for=
             "MediaTrackCapabilities" class="dictionary-members">
-              <dt><dfn><code>width</code></dfn> of type <span class=
-              "idlMemberType"><a>ULongRange</a></span></dt>
-              <dd>See <code><a href="#def-constraint-width">width</a></code>
+              <dt><dfn>width</dfn> of type {{ULongRange}}</dt>
+              <dd>See <a href="#def-constraint-width">width</a>
               for details.</dd>
-              <dt><dfn><code>height</code></dfn> of type <span class=
-              "idlMemberType"><a>ULongRange</a></span></dt>
-              <dd>See <code><a href="#def-constraint-height">height</a></code>
+              <dt><dfn>height</dfn> of type {{ULongRange}}</dt>
+              <dd>See <a href="#def-constraint-height">height</a>
               for details.</dd>
-              <dt><dfn><code>aspectRatio</code></dfn> of type <span class=
-              "idlMemberType"><a>DoubleRange</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-aspect">aspectRatio</a></code> for details.</dd>
-              <dt><dfn><code>frameRate</code></dfn> of type <span class=
-              "idlMemberType"><a>DoubleRange</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-frameRate">frameRate</a></code> for
+              <dt><dfn>aspectRatio</dfn> of type {{DoubleRange}}</dt>
+              <dd>See <a href=
+              "#def-constraint-aspect">aspectRatio</a> for details.</dd>
+              <dt><dfn>frameRate</dfn> of type {{DoubleRange}}</dt>
+              <dd>See <a href=
+              "#def-constraint-frameRate">frameRate</a> for
               details.</dd>
-              <dt><dfn><code>facingMode</code></dfn> of type <span class=
-              "idlMemberType">sequence&lt;DOMString&gt;</span></dt>
+              <dt><dfn>facingMode</dfn> of type <code>sequence&lt;{{DOMString}}&gt;</code></dt>
               <dd>
                 <p>A camera can report multiple facing modes. For example, in a
                 high-end telepresence solution with several cameras facing the
-                user, a camera to the left of the user can report both "left"
-                and "user". See <code><a href=
-                "#def-constraint-facingMode">facingMode</a></code> for
+                user, a camera to the left of the user can report both {{VideoFacingModeEnum/"left"}}
+                and {{VideoFacingModeEnum/"user"}}. See <a href=
+                "#def-constraint-facingMode">facingMode</a> for
                 additional details.</p>
               </dd>
-              <dt><dfn><code>resizeMode</code></dfn> of type <span class=
-              "idlMemberType">sequence&lt;DOMString&gt;</span></dt>
+              <dt><dfn>resizeMode</dfn> of type <code>sequence&lt;{{DOMString}}&gt;</code></dt>
               <dd>
                 <p>The user agent MAY use cropping and downscaling to offer
                 more resolution choices than this camera naturally produces.
                 The reported sequence MUST list all the means the UA may employ
-                to derive resolution choices for this camera. The value "none"
+                to derive resolution choices for this camera. The value {{VideoResizeModeEnum/"none"}}
                 MUST be present, indicating the ability to constrain the UA
-                from cropping and downscaling. See <code><a href=
-                "#def-constraint-resizeMode">resizeMode</a></code> for
+                from cropping and downscaling. See <a href=
+                "#def-constraint-resizeMode">resizeMode</a> for
                 additional details.</p>
               </dd>
-              <dt><dfn><code>sampleRate</code></dfn> of type <span class=
-              "idlMemberType"><a>ULongRange</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-sampleRate">sampleRate</a></code> for
+              <dt><dfn>sampleRate</dfn> of type {{ULongRange}}</dt>
+              <dd>See <a href=
+              "#def-constraint-sampleRate">sampleRate</a> for
               details.</dd>
-              <dt><dfn><code>sampleSize</code></dfn> of type <span class=
-              "idlMemberType"><a>ULongRange</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-sampleSize">sampleSize</a></code> for
+              <dt><dfn>sampleSize</dfn> of type {{ULongRange}}</dt>
+              <dd>See <a href=
+              "#def-constraint-sampleSize">sampleSize</a> for
               details.</dd>
-              <dt><dfn><code>echoCancellation</code></dfn> of type <span class=
-              "idlMemberType">sequence&lt;boolean&gt;</span></dt>
+              <dt><dfn>echoCancellation</dfn> of type <code>sequence&lt;{{boolean}}&gt;</code></dt>
               <dd>
                 <p>If the source cannot do echo cancellation a single
                 <code>false</code> is reported. If echo cancellation cannot be
                 turned off, a single <code>true</code> is reported. If the
                 script can control the feature, the source reports a list with
                 both <code>true</code> and <code>false</code> as possible
-                values. See <code><a href=
-                "#def-constraint-echoCancellation">echoCancellation</a></code>
+                values. See <a href=
+                "#def-constraint-echoCancellation">echoCancellation</a>
                 for additional details.</p>
               </dd>
-              <dt><dfn><code>autoGainControl</code></dfn> of type <span class=
-              "idlMemberType">sequence&lt;boolean&gt;</span></dt>
+              <dt><dfn>autoGainControl</dfn> of type <code>sequence&lt;{{boolean}}&gt;</code></dt>
               <dd>
                 <p>If the source cannot do auto gain control a single
                 <code>false</code> is reported. If auto gain control cannot be
                 turned off, a single <code>true</code> is reported. If the
                 script can control the feature, the source reports a list with
                 both <code>true</code> and <code>false</code> as possible
-                values. See <code><a href=
-                "#def-constraint-autoGainControl">autoGainControl</a></code>
+                values. See <a href=
+                "#def-constraint-autoGainControl">autoGainControl</a>
                 for additional details.</p>
               </dd>
-              <dt><dfn><code>noiseSuppression</code></dfn> of type <span class=
-              "idlMemberType">sequence&lt;boolean&gt;</span></dt>
+              <dt><dfn>noiseSuppression</dfn> of type <code>sequence&lt;{{boolean}}&gt;</code></dt>
               <dd>
                 <p>If the source cannot do noise suppression a single
                 <code>false</code> is reported. If noise suppression cannot be
                 turned off, a single <code>true</code> is reported. If the
                 script can control the feature, the source reports a list with
                 both <code>true</code> and <code>false</code> as possible
-                values. See <code><a href=
-                "#def-constraint-noiseSuppression">noiseSuppression</a></code>
+                values. See <a href=
+                "#def-constraint-noiseSuppression">noiseSuppression</a>
                 for additional details.</p>
               </dd>
-              <dt><dfn><code>latency</code></dfn> of type <span class=
-              "idlMemberType"><a>DoubleRange</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-latency">latency</a></code> for details.</dd>
-              <dt><dfn><code>channelCount</code></dfn> of type <span class=
-              "idlMemberType"><a>ULongRange</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-channelCount">channelCount</a></code> for
+              <dt><dfn>latency</dfn> of type {{DoubleRange}}</dt>
+              <dd>See <a href=
+              "#def-constraint-latency">latency</a> for details.</dd>
+              <dt><dfn>channelCount</dfn> of type {{ULongRange}}</dt>
+              <dd>See <a href=
+              "#def-constraint-channelCount">channelCount</a> for
               details.</dd>
-              <dt><dfn><code>deviceId</code></dfn> of type <span class=
-              "idlMemberType">DOMString</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-deviceId">deviceId</a></code> for details.</dd>
-              <dt><dfn><code>groupId</code></dfn> of type <span class=
-              "idlMemberType">DOMString</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-groupId">groupId</a></code> for details.</dd>
+              <dt><dfn>deviceId</dfn> of type {{DOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-deviceId">deviceId</a> for details.</dd>
+              <dt><dfn>groupId</dfn> of type {{DOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-groupId">groupId</a> for details.</dd>
             </dl>
           </section>
         </div>
@@ -1442,8 +1354,7 @@ interface MediaStreamTrack : EventTarget {
             Members</h2>
             <dl data-link-for="MediaTrackConstraints" data-dfn-for=
             "MediaTrackConstraints" class="dictionary-members">
-              <dt><dfn><code>advanced</code></dfn> of type <span class=
-              "idlMemberType">sequence&lt;<a>MediaTrackConstraintSet</a>&gt;</span></dt>
+              <dt><dfn>advanced</dfn> of type <code>sequence&lt;{{MediaTrackConstraintSet}}&gt;</code></dt>
               <dd>
                 <p>See <a href="#constraints">Constraints and ConstraintSet</a>
                 for the definition of this element.</p>
@@ -1478,83 +1389,68 @@ interface MediaStreamTrack : EventTarget {
             Members</h2>
             <dl data-link-for="MediaTrackConstraintSet" data-dfn-for=
             "MediaTrackConstraintSet" class="dictionary-members">
-              <dt><dfn><code>width</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainULong</a></span></dt>
-              <dd>See <code><a href="#def-constraint-width">width</a></code>
+              <dt><dfn>width</dfn> of type {{ConstrainULong}}</dt>
+              <dd>See <a href="#def-constraint-width">width</a>
               for details.</dd>
-              <dt><dfn><code>height</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainULong</a></span></dt>
-              <dd>See <code><a href="#def-constraint-height">height</a></code>
+              <dt><dfn>height</dfn> of type {{ConstrainULong}}</dt>
+              <dd>See <a href="#def-constraint-height">height</a>
               for details.</dd>
-              <dt><dfn><code>aspectRatio</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainDouble</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-aspect">aspectRatio</a></code> for details.</dd>
-              <dt><dfn><code>frameRate</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainDouble</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-frameRate">frameRate</a></code> for
+              <dt><dfn>aspectRatio</dfn> of type {{ConstrainDouble}}</dt>
+              <dd>See <a href=
+              "#def-constraint-aspect">aspectRatio</a> for details.</dd>
+              <dt><dfn>frameRate</dfn> of type {{ConstrainDouble}}</dt>
+              <dd>See <a href=
+              "#def-constraint-frameRate">frameRate</a> for
               details.</dd>
-              <dt><dfn><code>facingMode</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainDOMString</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-facingMode">facingMode</a></code> for
+              <dt><dfn>facingMode</dfn> of type {{ConstrainDOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-facingMode">facingMode</a> for
               details.</dd>
-              <dt><dfn><code>resizeMode</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainDOMString</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-resizeMode">resizeMode</a></code> for
+              <dt><dfn>resizeMode</dfn> of type {{ConstrainDOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-resizeMode">resizeMode</a> for
               details.</dd>
-              <dt><dfn><code>sampleRate</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainULong</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-sampleRate">sampleRate</a></code> for
+              <dt><dfn>sampleRate</dfn> of type {{ConstrainULong}}</dt>
+              <dd>See <a href=
+              "#def-constraint-sampleRate">sampleRate</a> for
               details.</dd>
-              <dt><dfn><code>sampleSize</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainULong</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-sampleSize">sampleSize</a></code> for
+              <dt><dfn>sampleSize</dfn> of type {{ConstrainULong}}</dt>
+              <dd>See <a href=
+              "#def-constraint-sampleSize">sampleSize</a> for
               details.</dd>
-              <dt><dfn><code>echoCancellation</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainBoolean</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-echoCancellation">echoCancellation</a></code>
+              <dt><dfn>echoCancellation</dfn> of type {{ConstrainBoolean}}</dt>
+              <dd>See <a href=
+              "#def-constraint-echoCancellation">echoCancellation</a>
               for details.</dd>
-              <dt><dfn><code>autoGainControl</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainBoolean</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-autoGainControl">autoGainControl</a></code> for
+              <dt><dfn>autoGainControl</dfn> of type {{ConstrainBoolean}}</dt>
+              <dd>See <a href=
+              "#def-constraint-autoGainControl">autoGainControl</a> for
               details.</dd>
-              <dt><dfn><code>noiseSuppression</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainBoolean</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-noiseSuppression">noiseSuppression</a></code>
+              <dt><dfn>noiseSuppression</dfn> of type {{ConstrainBoolean}}</dt>
+              <dd>See <a href=
+              "#def-constraint-noiseSuppression">noiseSuppression</a>
               for details.</dd>
-              <dt><dfn><code>latency</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainDouble</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-latency">latency</a></code> for details.</dd>
-              <dt><dfn><code>channelCount</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainULong</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-channelCount">channelCount</a></code> for
+              <dt><dfn>latency</dfn> of type {{ConstrainDouble}}</dt>
+              <dd>See <a href=
+              "#def-constraint-latency">latency</a> for details.</dd>
+              <dt><dfn>channelCount</dfn> of type {{ConstrainULong}}</dt>
+              <dd>See <a href=
+              "#def-constraint-channelCount">channelCount</a> for
               details.</dd>
-              <dt><dfn><code>deviceId</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainDOMString</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-deviceId">deviceId</a></code> for details.</dd>
-              <dt><dfn><code>groupId</code></dfn> of type <span class=
-              "idlMemberType"><a>ConstrainDOMString</a></span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-groupId">groupId</a></code> for details.</dd>
+              <dt><dfn>deviceId</dfn> of type {{ConstrainDOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-deviceId">deviceId</a> for details.</dd>
+              <dt><dfn>groupId</dfn> of type {{ConstrainDOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-groupId">groupId</a> for details.</dd>
             </dl>
           </section>
         </div>
       </section>
       <section id="media-track-settings">
         <h2><dfn>MediaTrackSettings</dfn></h2>
-        <p><code><a>MediaTrackSettings</a></code> represents the
-        <a>Settings</a> of a <code><a>MediaStreamTrack</a></code> object.</p>
+        <p>{{MediaTrackSettings}} represents the
+        <a>Settings</a> of a {{MediaStreamTrack}} object.</p>
         <p>Future specifications can extend the MediaTrackSettings dictionary
         by defining a partial dictionary with dictionary members of appropriate
         type.</p>
@@ -1582,75 +1478,60 @@ interface MediaStreamTrack : EventTarget {
             Members</h2>
             <dl data-link-for="MediaTrackSettings" data-dfn-for=
             "MediaTrackSettings" class="dictionary-members">
-              <dt><dfn><code>width</code></dfn> of type <span class=
-              "idlMemberType">long</span></dt>
-              <dd>See <code><a href="#def-constraint-width">width</a></code>
+              <dt><dfn>width</dfn> of type {{long}}</dt>
+              <dd>See <a href="#def-constraint-width">width</a>
               for details.</dd>
-              <dt><dfn><code>height</code></dfn> of type <span class=
-              "idlMemberType">long</span></dt>
-              <dd>See <code><a href="#def-constraint-height">height</a></code>
+              <dt><dfn>height</dfn> of type {{long}}</dt>
+              <dd>See <a href="#def-constraint-height">height</a>
               for details.</dd>
-              <dt><dfn><code>aspectRatio</code></dfn> of type <span class=
-              "idlMemberType">double</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-aspect">aspectRatio</a></code> for details.</dd>
-              <dt><dfn><code>frameRate</code></dfn> of type <span class=
-              "idlMemberType">double</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-frameRate">frameRate</a></code> for
+              <dt><dfn>aspectRatio</dfn> of type {{double}}</dt>
+              <dd>See <a href=
+              "#def-constraint-aspect">aspectRatio</a> for details.</dd>
+              <dt><dfn>frameRate</dfn> of type {{double}}</dt>
+              <dd>See <a href=
+              "#def-constraint-frameRate">frameRate</a> for
               details.</dd>
-              <dt><dfn><code>facingMode</code></dfn> of type <span class=
-              "idlMemberType">DOMString</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-facingMode">facingMode</a></code> for
+              <dt><dfn>facingMode</dfn> of type {{DOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-facingMode">facingMode</a> for
               details.</dd>
-              <dt><dfn><code>resizeMode</code></dfn> of type <span class=
-              "idlMemberType">DOMString</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-resizeMode">resizeMode</a></code> for
+              <dt><dfn>resizeMode</dfn> of type {{DOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-resizeMode">resizeMode</a> for
               details.</dd>
-              <dt><dfn><code>sampleRate</code></dfn> of type <span class=
-              "idlMemberType">long</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-sampleRate">sampleRate</a></code> for
+              <dt><dfn>sampleRate</dfn> of type {{long}}</dt>
+              <dd>See <a href=
+              "#def-constraint-sampleRate">sampleRate</a> for
               details.</dd>
-              <dt><dfn><code>sampleSize</code></dfn> of type <span class=
-              "idlMemberType">long</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-sampleSize">sampleSize</a></code> for
+              <dt><dfn>sampleSize</dfn> of type {{long}}</dt>
+              <dd>See <a href=
+              "#def-constraint-sampleSize">sampleSize</a> for
               details.</dd>
-              <dt><dfn><code>echoCancellation</code></dfn> of type <span class=
-              "idlMemberType">boolean</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-echoCancellation">echoCancellation</a></code>
+              <dt><dfn>echoCancellation</dfn> of type {{boolean}}</dt>
+              <dd>See <a href=
+              "#def-constraint-echoCancellation">echoCancellation</a>
               for details.</dd>
-              <dt><dfn><code>autoGainControl</code></dfn> of type <span class=
-              "idlMemberType">boolean</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-autoGainControl">autoGainControl</a></code> for
+              <dt><dfn>autoGainControl</dfn> of type {{boolean}}</dt>
+              <dd>See <a href=
+              "#def-constraint-autoGainControl">autoGainControl</a> for
               details.</dd>
-              <dt><dfn><code>noiseSuppression</code></dfn> of type <span class=
-              "idlMemberType">boolean</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-noiseSuppression">noiseSuppression</a></code>
+              <dt><dfn>noiseSuppression</dfn> of type {{boolean}}</dt>
+              <dd>See <a href=
+              "#def-constraint-noiseSuppression">noiseSuppression</a>
               for details.</dd>
-              <dt><dfn><code>latency</code></dfn> of type <span class=
-              "idlMemberType">double</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-latency">latency</a></code> for details.</dd>
-              <dt><dfn><code>channelCount</code></dfn> of type <span class=
-              "idlMemberType">long</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-channelCount">channelCount</a></code> for
+              <dt><dfn>latency</dfn> of type {{double}}</dt>
+              <dd>See <a href=
+              "#def-constraint-latency">latency</a> for details.</dd>
+              <dt><dfn>channelCount</dfn> of type {{long}}</dt>
+              <dd>See <a href=
+              "#def-constraint-channelCount">channelCount</a> for
               details.</dd>
-              <dt><dfn><code>deviceId</code></dfn> of type <span class=
-              "idlMemberType">DOMString</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-deviceId">deviceId</a></code> for details.</dd>
-              <dt><dfn><code>groupId</code></dfn> of type <span class=
-              "idlMemberType">DOMString</span></dt>
-              <dd>See <code><a href=
-              "#def-constraint-groupId">groupId</a></code> for details.</dd>
+              <dt><dfn>deviceId</dfn> of type {{DOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-deviceId">deviceId</a> for details.</dd>
+              <dt><dfn>groupId</dfn> of type {{DOMString}}</dt>
+              <dd>See <a href=
+              "#def-constraint-groupId">groupId</a> for details.</dd>
             </dl>
           </section>
         </div>
@@ -1660,7 +1541,7 @@ interface MediaStreamTrack : EventTarget {
         <p>The names of the initial set of constrainable properties for
         MediaStreamTrack are defined below.</p>
         <p>The following constrainable properties are defined to apply to both
-        video and audio <code><a>MediaStreamTrack</a></code> objects:</p>
+        video and audio {{MediaStreamTrack}} objects:</p>
         <table class="simple">
           <thead>
             <tr>
@@ -1675,46 +1556,36 @@ interface MediaStreamTrack : EventTarget {
               <td>DOMString</td>
               <td>
                 The identifier of the device generating the content of the
-                <a>MediaStreamTrack</a>. It conforms with the definition of
-                <code><a>MediaDeviceInfo</a></code>.<code><a
-                href="#def-mediadeviceinfo-deviceId">deviceId</a></code>.
+                {{MediaStreamTrack}}. It conforms with the definition of
+                {{MediaDeviceInfo.deviceId}}.
                 Note that the setting of this property is
                 uniquely determined by the source that is attached to the
-                <a>MediaStreamTrack</a>. In particular, <a data-link-for=
-                "MediaStreamTrack">getCapabilities()</a> will return only a
+                {{MediaStreamTrack}}. In particular, {{MediaStreamTrack/getCapabilities()}} will return only a
                 single value for deviceId. This property can therefore be used
-                for initial media selection with <a data-link-for=
-                "MediaDevices">getUserMedia()</a>. However, it is not useful
-                for subsequent media control with <a data-link-for=
-                "MediaStreamTrack">applyConstraints()</a>, since any attempt to
+                for initial media selection with {{MediaDevices/getUserMedia()}}. However, it is not useful
+                for subsequent media control with {{MediaStreamTrack/applyConstraints()}}, since any attempt to
                 set a different value will result in an unsatisfiable
                 <a>ConstraintSet</a>.
                 If a string of length 0 is used as a deviceId value constraint
-                with <a data-link-for="MediaDevices">getUserMedia()</a>, it
+                with {{MediaDevices/getUserMedia()}}, it
                 MAY be interpreted as if the constraint is not specified.
               </td>
             </tr>
             <tr id="def-constraint-groupId">
               <td><dfn>groupId</dfn></td>
-              <td>DOMString</td>
+              <td>{{DOMString}}</td>
               <td>
-                The <a data-link-type="dfn"
-                href="https://dom.spec.whatwg.org/#concept-document">
-                document</a>-unique group identifier for the device
-                generating the content of the <a>MediaStreamTrack</a>.
+                The [=document=]-unique group identifier for the device
+                generating the content of the {{MediaStreamTrack}}.
                 It conforms with the definition of
-                <code><a>MediaDeviceInfo</a></code>.<code><a
-                href="#def-mediadeviceinfo-groupId">groupId</a></code>.
+                {{MediaDeviceInfo.groupId}}.
                 Note that the setting of this property is uniquely
                 determined by the source that is attached to the
-                <a>MediaStreamTrack</a>. In particular, <a data-link-for=
-                "MediaStreamTrack">getCapabilities()</a> will return only a
+                {{MediaStreamTrack}}. In particular, {{MediaStreamTrack/getCapabilities()}} will return only a
                 single value for groupId. Since this property is not stable
                 between browsing sessions, its usefulness for initial media
-                selection with <a data-link-for=
-                "MediaDevices">getUserMedia()</a> is limited. It is not useful
-                for subsequent media control with <a data-link-for=
-                "MediaStreamTrack">applyConstraints()</a>, since any attempt to
+                selection with {{MediaDevices/getUserMedia()}} is limited. It is not useful
+                for subsequent media control with {{MediaStreamTrack/applyConstraints()}}, since any attempt to
                 set a different value will result in an unsatisfiable
                 <a>ConstraintSet</a>.
               </td>
@@ -1722,7 +1593,7 @@ interface MediaStreamTrack : EventTarget {
           </tbody>
         </table>
         <p>The following constrainable properties are defined to apply only to
-        video <code><a>MediaStreamTrack</a></code> objects:</p>
+        video {{MediaStreamTrack}} objects:</p>
         <table class="simple">
           <thead>
             <tr>
@@ -1734,7 +1605,7 @@ interface MediaStreamTrack : EventTarget {
           <tbody>
             <tr id="def-constraint-width">
               <td><dfn>width</dfn></td>
-              <td><code><a>ConstrainULong</a></code></td>
+              <td>{{ConstrainULong}}</td>
               <td>The width or width range, in pixels. As a capability, the
               range should span the video source's pre-set width values with
               min being the smallest width and max being the largest
@@ -1742,7 +1613,7 @@ interface MediaStreamTrack : EventTarget {
             </tr>
             <tr id="def-constraint-height">
               <td><dfn>height</dfn></td>
-              <td><code><a>ConstrainULong</a></code></td>
+              <td>{{ConstrainULong}}</td>
               <td>The height or height range, in pixels. As a capability, the
               range should span the video source's pre-set height values with
               min being the smallest height and max being the largest
@@ -1750,7 +1621,7 @@ interface MediaStreamTrack : EventTarget {
             </tr>
             <tr id="def-constraint-frameRate">
               <td><dfn>frameRate</dfn></td>
-              <td><code><a>ConstrainDouble</a></code></td>
+              <td>{{ConstrainDouble}}</td>
               <td>The exact frame rate (frames per second) or frame rate range.
               If this frame rate cannot be determined (e.g. the source does not
               natively provide a frame rate, or the frame rate cannot be
@@ -1759,16 +1630,16 @@ interface MediaStreamTrack : EventTarget {
             </tr>
             <tr id="def-constraint-aspect">
               <td><dfn>aspectRatio</dfn></td>
-              <td><code><a>ConstrainDouble</a></code></td>
+              <td>{{ConstrainDouble}}</td>
               <td>The exact aspect ratio (width in pixels divided by height in
               pixels, represented as a double rounded to the tenth decimal
               place) or aspect ratio range.</td>
             </tr>
             <tr id="def-constraint-facingMode">
               <td><dfn>facingMode</dfn></td>
-              <td><code><a>ConstrainDOMString</a></code></td>
+              <td>{{ConstrainDOMString}}</td>
               <td>This string (or each string, when a list) should be one of
-              the members of <code><a>VideoFacingModeEnum</a></code>. The
+              the members of {{VideoFacingModeEnum}}. The
               members describe the directions that the camera can face, as seen
               from the user's perspective. Note that <code><a data-link-for=
               "ConstrainablePattern">getConstraints</a></code> may not return
@@ -1778,10 +1649,10 @@ interface MediaStreamTrack : EventTarget {
             </tr>
             <tr id="def-constraint-resizeMode">
               <td><dfn>resizeMode</dfn></td>
-              <td><code><a>ConstrainDOMString</a></code></td>
+              <td>{{ConstrainDOMString}}</td>
               <td>
                 This string (or each string, when a list) should be one of the
-                members of <code><a>VideoResizeModeEnum</a></code>. The members
+                members of {{VideoResizeModeEnum}}. The members
                 describe the means by which the resolution can be derived by
                 the UA. In other words, whether the UA is allowed to use
                 cropping and downscaling on the camera output.
@@ -1864,8 +1735,8 @@ interface MediaStreamTrack : EventTarget {
                 description</th>
               </tr>
               <tr>
-                <td><dfn><code id=
-                "idl-def-VideoResizeModeEnum.user">none</code></dfn></td>
+                <td><dfn id=
+                "idl-def-VideoResizeModeEnum.user">none</dfn></td>
                 <td>
                   <p>This resolution is offered by the camera, its driver, or
                   the OS.</p>
@@ -1875,8 +1746,8 @@ interface MediaStreamTrack : EventTarget {
                 </td>
               </tr>
               <tr>
-                <td><dfn><code id=
-                "idl-def-VideoResizeModeEnum.right">crop-and-scale</code></dfn></td>
+                <td><dfn id=
+                "idl-def-VideoResizeModeEnum.right">crop-and-scale</dfn></td>
                 <td>
                   <p>This resolution is downscaled and/or cropped from a higher
                   camera resolution by the user agent. The media MUST NOT be
@@ -1888,7 +1759,7 @@ interface MediaStreamTrack : EventTarget {
           </table>
         </div>
         <p>The following constrainable properties are defined to apply only to
-        audio <code><a>MediaStreamTrack</a></code> objects:</p>
+        audio {{MediaStreamTrack}} objects:</p>
         <table class="simple">
           <thead>
             <tr>
@@ -1900,19 +1771,19 @@ interface MediaStreamTrack : EventTarget {
           <tbody>
             <tr id="def-constraint-sampleRate">
               <td>sampleRate</td>
-              <td><code><a>ConstrainULong</a></code></td>
+              <td>{{ConstrainULong}}</td>
               <td>The sample rate in samples per second for the audio
               data.</td>
             </tr>
             <tr id="def-constraint-sampleSize">
               <td>sampleSize</td>
-              <td><code><a>ConstrainULong</a></code></td>
+              <td>{{ConstrainULong}}</td>
               <td>The linear sample size in bits. This constraint can only be
               satisfied for audio devices that produce linear samples.</td>
             </tr>
             <tr id="def-constraint-echoCancellation">
               <td>echoCancellation</td>
-              <td><code><a>ConstrainBoolean</a></code></td>
+              <td>{{ConstrainBoolean}}</td>
               <td>When one or more audio streams is being played in the
               processes of various microphones, it is often desirable to
               attempt to remove all the sound being played from the input signals
@@ -1924,7 +1795,7 @@ interface MediaStreamTrack : EventTarget {
             </tr>
             <tr id="def-constraint-autoGainControl">
               <td>autoGainControl</td>
-              <td><code><a>ConstrainBoolean</a></code></td>
+              <td>{{ConstrainBoolean}}</td>
               <td>Automatic gain control is often desirable on the input signal
               recorded by the microphone. There are cases where it is not
               needed and it is desirable to turn it off so that the audio is
@@ -1933,7 +1804,7 @@ interface MediaStreamTrack : EventTarget {
             </tr>
             <tr id="def-constraint-noiseSuppression">
               <td>noiseSuppression</td>
-              <td><code><a>ConstrainBoolean</a></code></td>
+              <td>{{ConstrainBoolean}}</td>
               <td>Noise suppression is often desirable on the input signal
               recorded by the microphone. There are cases where it is not
               needed and it is desirable to turn it off so that the audio is
@@ -1942,7 +1813,7 @@ interface MediaStreamTrack : EventTarget {
             </tr>
             <tr id="def-constraint-latency">
               <td>latency</td>
-              <td><code><a>ConstrainDouble</a></code></td>
+              <td>{{ConstrainDouble}}</td>
               <td>The latency or latency range, in seconds. The latency is the
               time between start of processing (for instance, when sound occurs
               in the real world) to the data being available to the next step
@@ -1954,7 +1825,7 @@ interface MediaStreamTrack : EventTarget {
             </tr>
             <tr id="def-constraint-channelCount">
               <td>channelCount</td>
-              <td><code><a>ConstrainULong</a></code></td>
+              <td>{{ConstrainULong}}</td>
               <td>The number of independent channels of sound that the audio
               data contains, i.e. the number of audio samples per sample
               frame.</td>
@@ -1965,20 +1836,19 @@ interface MediaStreamTrack : EventTarget {
     </section>
     <section>
       <h3>MediaStreamTrackEvent</h3>
-      <p>The <code><a href="#event-mediastream-addtrack">addtrack</a></code>
-      and <code title="event-MediaStreamTracklist-removetrack"><a href=
-      "#event-mediastream-removetrack">removetrack</a></code> events use the
-      <code><a>MediaStreamTrackEvent</a></code> interface.</p>
-      <p>The <code>addtrack</code> and <code>removetrack</code> events notify
-      the script that the <a href="#track-set">track set</a> of a
-      <code><a>MediaStream</a></code> has been updated by the User Agent.</p>
+      <p>The {{addtrack}}
+      and {{removetrack}} events use the
+      {{MediaStreamTrackEvent}} interface.</p>
+      <p>The {{addtrack}} and {{removetrack}} events notify
+      the script that the [=track set=] of a
+      {{MediaStream}} has been updated by the User Agent.</p>
       <p><dfn data-lt="Fire a track event">Firing a track event named
-      <var>e</var></dfn> with a <code><a>MediaStreamTrack</a></code>
+      <var>e</var></dfn> with a {{MediaStreamTrack}}
       <var>track</var> means that an event with the name <var>e</var>, which
       does not bubble (except where otherwise stated) and is not cancelable
       (except where otherwise stated), and which uses the
-      <code><a>MediaStreamTrackEvent</a></code> interface with the
-      <code><a href="#dom-mediastreamtrackevent-track">track</a></code>
+      {{MediaStreamTrackEvent}} interface with the
+      {{MediaStreamTrackEvent/track}}
       attribute set to <var>track</var>, MUST be created and dispatched at the
       given target.</p>
       <div>
@@ -1992,10 +1862,10 @@ interface MediaStreamTrackEvent : Event {
           <h2>Constructors</h2>
           <dl data-link-for="MediaStreamTrackEvent" data-dfn-for=
           "MediaStreamTrackEvent" class="constructors">
-            <dt><dfn><code>MediaStreamTrackEvent</code></dfn></dt>
+            <dt><dfn>constructor()</dfn></dt>
             <dd>
               <p>Constructs a new
-              <code><a>MediaStreamTrackEvent</a></code>.</p>
+              {{MediaStreamTrackEvent}}.</p>
             </dd>
           </dl>
         </section>
@@ -2003,12 +1873,11 @@ interface MediaStreamTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="MediaStreamTrackEvent" data-dfn-for=
           "MediaStreamTrackEvent" class="attributes">
-            <dt><code>track</code> of type <span class=
-            "idlAttrType"><a>MediaStreamTrack</a></span>, readonly</dt>
+            <dt>{{track}} of type {{MediaStreamTrack}}, readonly</dt>
             <dd>
               <p>The <dfn id=
-              "dom-mediastreamtrackevent-track"><code>track</code></dfn>
-              attribute represents the <code><a>MediaStreamTrack</a></code>
+              "dom-mediastreamtrackevent-track">track</dfn>
+              attribute represents the {{MediaStreamTrack}}
               object associated with the event.</p>
             </dd>
           </dl>
@@ -2023,8 +1892,7 @@ interface MediaStreamTrackEvent : Event {
           <h2>Dictionary <dfn>MediaStreamTrackEventInit</dfn> Members</h2>
           <dl data-link-for="MediaStreamTrackEventInit" data-dfn-for=
           "MediaStreamTrackEventInit" class="dictionary-members">
-            <dt><dfn><code>track</code></dfn> of type <span class=
-            "idlMemberType"><a>MediaStreamTrack</a></span>, required</dt>
+            <dt><dfn>track</dfn> of type {{MediaStreamTrack}}, required</dt>
             <dd></dd>
           </dl>
         </section>
@@ -2056,22 +1924,22 @@ interface MediaStreamTrackEvent : Event {
       optimization can save battery, allow for less network congestion,
       etc...</p>
     </div>
-    <p>Note that <code>MediaStream</code> sinks (such as
+    <p>Note that {{MediaStream}} sinks (such as
     <code>&lt;video&gt;</code>, <code>&lt;audio&gt;</code>, and even
-    <code>RTCPeerConnection</code>) will continue to have mechanisms to further
+    <a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>) will continue to have mechanisms to further
     transform the source stream beyond that which the <a>Settings</a>,
     <a>Capabilities</a>, and <a>Constraints</a> described in this specification
     offer. (The sink transformation options, including those of
-    <code>RTCPeerConnection</code>, are outside the scope of this
+    <a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>, are outside the scope of this
     specification.)</p>
     <p>The act of changing or applying a track constraint may affect the
     <code><a>settings</a></code> of all tracks sharing that source and
     consequently all down-level sinks that are using that source. Many sinks
     may be able to take these changes in stride, such as the
-    <code>&lt;video&gt;</code> element or <code>RTCPeerConnection</code>.
+    <code>&lt;video&gt;</code> element or <a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>.
     Others like the Recorder API may fail as a result of a source setting
     change.</p>
-    <p>The <code>RTCPeerConnection</code> is an interesting object because it
+    <p>The <a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a> is an interesting object because it
     acts simultaneously as both a sink <strong>and</strong> a source for
     over-the-network streams. As a sink, it has source transformational
     capabilities (e.g., lowering bit-rates, scaling-up / down resolutions, and
@@ -2083,8 +1951,8 @@ interface MediaStreamTrackEvent : Event {
     specification. In the first figure a home client has obtained a video
     source from its local video camera. The source's width and height settings
     are 800 pixels and 600 pixels, respectively. Three
-    <code><a>MediaStream</a></code> objects on the home client contain tracks
-    that use this same <code><a>deviceId</a></code>. The three media streams
+    {{MediaStream}} objects on the home client contain tracks
+    that use this same <{{MediaStreamTrack/deviceId}}. The three media streams
     are connected to three different sinks: a <code>&lt;video&gt;</code>
     element (A), another <code>&lt;video&gt;</code> element (B), and a peer
     connection (C). The peer connection is streaming the source video to a
@@ -2100,8 +1968,7 @@ interface MediaStreamTrackEvent : Event {
     quality), and C is also scaling the video up slightly for sending over the
     network. On the remote client, sink Y is scaling the video <em>way</em>
     down, while sink Z is not applying any scaling.</p>
-    <p>In response to <code><a data-link-for=
-    "MediaStreamTrack">applyConstraints()</a></code> being called, one of the
+    <p>In response to {{MediaStreamTrack/applyConstraints()}} being called, one of the
     tracks wants a higher resolution (1920 by 1200 pixels) from the home
     client's video source.</p><img alt=
     "Changing media stream source effects: after the requested change" src=
@@ -2133,8 +2000,8 @@ interface MediaStreamTrackEvent : Event {
     source is sending a video stream sized at 1920 by 1200 pixels. The video
     source is also unconstrained, such that the exact source dimensions are
     flexible as far as the application is concerned. Two
-    <code><a>MediaStream</a></code> objects contain tracks with the same
-    <code><a>deviceId</a></code>, and those <code><a>MediaStream</a></code> s
+    {{MediaStream}} objects contain tracks with the same
+    {{MediaStreamTrack/deviceId}}, and those {{MediaStream}}s
     are connected to two different <code>&lt;video&gt;</code> element sinks A
     and B. Sink A has been sized to <code>width="1920"</code> and
     <code>height="1200"</code> and is displaying the source's video content
@@ -2160,7 +2027,7 @@ interface MediaStreamTrackEvent : Event {
     source is unable to satisfy, either because the source itself cannot
     satisfy the constraint or because the source is already satisfying a
     conflicting constraint. When this happens, the promise returned from
-    <code><a data-link-for="MediaStreamTrack">applyConstraints()</a></code>
+    {{MediaStreamTrack/applyConstraints()}}
     will be <a>rejected</a>, without applying any of the new constraints. Since
     no change in constraints occurs in this case, there is also no required
     change to the source itself as a result of this condition. Here is an
@@ -2185,75 +2052,69 @@ interface MediaStreamTrackEvent : Event {
   </section>
   <section>
     <h2>MediaStreams in Media Elements</h2>
-    <p>A <code>MediaStream</code> may be assigned to media elements. A
-    <code>MediaStream</code> is not preloadable or seekable and represents a
+    <p>A {{MediaStream}} may be assigned to media elements. A
+    {{MediaStream}} is not preloadable or seekable and represents a
     simple, potentially infinite, linear
     <a data-cite="!HTML/#media-timeline">media timeline</a>. The timeline
     starts at 0 and increments linearly in real time as long as the
     media element is <a data-cite="!HTML/#potentially-playing">
     potentially playing</a>. The timeline does not increment when
-    the playout of the <code>MediaStream</code> is paused.</p>
+    the playout of the {{MediaStream}} is paused.</p>
     <p>User Agents that support this specification MUST support the
-    <code><a data-cite=
-    "!HTML/#dom-media-srcobject">srcObject</a></code>
-    attribute of the <code>HTMLMediaElement</code> interface defined in
-    [[!HTML]], which includes support for playing <code>MediaStream</code>
+    {{HTMLMediaElement/srcObject}}
+    attribute of the {{HTMLMediaElement}} interface defined in
+    [[!HTML]], which includes support for playing {{MediaStream}}
     objects.</p>
     <p>The [[!HTML]] document outlines how the <code>HTMLMediaElement</code>
     works with a <em>media provider object</em>. The following applies when the
-    <em>media provider object</em> is a <code><a>MediaStream</a></code>:</p>
+    <em>media provider object</em> is a {{MediaStream}}:</p>
     <ul>
       <li>
-        <p>Whenever an [[!HTML]] <code><a data-cite=
-        "!HTML/#audiotrack">AudioTrack</a></code>
-        or a <code><a data-cite=
-        "!HTML/#videotrack">VideoTrack</a></code>
+        <p>Whenever an {{AudioTrack}}
+        or a {{VideoTrack}}
         is created, the <code>id</code> and <code>label</code> attributes must
         be initialized to the corresponding attributes of the
-        <code>MediaStreamTrack</code>, the <code>kind</code> attribute must be
-        initialized to "main" and the <code>language</code> attribute to the
+        {{MediaStreamTrack}}, the <code>kind</code> attribute must be
+        initialized to <code>"main"</code> and the <code>language</code> attribute to the
         empty string</p>
       </li>
       <li>The User Agent MUST always play the current data from the
-      <code><a>MediaStream</a></code> and MUST NOT buffer.</li>
+      {{MediaStream}} and MUST NOT buffer.</li>
       <li>
-        <p>Since the order in the <code><a>MediaStream</a></code> 's <a href=
-        "#track-set">track set</a> is undefined, no requirements are put on how
-        the <code><a data-cite=
-        "!HTML/#audiotracklist">AudioTrackList</a></code>
-        and <code><a data-cite=
-        "!HTML/#videotracklist">VideoTrackList</a></code>
+        <p>Since the order in the {{MediaStream}} 's [=track set=] is undefined, no requirements are put on how
+        the {{AudioTrackList}}
+        and {{VideoTrackList}}
         is ordered</p>
       </li>
       <li>
-        <p>If the element is an <code>HTMLVideoElement</code>, then it is said
+        <p>If the element is an {{HTMLVideoElement}}, then it is said
         to have <a data-cite="!HTML/#ended-playback">ended playback</a> when it
         has <dfn>ended video playback</dfn>, which is when:</p>
         <ol>
           <li>
             <p>The element's
-            <code><a data-cite="!HTML/#dom-media-readystate">readyState</a></code>
+            {{HTMLMediaElement/readyState}}
             is <code><a data-cite="!HTML/#dom-media-have_metadata">HAVE_METADATA</a></code>
             or greater, and</p>
             <ol>
               <li>
-                <p>The <code><a>MediaStream</a></code> state is
-                <a href="#stream-inactive">inactive</a> after having been
-                <a href="#stream-active">active</a>, or</p>
+                <p>The {{MediaStream}} state is
+                [= inactive =] after having been
+                [= active =], or</p>
               </li>
               <li>
-                <p>The <code><a>MediaStream</a></code> state is
-                <a href="#stream-active">active</a> after having been
-                <a href="#stream-inactive">inactive</a> after having been
-                <a href="#stream-active">active</a> after <a data-cite=
-                "!HTML/#dom-media-play">play()</a> was last called, and
-                <code>autoplay</code> is <code>false</code>.</p>
+                <p>The {{MediaStream}} state is
+                [= active =] after having been
+                [= inactive =] after having been
+                [= active =] after
+                {{HTMLMediaElement/play()}} was last called, and
+                {{HTMLMediaElement/autoplay}} is <code>false</code>.</p>
               </li>
             </ol>
             <div class="note">
               <p>Once playback has ended, it won't resume if new
-              <code><a>MediaStreamTrack</a></code>s are added to the
-              <code><a>MediaStream</a></code> unless <code>autoplay</code> is
+              {{MediaStreamTrack}}s are added to the
+              {{MediaStream}} unless {{HTMLMediaElement/autoplay}} is
               <code>true</code> or the element is restarted, e.g., by the web
               application calling <a data-cite="!HTML/#dom-media-play">play()</a>.
               </p>
@@ -2262,51 +2123,48 @@ interface MediaStreamTrackEvent : Event {
         </ol>
       </li>
       <li>
-        <p>If the element is an <code>HTMLAudioElement</code>, then it is said
+        <p>If the element is an {{HTMLAudioElement}}, then it is said
         to have <a data-cite="!HTML/#ended-playback">ended playback</a> when it
         has <dfn>ended audio playback</dfn>, which is when:</p>
         <ol>
           <li>
             <p>The element's
-            <code><a data-cite="!HTML/#dom-media-readystate">readyState</a></code>
+            {{HTMLMediaElement/readyState}}
             is <code><a data-cite="!HTML/#dom-media-have_metadata">HAVE_METADATA</a></code>
             or greater, and</p>
             <ol>
               <li>
-                <p>The <code><a>MediaStream</a></code> state is
+                <p>The {{MediaStream}} state is
                 <a href="#stream-inaudible">inaudible</a> after having been
                 <a href="#stream-audible">audible</a>, or</p>
               </li>
               <li>
-                <p>The <code><a>MediaStream</a></code> state is
+                <p>The {{MediaStream}} state is
                 <a href="#stream-audible">audible</a> after having been
                 <a href="#stream-inaudible">inaudible</a> after having been
-                <a href="#stream-audible">audible</a> after <a data-cite=
-                  "!HTML/#dom-media-play">play()</a> was last called, and
-                <code>autoplay</code> is <code>false</code>.</p>
+                <a href="#stream-audible">audible</a> after {{HTMLMediaElement/play()}} was last called, and
+                {{HTMLMediaElement/autoplay}} is <code>false</code>.</p>
               </li>
             </ol>
             <div class="note">
               <p>Once playback has ended, it won't resume if new audio
-              <code><a>MediaStreamTrack</a></code>s are added to the
-              <code><a>MediaStream</a></code> unless <code>autoplay</code> is
+              {{MediaStreamTrack}}s are added to the
+              {{MediaStream}} unless {{HTMLMediaElement/autoplay}} is
               <code>true</code> or the element is restarted, e.g., by the web
-              application calling <a data-cite="!HTML/#dom-media-play">play()</a>.
+              application calling {{HTMLMediaElement/play()}}.
               </p>
             </div>
           </li>
         </ol>
       </li>
       <li>
-        <p>Any calls to the <code><a data-cite=
-        "!HTML/#dom-media-fastseek">
-        fastSeek</a></code> method on a <code>HTMLMediaElement</code> must be
+        <p>Any calls to the {{HTMLMediaElement/fastSeek()}} method on a {{HTMLMediaElement}} must be
         ignored</p>
       </li>
     </ul>
-    <p>The nature of the <code><a>MediaStream</a></code> places certain
+    <p>The nature of the {{MediaStream}} places certain
     restrictions on the behavior of attributes of the associated
-    <code>HTMLMediaElement</code> and on the operations that can be performed
+    {{HTMLMediaElement}} and on the operations that can be performed
     on it, as shown below:</p>
     <table class="simple">
       <thead>
@@ -2320,35 +2178,28 @@ interface MediaStreamTrackEvent : Event {
       <tbody>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-preload">
-            <code>preload</code></a>
+            {{HTMLMediaElement/preload}}
           </td>
-          <td><code>DOMString</code></td>
+          <td>{{DOMString}}</td>
           <td>On getting: <code>none</code>. On setting: ignored.</td>
-          <td>A MediaStream cannot be preloaded.</td>
+          <td>A {{MediaStream}} cannot be preloaded.</td>
         </tr>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-buffered">
-            <code>buffered</code></a>
+            {{HTMLMediaElement/buffered}}
           </td>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#timeranges"><code>TimeRanges</code></a>
+            {{TimeRanges}}
           </td>
           <td><code>buffered.length</code> MUST return <code>0</code>.</td>
-          <td>A MediaStream cannot be preloaded. Therefore, the amount buffered
-          is always an empty TimeRange.</td>
+          <td>A {{MediaStream}} cannot be preloaded. Therefore, the amount buffered
+          is always an empty time range.</td>
         </tr>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-currenttime">
-            <code>currentTime</code></a>
+            {{HTMLMediaElement/currentTime}}
           </td>
-          <td><code>double</code></td>
+          <td>{{double}}</td>
           <td>Any non-negative integer. The initial value is <code>0</code> and
           the values increments linearly in real time whenever the stream is
           playing.</td>
@@ -2361,24 +2212,20 @@ interface MediaStreamTrackEvent : Event {
         </tr>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-seeking">
-            <code>seeking</code></a>
+            {{HTMLMediaElement/seeking}}
           </td>
-          <td><code>boolean</code></td>
+          <td>{{boolean}}</td>
           <td><code>false</code></td>
-          <td>A MediaStream is not seekable. Therefore, this attribute MUST
+          <td>A {{MediaStream}} is not seekable. Therefore, this attribute MUST
           always return the value <code>false</code>.</td>
         </tr>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-defaultplaybackrate">
-            <code>defaultPlaybackRate</code></a>
+            {{HTMLMediaElement/defaultPlaybackRate}}
           </td>
-          <td><code>double</code></td>
+          <td>{{double}}</td>
           <td>On getting: <code>1.0</code>. On setting: ignored.</td>
-          <td>A MediaStream is not seekable. Therefore, this attribute MUST
+          <td>A {{MediaStream}} is not seekable. Therefore, this attribute MUST
           always return the value <code>1.0</code> and any attempt to alter it
           MUST be ignored. Note that this also means that the
           <code><a data-cite=
@@ -2387,13 +2234,11 @@ interface MediaStreamTrackEvent : Event {
         </tr>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-playbackrate">
-            <code>playbackRate</code></a>
+            {{HTMLMediaElement/playbackRate}}
           </td>
-          <td><code>double</code></td>
+          <td>{{double}}</td>
           <td>On getting: <code>1.0</code>. On setting: ignored.</td>
-          <td>A MediaStream is not seekable. Therefore, this attribute MUST
+          <td>A {{MediaStream}} is not seekable. Therefore, this attribute MUST
           always return the value <code>1.0</code> and any attempt to alter it
           MUST be ignored. Note that this also means that the
           <code><a data-cite=
@@ -2402,74 +2247,53 @@ interface MediaStreamTrackEvent : Event {
         </tr>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-played">
-            <code>played</code></a>
+            {{HTMLMediaElement/played}}
           </td>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#timeranges"><code>TimeRanges</code></a>
+            {{TimeRanges}}
           </td>
           <td>
             <code>played.length</code> MUST return <code>1</code>.<br>
             <code>played.start(0)</code> MUST return <code>0</code>.<br>
-            <code>played.end(0)</code> MUST return the last known <a class=
-            "externalDFN" data-cite=
-            "!HTML/#dom-media-currenttime">
-            <code>currentTime</code></a> .
+            <code>played.end(0)</code> MUST return the last known {{HTMLMediaElement/currentTime}}.
           </td>
-          <td>A <code><a>MediaStream</a></code>'s timeline always consists of a
+          <td>A {{MediaStream}}'s timeline always consists of a
           single range, starting at 0 and extending up to the currentTime.</td>
         </tr>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-seekable">
-            <code>seekable</code></a>
+            {{HTMLMediaElement/seekable}}
           </td>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#timeranges"><code>TimeRanges</code></a>
+            {{TimeRanges}}
           </td>
           <td><code>seekable.length</code> MUST return <code>0</code>.</td>
-          <td>A <code><a>MediaStream</a></code> is not seekable.</td>
+          <td>A {{MediaStream}} is not seekable.</td>
         </tr>
         <tr>
           <td>
-            <a class="externalDFN" data-cite=
-            "!HTML/#dom-media-loop">
-            <code>loop</code></a>
+            {{HTMLMediaElement/loop}}
           </td>
-          <td><code>boolean</code></td>
+          <td>{{boolean}}</td>
           <td><code>true</code>, <code>false</code></td>
-          <td>Setting the <code>loop</code> attribute has no effect since a
-          <code><a>MediaStream</a></code> has no defined end and therefore
+          <td>Setting the {{HTMLMediaElement/loop}} attribute has no effect since a
+          {{MediaStream}} has no defined end and therefore
           cannot be looped.</td>
         </tr>
       </tbody>
     </table>
     <p>Since none of the setters listed above alter internal state of the
-    <code>HTMLMediaElement</code>, once a <code>MediaStream</code> is no longer
-    the element's <a data-link-type="dfn"
-    href="https://html.spec.whatwg.org/#assigned-media-provider-object"
+    {{HTMLMediaElement}}, once a {{MediaStream}} is no longer
+    the element's <a data-cite="HTML#assigned-media-provider-object"
     >assigned media provider object</a>, the attributes listed will appear to
     resume the values they had before a stream was assigned to the element.</p>
     <div class="note">
-      <p>A <code>MediaStream</code> stops being the element's <a data-link-type="dfn"
-      href="https://html.spec.whatwg.org/#media-element-load-algorithm"
-      >assigned media provider object</a> when <code><a data-cite=
-      "!HTML/#dom-media-srcobject"
-      >srcObject</a></code> is assigned <code>null</code> or a non-stream object,
-      just ahead of the <a data-link-type="dfn"
-      href="https://html.spec.whatwg.org/#media-element-load-algorithm"
-      >media element load algorithm</a>. As a result, the <code><a data-cite=
+      <p>A {{MediaStream}} stops being the element's <a data-cite="HTML#assigned-media-provider-object">assigned media provider object</a> when {{HTMLMediaElement/srcObject}} is assigned <code>null</code> or a non-stream object,
+      just ahead of the <a data-cite="HTML#media-element-load-algorithm">media element load algorithm</a>. As a result, the <code><a data-cite=
       "!HTML/#event-media-ratechange">ratechange</a></code>
-      event may fire (from step 7) if <a class="externalDFN" data-cite=
-      "!HTML/#dom-media-playbackrate">
-      <code>playbackRate</code></a> and <a class="externalDFN" data-cite=
-      "!HTML/#dom-media-defaultplaybackrate">
-      <code>defaultPlaybackRate</code></a> were different from before a
-      <code>MediaStream</code> was assigned.</p>
+      event may fire (from step 7) if {{HTMLMediaElement/playbackRate}}
+      and {{HTMLMediaElement/defaultPlaybackRate}} were different from before a
+      {{MediaStream}} was assigned.</p>
     </div>
   </section>
   <section>
@@ -2703,7 +2527,7 @@ interface MediaStreamTrackEvent : Event {
   </section>
   <section class="informative">
     <h2>Event summary</h2>
-    <p>The following events fire on <code><a>MediaStream</a></code>
+    <p>The following events fire on {{MediaStream}}
     objects:</p>
     <table>
       <tbody>
@@ -2716,23 +2540,23 @@ interface MediaStreamTrackEvent : Event {
       <tbody>
         <tr>
           <td><dfn id=
-          "event-mediastream-addtrack"><code>addtrack</code></dfn></td>
-          <td><code><a>MediaStreamTrackEvent</a></code></td>
-          <td>A new <code><a>MediaStreamTrack</a></code> has been added to this
+          "event-mediastream-addtrack"><code class=event>addtrack</code></dfn></td>
+          <td>{{MediaStreamTrackEvent}}</td>
+          <td>A new {{MediaStreamTrack}} has been added to this
           stream. Note that this event is not fired when the script directly
-          modifies the tracks of a <code><a>MediaStream</a></code>.</td>
+          modifies the tracks of a {{MediaStream}}.</td>
         </tr>
         <tr>
           <td><dfn id=
-          "event-mediastream-removetrack"><code>removetrack</code></dfn></td>
-          <td><code><a>MediaStreamTrackEvent</a></code></td>
-          <td>A <code><a>MediaStreamTrack</a></code> has been removed from this
+          "event-mediastream-removetrack"><code class=event>removetrack</code></dfn></td>
+          <td>{{MediaStreamTrackEvent}}</td>
+          <td>A {{MediaStreamTrack}} has been removed from this
           stream. Note that this event is not fired when the script directly
-          modifies the tracks of a <code><a>MediaStream</a></code>.</td>
+          modifies the tracks of a {{MediaStream}}.</td>
         </tr>
       </tbody>
     </table>
-    <p>The following events fire on <code><a>MediaStreamTrack</a></code>
+    <p>The following events fire on {{MediaStreamTrack}}
     objects:</p>
     <table>
       <tbody>
@@ -2745,23 +2569,23 @@ interface MediaStreamTrackEvent : Event {
       <tbody>
         <tr>
           <td><dfn id=
-          "event-mediastreamtrack-mute"><code>mute</code></dfn></td>
-          <td><code>Event</code></td>
-          <td>The <code><a>MediaStreamTrack</a></code> object's source is
+          "event-mediastreamtrack-mute"><code class=event>mute</code></dfn></td>
+          <td>{{Event}}</td>
+          <td>The {{MediaStreamTrack}} object's source is
           temporarily unable to provide data.</td>
         </tr>
         <tr>
           <td><dfn id=
-          "event-mediastreamtrack-unmute"><code>unmute</code></dfn></td>
-          <td><code>Event</code></td>
-          <td>The <code><a>MediaStreamTrack</a></code> object's source is live
+          "event-mediastreamtrack-unmute"><code class=event>unmute</code></dfn></td>
+          <td>{{Event}}</td>
+          <td>The {{MediaStreamTrack}} object's source is live
           again after having been temporarily unable to provide data.</td>
         </tr>
         <tr>
-          <td><code id="event-mediastreamtrack-ended">ended</code></td>
-          <td><code>Event</code></td>
+          <td><code  class=event id="event-mediastreamtrack-ended">ended</code></td>
+          <td>{{Event}}</td>
           <td>
-            <p>The <code><a>MediaStreamTrack</a></code> object's source will no
+            <p>The {{MediaStreamTrack}} object's source will no
             longer provide any data, either because the user revoked the
             permissions, or because the source device has been ejected, or
             because the remote peer permanently stopped sending data.</p>
@@ -2769,7 +2593,7 @@ interface MediaStreamTrackEvent : Event {
         </tr>
       </tbody>
     </table>
-    <p>The following events fire on <code><a>MediaDevices</a></code>
+    <p>The following events fire on {{MediaDevices}}
     objects:</p>
     <table>
       <tbody>
@@ -2782,12 +2606,11 @@ interface MediaStreamTrackEvent : Event {
       <tbody>
         <tr>
           <td><dfn id=
-          "event-mediadevices-devicechange"><code>devicechange</code></dfn></td>
-          <td><code>Event</code></td>
+          "event-mediadevices-devicechange"><code class=event>devicechange</code></dfn></td>
+          <td>{{Event}}</td>
           <td>The set of media devices, available to the User Agent, has
           changed. The current list devices can be retrieved with the
-          <code><a href=
-          "#dom-mediadevices-enumeratedevices">enumerateDevices()</a></code>
+          {{MediaDevices/enumerateDevices()}}
           method.</td>
         </tr>
       </tbody>
@@ -2809,11 +2632,10 @@ interface MediaStreamTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="Navigator" data-dfn-for="Navigator" class=
           "attributes">
-            <dt><dfn><code>mediaDevices</code></dfn> of type <span class=
-            "idlAttrType"><a>MediaDevices</a></span>, readonly</dt>
+            <dt><dfn>mediaDevices</dfn> of type {{MediaDevices}}, readonly</dt>
             <dd>
-              <p>Returns the <code>MediaDevices</code> object associated with
-              this <code>Navigator</code> object.</p>
+              <p>Returns the {{MediaDevices}} object associated with
+              this {{Navigator}} object.</p>
             </dd>
           </dl>
         </section>
@@ -2825,7 +2647,6 @@ interface MediaStreamTrackEvent : Event {
       to the API used to examine and get access to media devices available to
       the User Agent.</p>
       <p>On page load, run the following steps:</p>
-      <p></p>
       <ol>
         <li>
           <p>On the <a data-cite=
@@ -2913,9 +2734,8 @@ interface MediaStreamTrackEvent : Event {
           <p>Set <a>[[\storedDeviceList]]</a> to null.</p>
         </li>
         <li>
-          <p>Queue a task that fires a simple event named <code><a href=
-          "#event-mediadevices-devicechange">devicechange</a></code> at the
-          <code><a>MediaDevices</a></code> object.</p>
+          <p>Queue a task that fires a simple event named <a>devicechange</a> at the
+          {{MediaDevices}} object.</p>
         </li>
       </ol>
       <p>If a browsing context later comes to meet the
@@ -2927,10 +2747,10 @@ interface MediaStreamTrackEvent : Event {
       removed at the same time, e.g. a camera with a microphone.</p>
       <p><a>[[\storedDeviceList]]</a> before these two steps can potentially list
       the exact same set of devices in the same order as the list of devices
-      generated by a call to <code>enumerateDevices</code> after the two above steps.
+      generated by a call to {{MediaDevices/enumerateDevices}} after the two above steps.
       In that case, if the "device-info" permission is not "granted", the User Agent
       MUST skip these two steps, thus not fire a
-      <code><a href="#event-mediadevices-devicechange">devicechange</a></code>
+      <a>devicechange</a>
       event. If the "device-info" permission is "granted", the User Agent MAY also
       skip these two steps.</p>
       <p>These events are potentially triggered simultaneously across browsing
@@ -2947,11 +2767,9 @@ interface MediaDevices : EventTarget {
           <h2>Attributes</h2>
           <dl data-link-for="MediaDevices" data-dfn-for="MediaDevices" class=
           "attributes">
-            <dt><dfn><code>ondevicechange</code></dfn> of type <span class=
-            "idlAttrType"><a>EventHandler</a></span></dt>
+            <dt><dfn>ondevicechange</dfn> of type {{EventHandler}}</dt>
             <dd>
-              <p>The event type of this event handler is <code><a href=
-              "#event-mediadevices-devicechange">devicechange</a></code>.</p>
+              <p>The event type of this event handler is <a>devicechange</a>.</p>
             </dd>
           </dl>
         </section>
@@ -2959,23 +2777,23 @@ interface MediaDevices : EventTarget {
           <h2>Methods</h2>
           <dl data-link-for="MediaDevices" data-dfn-for="MediaDevices" class=
           "methods">
-            <dt><dfn><code>enumerateDevices</code></dfn></dt>
+            <dt><dfn>enumerateDevices</dfn></dt>
             <dd>
               <p>Collects information about the User Agent's available media
               input and output devices.</p>
               <p>This method returns a promise. The promise will be
               <a>fulfilled</a> with a sequence of
-              <code><a>MediaDeviceInfo</a></code> objects representing the
+              {{MediaDeviceInfo}} objects representing the
               User Agent's available media input and output devices if
               enumeration is successful.</p>
               <p>Elements of this sequence that represent input devices will be
-              of type <code><a>InputDeviceInfo</a></code> which extends
-              <code><a>MediaDeviceInfo</a></code>.</p>
-              <p>Camera and microphone sources <em class="rfc2119">should</em>
+              of type {{InputDeviceInfo}} which extends
+              {{MediaDeviceInfo}}.</p>
+              <p>Camera and microphone sources SHOULD
               be enumerable. Specifications that add additional types of source
               will provide recommendations about whether the source type should
               be enumerable.</p>
-              <p>When the <code>enumerateDevices()</code> method is
+              <p>When the {{MediaDevices/enumerateDevices()}} method is
               called, the User Agent must run the following steps:</p>
               <ol>
                 <li>
@@ -2986,14 +2804,13 @@ interface MediaDevices : EventTarget {
                   <ol>
                     <li>
                       <p>Let <var>document</var> be the <a>current settings object</a>'s
-                      <a>responsible document</a>.</p>
+                      [=environment settings object/responsible document=].</p>
                     </li>
                     <li>
                       <p>The User Agent MUST wait to proceed to the next step until the
                       <a>device information can be exposed check</a> returns <code>true</code>.</p>
                       <p>The User Agent MAY wait to proceed to the next step
-                      until <var>document</var> is <a data-cite=
-                          "!HTML/#fully-active">fully active</a>
+                      until <var>document</var> is [=Document/fully active=]
                       and <a data-cite="!HTML/#gains-focus">has
                       focus.</a></p>
                     </li>
@@ -3002,11 +2819,11 @@ interface MediaDevices : EventTarget {
                       <p>If <a>[[\storedDeviceList]]</a> is not null, run the following sub steps:</p>
                       <ol>
                         <li>
-                          <p>For each <code><a>MediaDeviceInfo</a></code> object in <a>[[\storedDeviceList]]</a>,
+                          <p>For each {{MediaDeviceInfo}} object in <a>[[\storedDeviceList]]</a>,
                           <var>storedDeviceInfo</var>:
                           <ul>
                              <li>
-                               <p>Append to <var>resultList</var> a <code><a>MediaDeviceInfo</a></code>
+                               <p>Append to <var>resultList</var> a {{MediaDeviceInfo}}
                                copy of <var>storedDeviceInfo</var>.</p>
                              </li>
                            </ul>
@@ -3021,53 +2838,38 @@ interface MediaDevices : EventTarget {
                       <ol>
                         <li>
                           <p>If <var>device</var> is a camera, and
-                          <var>document</var> is not <a data-link-type="dfn"
-                            href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use"
-                            >allowed to use</a> the feature identified by
-                          <code>"camera"</code>, abort these steps and continue
+                          <var>document</var> is not [=allowed to use=] the feature identified by
+                          <a data-dfn-link-for="">"camera"</a>, abort these steps and continue
                           with the next device (if any).</p>
                         </li>
                         <li>
                           <p>If <var>device</var> is a microphone, and
-                          <var>document</var> is not <a data-link-type="dfn"
-                            href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use"
-                            >allowed to use</a> the feature identified by
-                          <code>"microphone"</code>, abort these steps and
+                          <var>document</var> is not [=allowed to use=] the feature identified by
+                          <a data-dfn-link-for="">"microphone"</a>, abort these steps and
                           continue with the next device (if any).</p>
                         </li>
                         <li>
                           <p>Let <var>deviceInfo</var> be a new
-                          <code><a>MediaDeviceInfo</a></code> object to
+                          {{MediaDeviceInfo}} object to
                           represent <var>device</var>.</p>
                         </li>
                         <li>
-                          <p>If a stored <code><a data-link-for=
-                          "MediaDeviceInfo">deviceId</a></code> exists for
-                          <var>device</var>, initialize <var>deviceInfo</var>'s
-                          <code><a data-link-for=
-                          "MediaDeviceInfo">deviceId</a></code> to that value.
-                          Otherwise, let <var>deviceInfo</var>'s
-                          <code><a data-link-for=
-                          "MediaDeviceInfo">deviceId</a></code> member be a
+                          <p>If a stored {{MediaDeviceInfo/deviceId}} exists for
+                          <var>device</var>, initialize <var>deviceInfo</var>.{{MediaDeviceInfo/deviceId}} to that value.
+                          Otherwise, let <var>deviceInfo</var>.{{MediaDeviceInfo/deviceId}} be a
                           newly generated unique identifier.</p>
                         </li>
                         <li>
                           <p>If <var>device</var> belongs to the same physical
                           device as a device already represented for <var>document</var>,
-                          initialize <var>deviceInfo</var>'s
-                          <code><a data-link-for=
-                          "MediaDeviceInfo">groupId</a></code> member to the
-                          <code><a data-link-for=
-                          "MediaDeviceInfo">groupId</a></code> value of the
-                          existing <code><a>MediaDeviceInfo</a></code> object.
-                          Otherwise, let <var>deviceInfo</var>'s
-                          <code><a data-link-for=
-                          "MediaDeviceInfo">groupId</a></code> member be a
+                          initialize <var>deviceInfo</var>.{{MediaDeviceInfo/groupId}} to the
+                          {{MediaDeviceInfo/groupId}} value of the
+                          existing {{MediaDeviceInfo}} object.
+                          Otherwise, let <var>deviceInfo</var>.{{MediaDeviceInfo/groupId}} be a
                           newly generated unique identifier.</p>
 
-                          <p>A good practice for generating <code><a
-                          data-link-for="MediaDeviceInfo">deviceId</a></code>
-                          and <code><a data-link-for="MediaDeviceInfo">groupId</a></code>
+                          <p>A good practice for generating {{MediaDeviceInfo/deviceId}}
+                          and {{MediaDeviceInfo/groupId}}
                           values is to use a UUID [[rfc4122]], which is 36
                           characters long in its canonical form. To avoid
                           fingerprinting, implementations SHOULD use the forms in
@@ -3090,14 +2892,14 @@ interface MediaDevices : EventTarget {
                       <ol>
                         <li>
                           <p>If any of the local devices are attached to a
-                          <code>live</code> MediaStreamTrack in the current
+                          live MediaStreamTrack in the current
                           browsing context, set <var>list-permission</var> to
-                          "granted", otherwise set <var>list-permission</var>
-                          to "granted" if <a>[[\canExposeDeviceInfo]]</a> is
-                          <code>true</code> and "denied" otherwise.</p>
+                          <code>"granted"</code>, otherwise set <var>list-permission</var>
+                          to <code>"granted"</code> if <a>[[\canExposeDeviceInfo]]</a> is
+                          <code>true</code> and <code>"denied"</code> otherwise.</p>
                         </li>
                         <li>
-                          <p>If <var>list-permission</var> is "granted",
+                          <p>If <var>list-permission</var> is <code>"granted"</code>,
                           then <a>resolve</a> <var>p</var> with
                           <var>resultList</var>, and abort these steps.</p>
                         </li>
@@ -3105,20 +2907,20 @@ interface MediaDevices : EventTarget {
                           <p>Let <var>filteredList</var> be an empty list.</p>
                         </li>
                         <li>
-                          <p>For each <code><a>MediaDeviceInfo</a></code>,
+                          <p>For each {{MediaDeviceInfo}},
                           <var>deviceInfo</var>, in <var>resultList</var>,
                           run the following sub steps:</p>
                           <ol>
                             <li>
-                              <p>If <var>filteredList</var> contains a <code>MediaDeviceInfo</code> object
-                              whose <code><a href="#def-mediadeviceinfo-kind">kind</a></code>
-                              is the same as <var>deviceInfo</var>.<code><a href="#def-mediadeviceinfo-kind">kind</a></code>,
+                              <p>If <var>filteredList</var> contains a {{MediaDeviceInfo}} object
+                              whose {{MediaDeviceInfo/kind}}
+                              is the same as <var>deviceInfo</var>.{{MediaDeviceInfo/kind}},
                               skip <var>deviceInfo</var>.</p>
                             </li>
                             <li>
-                              <p>Let <var>filteredDeviceInfo</var> be a new <code>MediaDeviceInfo</code> object
-                              whose <code><a href="#def-mediadeviceinfo-kind">kind</a></code>
-                              is set to <var>deviceInfo</var>.<code><a href="#def-mediadeviceinfo-kind">kind</a></code>.</p>
+                              <p>Let <var>filteredDeviceInfo</var> be a new {{MediaDeviceInfo}} object
+                              whose {{MediaDeviceInfo/kind}}
+                              is set to <var>deviceInfo</var>.{{MediaDeviceInfo/kind}}.</p>
                             </li>
                             <li>
                               <p>Append <var>filteredDeviceInfo</var> to <var>filteredList</var>.</p>
@@ -3156,11 +2958,11 @@ interface MediaDevices : EventTarget {
         information depends on whether or not permission has been granted to
         the page's origin.</p>
         <p>If no such access has been granted, the
-        <code><a>MediaDeviceInfo</a></code> object will contain the
-        deviceId, kind, and groupId.</p>
+        {{MediaDeviceInfo}} object will contain the
+        {{MediaDeviceInfo/deviceId}}, {{MediaDeviceInfo/kind}}, and {{MediaDeviceInfo/groupId}}.</p>
         <p>If access has been granted for a media device, the
-        <dfn>MediaDeviceInfo</dfn> object will contain the deviceId, kind,
-        label, and groupId.</p>
+        <dfn>MediaDeviceInfo</dfn> object will contain the {{MediaDeviceInfo/deviceId}}, {{MediaDeviceInfo/kind}},
+        {{MediaDeviceInfo/label}}, and {{MediaDeviceInfo/groupId}}.</p>
       </section>
       <section>
         <h2>Device information can be exposed check</h2>
@@ -3170,9 +2972,8 @@ interface MediaDevices : EventTarget {
         <ol>
           <li>If <a>[[\canExposeDeviceInfo]]</a> is <code>true</code>, return <code>true</code>.
           </li>
-          <li>If the <a>current settings object</a>'s <a>responsible
-          document</a> is <a data-cite="!HTML/#fully-active">fully
-          active</a> and <a data-cite="!HTML/#gains-focus">has
+          <li>If the <a>current settings object</a>'s [=environment settings object/responsible
+          document=] is [=Document/fully active=] and <a data-cite="!HTML/#gains-focus">has
           focus</a>, return <code>true</code>.
           </li>
           <li>Return <code>false</code>.</li>
@@ -3182,9 +2983,9 @@ interface MediaDevices : EventTarget {
         <h2>Set device information exposure</h2>
         <p>To <dfn data-lt="set-device-information-exposure" id=
         "set-device-information-exposure">set the device information exposure</dfn>,
-        with a <code>value</code> of type boolean, run the following steps:</p>
+        with a <var>value</var> of type boolean, run the following steps:</p>
         <ol>
-          <li>Set <a>[[\canExposeDeviceInfo]]</a> to <code>value</code>.</li>
+          <li>Set <a>[[\canExposeDeviceInfo]]</a> to <var>value</var>.</li>
         </ol>
         <div class="note">
           <p>A User Agent MAY at any point set the device information exposure back to <code>false</code>,
@@ -3208,21 +3009,17 @@ interface MediaDeviceInfo {
           <h2>Attributes</h2>
           <dl data-link-for="MediaDeviceInfo" data-dfn-for="MediaDeviceInfo"
           class="attributes">
-            <dt id="def-mediadeviceinfo-deviceId"><dfn><code>deviceId</code></dfn>
-            of type <span class="idlAttrType">DOMString</span>, readonly</dt>
+            <dt id="def-mediadeviceinfo-deviceId"><dfn>deviceId</dfn>
+            of type {{DOMString}}, readonly</dt>
             <dd>
               <p>The identifier of the represented device. The device MUST be
-              uniquely identified by its identifier and its <code><a
-              href="#def-mediadeviceinfo-kind">kind</a></code>.</p>
+              uniquely identified by its identifier and its {{MediaDeviceInfo/kind}}.</p>
               <p>To to ensure stored identifiers are recognized, the identifier
-              MUST be the same in documents of the same origin in <a data-cite=
-              "!HTML/#top-level-browsing-context">top-level browsing contexts.</a>
-              In <a data-cite=
-              "!HTML/#nested-browsing-context">nested browsing contexts</a>,
+              MUST be the same in documents of the same origin in [=top-level browsing contexts=].
+              In [=nested browsing contexts=],
               the decision of whether or not the identifier is the same across
               documents, MUST follow the user agents' partitioning rules for
-              storage (such as <a data-cite=
-              "!HTML/#dom-localstorage"><code>localStorage</code></a>), if any,
+              storage (such as {{WindowLocalStorage/localStorage}}), if any,
               to not interfere with mitigations for cross-site correlation.
               The identifier SHOULD be origin-unique,
               in which case some sort of UUID is recommended.
@@ -3233,46 +3030,43 @@ interface MediaDeviceInfo {
               can be reused across origins as long as it is not tied to the user
               and can be guessed by other means, like the User-Agent string.</p>
               <p>If any local devices have been attached to a live
-              MediaStreamTrack in a page from this origin, or <a href=
-              "#stored-permissions">stored permission</a> to access local
+              {{MediaStreamTrack}} in a page from this origin, or [=stored permission=] to access local
               devices has been granted to this origin, then this identifier
               MUST be persisted, except as detailed below. Unique and stable
               identifiers let the application save, identify the availability
               of, and directly request specific sources, across multiple
               visits.</p>
               <p>However, as long as no local device has been attached to a
-              live MediaStreamTrack in a page from this origin, and no <a href=
-              "#stored-permissions">stored permission</a> to access local
+              live MediaStreamTrack in a page from this origin, and no [=stored permission=] to access local
               devices has been granted to this origin, then the user agent MAY
               clear this identifier once the last browsing session from this
               origin has been closed. If the user agent chooses not to clear
               the identifier in this condition, then it MUST provide for the
               user to visibly inspect and delete the identifier, like a
               cookie.</p>
-              <p class="fingerprint">Since <code>deviceId</code> may persist
+              <p class="fingerprint">Since {{deviceId}} may persist
               across browsing sessions and to reduce its potential as a
-              fingerprinting mechanism, <code>deviceId</code> is to be treated
+              fingerprinting mechanism, {{deviceId}} is to be treated
               as other persistent storage mechanisms such as cookies
               [[COOKIES]], in that user agents MUST NOT persist device
               identifiers for sites that are blocked from using cookies, and
               user agents MUST reset per-origin device identifiers when other
               persistent storage are cleared.</p>
             </dd>
-            <dt id="def-mediadeviceinfo-kind"><dfn><code>kind</code></dfn> of
-            type <span class= "idlAttrType"><a>MediaDeviceKind</a></span>,
+            <dt id="def-mediadeviceinfo-kind"><dfn>kind</dfn> of
+            type {{MediaDeviceKind}},
             readonly</dt>
             <dd>
               <p>The kind of the represented device.</p>
             </dd>
-            <dt><dfn><code>label</code></dfn> of type <span class=
-            "idlAttrType">DOMString</span>, readonly</dt>
+            <dt><dfn>label</dfn> of type {{DOMString}}, readonly</dt>
             <dd>
               <p>A label describing this device (for example "External USB
               Webcam"). If the device has no associated label, then this
               attribute MUST return the empty string.</p>
             </dd>
-            <dt id="def-mediadeviceinfo-groupId"><dfn><code>groupId</code></dfn>
-            of type <span class="idlAttrType">DOMString</span>, readonly</dt>
+            <dt id="def-mediadeviceinfo-groupId"><dfn>groupId</dfn>
+            of type {{DOMString}}, readonly</dt>
             <dd>
               <p>The group identifier of the represented device. Two devices
               have the same group identifier if they belong to the same
@@ -3280,8 +3074,7 @@ interface MediaDeviceInfo {
               representing the speaker and microphone of the same headset
               have the same groupId.</p>
               <p>The group identifier MUST be uniquely generated for each
-              <a data-link-type="dfn"
-              href="https://dom.spec.whatwg.org/#concept-document">document</a>.</p>
+              <a>document</a>.</p>
             </dd>
           </dl>
         </section>
@@ -3289,10 +3082,9 @@ interface MediaDeviceInfo {
           <h2>Methods</h2>
           <dl data-link-for="MediaDeviceInfo" data-dfn-for="MediaDeviceInfo"
           class="methods">
-            <dt><dfn><code>toJSON</code></dfn></dt>
+            <dt><dfn>toJSON</dfn></dt>
             <dd>
-              When called, run [[!WEBIDL]]'s <a data-cite=
-              "WEBIDL#default-tojson-operation">default toJSON operation</a>.
+              When called, run [[!WEBIDL]]'s <a>default toJSON operation</a>.
             </dd>
           </dl>
         </section>
@@ -3312,24 +3104,24 @@ interface MediaDeviceInfo {
               description</th>
             </tr>
             <tr>
-              <td><dfn><code id=
-              "idl-def-MediaDeviceKind.audioinput">audioinput</code></dfn></td>
+              <td><dfn id=
+              "idl-def-MediaDeviceKind.audioinput">audioinput</dfn></td>
               <td>
                 <p>Represents an audio input device; for example a
                 microphone.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn><code id=
-              "idl-def-MediaDeviceKind.audiooutput">audiooutput</code></dfn></td>
+              <td><dfn id=
+              "idl-def-MediaDeviceKind.audiooutput">audiooutput</dfn></td>
               <td>
                 <p>Represents an audio output device; for example a pair of
                 headphones.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn><code id=
-              "idl-def-MediaDeviceKind.videoinput">videoinput</code></dfn></td>
+              <td><dfn id=
+              "idl-def-MediaDeviceKind.videoinput">videoinput</dfn></td>
               <td>
                 <p>Represents a video input device; for example a webcam.</p>
               </td>
@@ -3352,24 +3144,24 @@ interface InputDeviceInfo : MediaDeviceInfo {
           <h2>Methods</h2>
           <dl data-link-for="InputDeviceInfo" data-dfn-for="InputDeviceInfo"
           class="methods">
-            <dt><dfn><code>getCapabilities</code></dfn></dt>
+            <dt><dfn>getCapabilities</dfn></dt>
             <dd>
-              <p>Returns a <code><a>MediaTrackCapabilities</a></code> object
+              <p>Returns a {{MediaTrackCapabilities}} object
               describing the primary audio or video track of a device's
-              <code><a>MediaStream</a></code> (according to its
-              <code>kind</code> value), in the absence of any user-supplied
+              {{MediaStream}} (according to its
+              {{MediaStreamTrack/kind}} value), in the absence of any user-supplied
               constraints. These capabilities MUST be identical to those that
               would have been obtained by calling
-              <code>getCapabilities()</code> on the first
-              <code><a>MediaStreamTrack</a></code> of this type in a
-              <code><a>MediaStream</a></code> returned by
-              <code>getUserMedia({deviceId: <i>id</i>})</code> where <i>id</i>
-              is the value of the <code>deviceId</code> attribute of this
-              <code>MediaDeviceInfo</code>.</p>
+              {{MediaStreamTrack/getCapabilities()}} on the first
+              {{MediaStreamTrack}} of this type in a
+              {{MediaStream}} returned by
+              <code>getUserMedia({deviceId: <i>id</i>})</code> where <var>id</var>
+              is the value of the {{MediaDeviceInfo/deviceId}} attribute of this
+              {{MediaDeviceInfo}}.</p>
               <p>If no access has been granted to any local devices and this
-              <code>InputDeviceInfo</code> has been filtered with respect to
+              {{InputDeviceInfo}} has been filtered with respect to
               unique identifying information (see above description of
-              <code>enumerateDevices()</code> result), then this method returns
+              {{MediaDevices/enumerateDevices()}} result), then this method returns
               an empty dictionary.</p>
             </dd>
           </dl>
@@ -3379,10 +3171,10 @@ interface InputDeviceInfo : MediaDeviceInfo {
   </section>
   <section id="local-content">
     <h2>Obtaining local multimedia content</h2>
-    <p>This section extends <code><a>Navigator</a></code> and
-    <code><a>MediaDevices</a></code> with APIs to request permission to access
+    <p>This section extends {{Navigator}} and
+    {{MediaDevices}} with APIs to request permission to access
     media input devices available to the User Agent.</p>
-    <p>Alternatively, a local <code><a>MediaStream</a></code> can be captured
+    <p>Alternatively, a local {{MediaStream}} can be captured
     from certain types of DOM elements, such as the video element
     [[mediacapture-fromelement]]. This can be useful for automated testing.</p>
     <p>When on an insecure origin [[mixed-content]], User Agents are encouraged
@@ -3399,8 +3191,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
         changes from the method definition that has existed here for many
         months.
         <p>First, the official definition for the getUserMedia() method, and
-        the one which developers are encouraged to use, is now at <a href=
-        "#dom-mediadevices-getusermedia">MediaDevices</a>. This decision
+        the one which developers are encouraged to use, is now at {{MediaDevices}}. This decision
         reflected consensus as long as the original API remained available here
         under the Navigator object for backwards compatibility reasons, since
         the working group acknowledges that early users of these APIs have been
@@ -3436,23 +3227,21 @@ interface InputDeviceInfo : MediaDeviceInfo {
           <h2>Methods</h2>
           <dl data-link-for="Navigator" data-dfn-for="Navigator" class=
           "methods">
-            <dt><dfn><code>getUserMedia</code></dfn></dt>
+            <dt><dfn>getUserMedia</dfn></dt>
             <dd>
               <p>Prompts the user for permission to use their Web cam or other
               video or audio input.</p>
               <p>The <var>constraints</var> argument is a dictionary of type
-              <code><a>MediaStreamConstraints</a></code>.</p>
+              {{MediaStreamConstraints}}.</p>
               <p>The <var>successCallback</var> will be invoked with a suitable
-              <code><a>MediaStream</a></code> object as its argument if the
-              user accepts valid tracks as described in <a href=
-              "#dom-mediadevices-getusermedia">getUserMedia()</a> on
-              <code><a>MediaDevices</a></code>.</p>
+              {{MediaStream}} object as its argument if the
+              user accepts valid tracks as described in {{MediaDevices/getUserMedia()}} on
+              {{MediaDevices}}.</p>
               <p>The <var>errorCallback</var> will be invoked if there is a
               failure in finding valid tracks or if the user denies permission,
-              as described in <a href=
-              "#dom-mediadevices-getusermedia">getUserMedia()</a> on
-              <code><a>MediaDevices</a></code>.</p>
-              <p>When the <code><a>getUserMedia()</a></code> method is called,
+              as described in {{MediaDevices/getUserMedia()}} on
+              {{MediaDevices}}.</p>
+              <p>When the {{getUserMedia()}} method is called,
               the User Agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -3535,7 +3324,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
           <h2>Methods</h2>
           <dl data-link-for="MediaDevices" data-dfn-for="MediaDevices" class=
           "methods">
-            <dt><dfn><code>getSupportedConstraints</code></dfn></dt>
+            <dt><dfn>getSupportedConstraints</dfn></dt>
             <dd>
               <p>Returns a dictionary whose members are the constrainable
               properties known to the User Agent. A supported constrainable
@@ -3544,19 +3333,19 @@ interface InputDeviceInfo : MediaDeviceInfo {
               dictionary. The values returned represent what the browser
               implements and will not change during a browsing session.</p>
             </dd>
-            <dt><dfn><code>getUserMedia</code></dfn></dt>
+            <dt>getUserMedia</dt>
             <dd>
               <p>Prompts the user for permission to use their Web cam or other
               video or audio input.</p>
               <p>The <var>constraints</var> argument is a dictionary of type
-              <code><a>MediaStreamConstraints</a></code>.</p>
+              {{MediaStreamConstraints}}.</p>
               <p>This method returns a promise. The promise will be
-              <a>fulfilled</a> with a suitable <code><a>MediaStream</a></code>
+              <a>fulfilled</a> with a suitable {{MediaStream}}
               object if the user accepts valid tracks as described below.</p>
               <p>The promise will be <a>rejected</a> if there is a failure in
               finding valid tracks or if the user denies permission, as
               described below.</p>
-              <p>When the <code><dfn>getUserMedia()</dfn></code> method is
+              <p>When the <dfn>getUserMedia()</dfn> method is
               called, the User Agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -3566,23 +3355,22 @@ interface InputDeviceInfo : MediaDeviceInfo {
                 <li>
                   <p>Let <var>requestedMediaTypes</var> be the set of media
                   types in <var>constraints</var> with either a dictionary
-                  value or a value of "true".</p>
+                  value or a value of <code>true</code>.</p>
                 </li>
                 <li>
                   <p>If <var>requestedMediaTypes</var> is the empty set, return
-                  a promise <a>rejected</a> with a <code>TypeError</code>. The
+                  a promise <a>rejected</a> with a {{TypeError}}. The
                   word "optional" occurs in the WebIDL due to WebIDL rules, but
                   the argument MUST be supplied in order for the call to
                   succeed.</p>
                 </li>
                 <li>
-                  <p>If the <a>current settings object</a>'s <a>responsible
-                  document</a> is NOT <a data-cite=
-                  "!HTML/#fully-active">fully active</a>, return
+                  <p>If the <a>current settings object</a>'s [=environment settings object/responsible
+                  document=] is NOT [=Document/fully active=], return
                   a promise <a>rejected</a> with a
-                  <code><a>DOMException</a></code> object whose
-                  <code>name</code> attribute has the value
-                  <code>InvalidStateError</code>.</p>
+                  {{DOMException}} object whose
+                  {{DOMException/name}} attribute has the value
+                  {{"InvalidStateError"}}.</p>
                 </li>
                 <li>
                   <p>Let <var>p</var> be a new promise.</p>
@@ -3592,9 +3380,8 @@ interface InputDeviceInfo : MediaDeviceInfo {
                   <ol>
                     <li>
                       <p>The User Agent MUST wait to proceed to the next step until
-                      the <a>current settings object</a>'s <a>responsible
-                      document</a> is <a data-cite=
-                          "!HTML/#fully-active">fully active</a>
+                      the <a>current settings object</a>'s [=environment settings object/responsible
+                      document=] is [=Document/fully active=]
                       and <a data-cite="!HTML/#gains-focus">has
                       focus.</a></p>
                     </li>
@@ -3614,21 +3401,21 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           <var>candidateSet</var>.</p>
                           <p>If <var>candidateSet</var> is the empty set,
                           <a>reject</a> <var>p</var> with a new
-                          <code><a>DOMException</a></code> object whose
-                          <code>name</code> attribute has the value
-                          <code>NotFoundError</code> and abort these steps.</p>
+                          {{DOMException}} object whose
+                          {{DOMException/name}} attribute has the value
+                          {{"NotFoundError"}} and abort these steps.</p>
                         </li>
                         <li>If the value of the <var>kind</var> entry of
-                        <var>constraints</var> is "true", set <var>CS</var> to
+                        <var>constraints</var> is <code>true</code>, set <var>CS</var> to
                         the empty constraint set (no constraint). Otherwise,
                         continue with <var>CS</var> set to the value of the
                         <var>kind</var> entry of <var>constraints</var>.</li>
                         <li>Remove any constrainable property inside of
                         <var>CS</var> that are not defined for
-                        <code><a>MediaStreamTrack</a></code> objects of type
+                        {{MediaStreamTrack}} objects of type
                         <var>kind</var>. This means that audio-only constraints
-                        inside of "video" and video-only constraints inside of
-                        "audio" are simply ignored rather than causing
+                        inside of <a>"video"</a> and video-only constraints inside of
+                        <a>"audio"</a> are simply ignored rather than causing
                         <code>OverconstrainedError</code>.</li>
                         <li>
                           <p>Run the <a>SelectSettings</a> algorithm on each
@@ -3655,13 +3442,13 @@ interface InputDeviceInfo : MediaDeviceInfo {
                         <li>
                           <p><a>Retrieve the permission state</a> for all
                           candidate devices in <var>candidateSet</var> that are
-                          not attached to a <code>live</code> MediaStreamTrack
+                          not attached to a live {{MediaStreamTrack}}
                           in the current browsing context. Remove from
                           <var>candidateSet</var> any device for which the
-                          permission state is "denied".</p>
+                          permission state is {{PermissionState/"denied"}}.</p>
                           <p>If <var>candidateSet</var> is now empty,
                           indicating that all devices of this type are in state
-                          "denied", jump to the step labeled
+                          {{PermissionState/"denied"}}, jump to the step labeled
                           <em>PermissionFailure</em> below.</p>
                         </li>
                         <li>
@@ -3678,7 +3465,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                     </li>
                     <li>
                       <p>Let <var>stream</var> be a new and empty
-                      <code><a>MediaStream</a></code> object.</p>
+                      {{MediaStream}} object.</p>
                     </li>
                     <li>
                       <p>For each media type <var>kind</var> in
@@ -3691,20 +3478,19 @@ interface InputDeviceInfo : MediaDeviceInfo {
                       </div>
                       <ol>
                         <li>
-                          <p><a>Request permission to
-                          use</a> a PermissionDescriptor with its name member set
+                          <p>[=Request permission to
+                          use=] a {{PermissionDescriptor}} with its {{PermissionDescriptor/name}} member set
                           to the permission name associated with <var>kind</var>
-                          (e.g. "camera" for "video", "microphone" for "audio"),
+                          (e.g. {{PermissionName/"camera"}} for <a>"video"</a>, {{PermissionName/"microphone"}} for <a>"audio"</a>),
                           and, optionally, consider its deviceId member set to
                           any appropriate device's <var>deviceId</var>,
                           while considering all devices attached to a
-                          <code>live</code> and <a>same-permission</a>
-                          MediaStreamTrack in the current <a data-cite=
-                          "!HTML/#browsing-context">browsing
-                          context</a> to have permission status "granted",
+                          live and <a>same-permission</a>
+                          {{MediaStreamTrack}} in the current [=browsing
+                          context=] to have permission status {{PermissionState/"granted"}},
                           resulting in a set of provided media.
                           <dfn>Same-permission</dfn> in this context means a
-                          MediaStreamTrack that required the same level of
+                          {{MediaStreamTrack}} that required the same level of
                           permission to obtain as what is being requested (e.g. not
                           isolated).</p>
                           <p>When asking the user’s permission, the user agent
@@ -3717,7 +3503,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           choose from the <var>finalSet</var> is completely up to
                           the User Agent and may be determined by asking the user.
                           Once selected, the source of the
-                          <code><a>MediaStreamTrack</a></code> MUST NOT change.</p>
+                          {{MediaStreamTrack}} MUST NOT change.</p>
                           <p>The User Agent MAY use the value of the computed
                           "fitness distance" from the <a>SelectSettings</a>
                           algorithm, or any other internally-available information
@@ -3728,28 +3514,28 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           (when possible). User Agents
                           MAY allow users to use any media source, including
                           pre-recorded media files.</p>
-                          <p>If the result of the request is "granted", then using
+                          <p>If the result of the request is {{PermissionState/"granted"}}, then using
                           the granted device's deviceId, <var>deviceId</var>, set
-                          <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> to
+                          <a>[[\devicesLiveMap]]</a>[<var>deviceId</var>] to
                           <code>true</code>, if it isn’t already <code>true</code>,
                           and set the
-                          <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> to
+                          <a>[[\devicesAccessibleMap]]</a>[<var>deviceId</var>] to
                           <code>true</code>, if it isn’t already
                           <code>true</code>.</p>
-                          <p>If the result is "denied", jump to the step labeled
+                          <p>If the result is {{PermissionState/"denied"}}, jump to the step labeled
                           <em>Permission Failure</em> below. If the user never
                           responds, this algorithm stalls on this step.</p>
                           <p>If the user grants permission but a hardware error
                           such as an OS/program/webpage lock prevents access,
                           <a>reject</a> <var>p</var> with a new
-                          <code><a>DOMException</a></code> object whose
-                          <code>name</code> attribute has the value
-                          <code>NotReadableError</code> and abort these steps.</p>
-                          <p>If the result is "granted" but device access fails for
+                          {{DOMException}} object whose
+                          {{DOMException/name}} attribute has the value
+                          {{"NotReadableError"}} and abort these steps.</p>
+                          <p>If the result is {{PermissionState/"granted"}} but device access fails for
                           any reason other than those listed above, <a>reject</a>
-                          <var>p</var> with a new <code><a>DOMException</a></code>
-                          object whose <code>name</code> attribute has the
-                          value <code>AbortError</code> and abort these steps.</p>
+                          <var>p</var> with a new {{DOMException}}
+                          object whose {{DOMException/name}} attribute has the
+                          value {{"AbortError"}} and abort these steps.</p>
                         </li>
                         <li>
                           <p>Add <var>track</var> to <var>stream</var>'s track set.</p>
@@ -3774,9 +3560,9 @@ interface InputDeviceInfo : MediaDeviceInfo {
                     </li>
                     <li>
                       <p><em>Permission Failure</em>: <a>Reject</a>
-                      <var>p</var> with a new <code><a>DOMException</a></code>
-                      object whose <code>name</code> attribute has the
-                      value <code>NotAllowedError</code>.</p>
+                      <var>p</var> with a new {{DOMException}}
+                      object whose {{DOMException/name}} attribute has the
+                      value {{"NotAllowedError"}}.</p>
                     </li>
                     <li>
                       <p><em>Constraint Failure</em>: Let <var>message</var> be
@@ -3807,7 +3593,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
     <section>
       <h2>MediaStreamConstraints</h2>
       <p>The <dfn>MediaStreamConstraints</dfn> dictionary is used to instruct
-      the User Agent what sort of <a>MediaStreamTrack</a>s to include in the
+      the User Agent what sort of {{MediaStreamTrack}}s to include in the
       <a>MediaStream</a> returned by <a data-link-for=
       "MediaDevices">getUserMedia()</a>.</p>
       <div>
@@ -3821,18 +3607,16 @@ interface InputDeviceInfo : MediaDeviceInfo {
           Members</h2>
           <dl data-link-for="MediaStreamConstraints" data-dfn-for=
           "MediaStreamConstraints" class="dictionary-members">
-            <dt><dfn><code>video</code></dfn> of type <span class=
-            "idlMemberType">(boolean or MediaTrackConstraints)</span>,
+            <dt><dfn>video</dfn> of type <code>({{boolean}} or {{MediaTrackConstraints}})</code>,
             defaulting to <code>false</code></dt>
             <dd>
               <p>If <code>true</code>, it requests that the returned
               <a>MediaStream</a> contain a video track. If a <a>Constraints</a>
               structure is provided, it further specifies the nature and
               settings of the video Track. If <code>false</code>, the
-              <a>MediaStream</a> MUST NOT contain a video Track.</p>
+              {{MediaStream}} MUST NOT contain a video Track.</p>
             </dd>
-            <dt><dfn><code>audio</code></dfn> of type <span class=
-            "idlMemberType">(boolean or MediaTrackConstraints)</span>,
+            <dt><dfn>audio</dfn> of type <code>({{boolean}} or {{MediaTrackConstraints}})</code>,
             defaulting to <code>false</code></dt>
             <dd>
               <p>If <code>true</code>, it requests that the returned
@@ -3856,12 +3640,10 @@ interface InputDeviceInfo : MediaDeviceInfo {
           Parameters</h2>
           <dl data-link-for="NavigatorUserMediaSuccessCallback" data-dfn-for=
           "NavigatorUserMediaSuccessCallback" class="callback-members">
-            <dt><code>stream</code> of type <span class=
-            "idlMemberType"><a>MediaStream</a></span></dt>
+            <dt>stream of type {{MediaStream}}</dt>
             <dd>
-              <code><a>MediaStream</a></code> object representing the stream to
-              which the user granted permission as described in the <a data-lt=
-              "Navigator.getUserMedia"><code>navigator.getUserMedia()</code></a>
+              {{MediaStream}} object representing the stream to
+              which the user granted permission as described in the {{Navigator.getUserMedia}}
               algorithm.
             </dd>
           </dl>
@@ -3878,12 +3660,10 @@ interface InputDeviceInfo : MediaDeviceInfo {
           Parameters</h2>
           <dl data-link-for="NavigatorUserMediaErrorCallback" data-dfn-for=
           "NavigatorUserMediaErrorCallback" class="callback-members">
-            <dt><code>error</code> of type <span class=
-            "idlMemberType"><a>MediaStreamError</a></span></dt>
+            <dt>error of type {{MediaStreamError}}</dt>
             <dd>
-              Error in obtaining a <code><a>MediaStream</a></code> as described
-              in the failure steps of the <a data-lt=
-              "Navigator.getUserMedia"><code>navigator.getUserMedia()</code></a>
+              Error in obtaining a {{MediaStream}} as described
+              in the failure steps of the {{Navigator.getUserMedia}}
               algorithm.
             </dd>
           </dl>
@@ -3893,7 +3673,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
         <pre class="idl">typedef object MediaStreamError;</pre>
         <div class="idlTypedefDesc">
           A <dfn>MediaStreamError</dfn> object is either a
-          <code><a>DOMException</a></code> object or an
+          {{DOMException}} object or an
           <code><a>OverconstrainedError</a></code> object.
         </div>
       </div>
@@ -3936,11 +3716,11 @@ interface InputDeviceInfo : MediaDeviceInfo {
         stream was affected must be removed.</p>
       </div>
       <div class="practice">
-        <span id="stored-permissions" class="practicelab">Stored
-        Permissions</span>
+        <dfn id="stored-permissions" class="practicelab">Stored
+        Permission</dfn>s
         <p class="practicedesc">When permission is requested for a device, the
-        User Agent may choose to <a href="#create-permission">create a
-        permission storage entry</a> for later use by the same origin, so that
+        User Agent may choose to [=create a
+        permission storage entry=] for later use by the same origin, so that
         the user does not need to grant permission again at a later time.
         It is a User Agent choice whether it offers functionality to store
         permission to each device separately, all devices of a given class, or
@@ -4141,7 +3921,7 @@ const constraints = {
     frames per second, and no greater than 40, the Setting can be any
     intermediate value, e.g., 32, 35, or 37 frames per second. The application
     can query the current settings of the object's constrainable properties via
-    the <code><a data-link-for="MediaStreamTrack">getSettings()</a></code>
+    the {{MediaStreamTrack/getSettings()}}
     accessor.</p>
     <section>
       <h2>Interface Definition</h2>
@@ -4192,7 +3972,7 @@ interface ConstrainablePattern {
           <h2>Methods</h2>
           <dl data-link-for="ConstrainablePattern" data-dfn-for=
           "ConstrainablePattern" class="methods">
-            <dt><code>getCapabilities</code></dt>
+            <dt>getCapabilities</dt>
             <dd>
               <p>The <dfn data-lt=
               "ConstrainablePattern.getCapabilities">getCapabilities()</dfn>
@@ -4214,12 +3994,12 @@ interface ConstrainablePattern {
                 to "medium". It might also indicate that given a ConstraintSet
                 imposing a strict value of 3, the User Agent should attempt to
                 set the value of "medium" on the hardware, and that
-                <code><a>getSettings()</a></code> should return a
+                {{getSettings()}} should return a
                 fluxCapacitance of 0, since that is the value defined as
                 corresponding to "medium".</p>
               </div>
             </dd>
-            <dt><code>getConstraints</code></dt>
+            <dt>{{getConstraints}}</dt>
             <dd>
               <p>The <dfn>getConstraints()</dfn> method returns the Constraints
               that were the argument to the most recent successful invocation
@@ -4227,14 +4007,14 @@ interface ConstrainablePattern {
               maintaining the order in which they were specified. Note that
               some of the advanced ConstraintSets returned may not be currently
               satisfied. To check which ConstraintSets are currently in effect,
-              the application should use <code>getSettings</code>. Instead of
+              the application should use {{getSettings}}. Instead of
               returning the exact constraints as described above, the UA MAY
               return a constraint set that has the identical effect in all
               situations as the applied constraints. When invoked, the User Agent
               MUST return the value of the <a>[[\Constraints]]</a> internal slot.
               </p>
             </dd>
-            <dt><code>getSettings</code></dt>
+            <dt>getSettings</dt>
             <dd>
               <p>The <dfn>getSettings()</dfn> method returns the current
               settings of all the constrainable properties of the object,
@@ -4245,7 +4025,7 @@ interface ConstrainablePattern {
               Agent MUST return the value of the <a>[[\Settings]]</a>
               internal slot.</p>
             </dd>
-            <dt><code>applyConstraints</code></dt>
+            <dt>applyConstraints</dt>
             <dd>
               <p>When the <dfn>applyConstraints template method</dfn> is invoked, the
               User Agent MUST run the following steps:</p>
@@ -4410,7 +4190,7 @@ interface ConstrainablePattern {
                   which means that unknown/unsupported required constraints
                   will silently disappear. To avoid this being a surprise,
                   application authors are expected to first use the
-                  <code>getSupportedConstraints()</code> method as shown in the
+                  {{MediaDevices/getSupportedConstraints()}} method as shown in the
                   Examples below.</p>
                 </li>
                 <li>Let <var>object</var> be the
@@ -4456,9 +4236,8 @@ interface ConstrainablePattern {
                   <p>Select one settings dictionary from <var>candidates</var>,
                   and return it as the result of the <a>SelectSettings</a>
                   algorithm. The UA SHOULD use the one with the smallest
-                  <code>fitness distance</code>, as calculated in step 3, but
-                  MAY prefer ones with <code><a href=
-                  "#def-constraint-resizeMode">resizeMode</a></code> set to
+                  <a>fitness distance</a>, as calculated in step 3, but
+                  MAY prefer ones with <a>resizeMode</a> set to
                   <code>"none"</code> over <code>"crop-and-scale"</code>.</p>
                 </li>
               </ol>
@@ -4525,10 +4304,10 @@ interface ConstrainablePattern {
         </section>
       </div>
       <p>An example of Constraints that could be passed into
-      <code><a data-link-for="MediaStreamTrack">applyConstraints()</a></code>
+      {{MediaStreamTrack/applyConstraints()}}
       or returned as a value of <code><a>constraints</a></code> is below. It
-      uses the <a href="#constrainable-properties">constrainable properties
-      defined for <code>MediaStreamTrack</code></a>.</p>
+      uses the <a href="#constrainable-properties">constrainable properties</a>
+      defined for {{MediaStreamTrack}}.</p>
       <pre class="example">
 const supports = navigator.mediaDevices.getSupportedConstraints();
 if (!supports.facingMode) {
@@ -4655,13 +4434,11 @@ async function specifyCamera() {
           <h2>Dictionary <dfn>DoubleRange</dfn> Members</h2>
           <dl data-link-for="DoubleRange" data-dfn-for="DoubleRange" class=
           "dictionary-members">
-            <dt><dfn><code>max</code></dfn> of type <span class=
-            "idlMemberType">double</span></dt>
+            <dt><dfn>max</dfn> of type {{double}}</dt>
             <dd>
               <p>The maximum legal value of this property.</p>
             </dd>
-            <dt><dfn><code>min</code></dfn> of type <span class=
-            "idlMemberType">double</span></dt>
+            <dt><dfn>min</dfn> of type {{double}}</dt>
             <dd>
               <p>The minimum value of this Property.</p>
             </dd>
@@ -4678,13 +4455,11 @@ async function specifyCamera() {
           <h2>Dictionary <dfn>ConstrainDoubleRange</dfn> Members</h2>
           <dl data-link-for="ConstrainDoubleRange" data-dfn-for=
           "ConstrainDoubleRange" class="dictionary-members">
-            <dt><dfn><code>exact</code></dfn> of type <span class=
-            "idlMemberType">double</span></dt>
+            <dt><dfn>exact</dfn> of type {{double}}</dt>
             <dd>
               <p>The exact required value for this property.</p>
             </dd>
-            <dt><dfn><code>ideal</code></dfn> of type <span class=
-            "idlMemberType">double</span></dt>
+            <dt><dfn>ideal</dfn> of type {{double}}</dt>
             <dd>
               <p>The ideal (target) value for this property.</p>
             </dd>
@@ -4701,13 +4476,11 @@ async function specifyCamera() {
           <h2>Dictionary <dfn>ULongRange</dfn> Members</h2>
           <dl data-link-for="ULongRange" data-dfn-for="ULongRange" class=
           "dictionary-members">
-            <dt><dfn><code>max</code></dfn> of type <span class=
-            "idlMemberType">unsigned long</span></dt>
+            <dt><dfn>max</dfn> of type {{unsigned long}}</dt>
             <dd>
               <p>The maximum legal value of this property.</p>
             </dd>
-            <dt><dfn><code>min</code></dfn> of type <span class=
-            "idlMemberType">unsigned long</span></dt>
+            <dt><dfn>min</dfn> of type {{unsigned long}}</dt>
             <dd>
               <p>The minimum value of this property.</p>
             </dd>
@@ -4724,13 +4497,11 @@ async function specifyCamera() {
           <h2>Dictionary <dfn>ConstrainULongRange</dfn> Members</h2>
           <dl data-link-for="ConstrainULongRange" data-dfn-for=
           "ConstrainULongRange" class="dictionary-members">
-            <dt><dfn><code>exact</code></dfn> of type <span class=
-            "idlMemberType">unsigned long</span></dt>
+            <dt><dfn>exact</dfn> of type {{unsigned long}}</dt>
             <dd>
               <p>The exact required value for this property.</p>
             </dd>
-            <dt><dfn><code>ideal</code></dfn> of type <span class=
-            "idlMemberType">unsigned long</span></dt>
+            <dt><dfn>ideal</dfn> of type {{unsigned long}}</dt>
             <dd>
               <p>The ideal (target) value for this property.</p>
             </dd>
@@ -4747,13 +4518,11 @@ async function specifyCamera() {
           <h2>Dictionary <dfn>ConstrainBooleanParameters</dfn> Members</h2>
           <dl data-link-for="ConstrainBooleanParameters" data-dfn-for=
           "ConstrainBooleanParameters" class="dictionary-members">
-            <dt><dfn><code>exact</code></dfn> of type <span class=
-            "idlMemberType">boolean</span></dt>
+            <dt><dfn>exact</dfn> of type {{boolean}}</dt>
             <dd>
               <p>The exact required value for this property.</p>
             </dd>
-            <dt><dfn><code>ideal</code></dfn> of type <span class=
-            "idlMemberType">boolean</span></dt>
+            <dt><dfn>ideal</dfn> of type {{boolean}}</dt>
             <dd>
               <p>The ideal (target) value for this property.</p>
             </dd>
@@ -4770,15 +4539,13 @@ async function specifyCamera() {
           <h2>Dictionary <dfn>ConstrainDOMStringParameters</dfn> Members</h2>
           <dl data-link-for="ConstrainDOMStringParameters" data-dfn-for=
           "ConstrainDOMStringParameters" class="dictionary-members">
-            <dt><dfn><code>exact</code></dfn> of type <span class=
-            "idlMemberType">(DOMString or
-            sequence&lt;DOMString&gt;)</span></dt>
+            <dt><dfn>exact</dfn> of type <code>({{DOMString}} or
+            sequence&lt;{{DOMString}}&gt;)</code></dt>
             <dd>
               <p>The exact required value for this property.</p>
             </dd>
-            <dt><dfn><code>ideal</code></dfn> of type <span class=
-            "idlMemberType">(DOMString or
-            sequence&lt;DOMString&gt;)</span></dt>
+            <dt><dfn>ideal</dfn> of type <code>({{DOMString}} or
+            sequence&lt;{{DOMString}}&gt;)</code></dt>
             <dd>
               <p>The ideal (target) value for this property.</p>
             </dd>
@@ -4868,7 +4635,7 @@ async function specifyCamera() {
       would still suggest that more than two resolutions were available.</p>A
       specification using the Constrainable Pattern should not subclass the
       below dictionary, but instead provide its own definition. See
-      <code><a>MediaTrackCapabilities</a></code> for an example.
+      {{MediaTrackCapabilities}} for an example.
       <div>
         <pre class="idl">dictionary Capabilities {};</pre>
       </div>
@@ -4879,7 +4646,7 @@ async function specifyCamera() {
       pairs. It MUST contain each key returned in
       <code>getCapabilities()</code> for which the property is defined on the
       object type it's returned on; for instance, an audio
-      <code><a>MediaStreamTrack</a></code> has no "width" property. There MUST
+      {{MediaStreamTrack}} has no "width" property. There MUST
       be a single value for each key and the value MUST be a member of the set
       defined for that property by <code>getCapabilities()</code>. The
       <code>Settings</code> dictionary contains the actual values that the User
@@ -5097,35 +4864,22 @@ window.onload = async () =&gt; {
   </section>
   <section>
     <h1 id=feature-policy-integration>Feature Policy Integration</h1>
-    <p>This specification defines two <a data-link-type="dfn"
-      href="https://wicg.github.io/feature-policy/#policy-controlled-feature"
-      >policy-controlled feature</a>s
+    <p>This specification defines two [=policy-controlled feature=]s
     identified by the strings
-    <code>"<dfn data-lt="camera-feature">camera</dfn>"</code> and
-    <code>"<dfn data-lt="microphone-feature">microphone</dfn>"</code>.
-    Both have a <a data-link-type="dfn"
-      href="https://wicg.github.io/feature-policy/#default-allowlist"
-      >default allowlist</a> of <code>"self"</code>.
+    <code><dfn>"camera"</dfn></code> and
+    <code><dfn>"microphone"</dfn></code>.
+    Both have a [=default allowlist=] of <code class=featurepolicy>"self"</code>.
     <div class="note">
-      <p>A <a data-link-type="dfn"
-        href="https://dom.spec.whatwg.org/#concept-document">document</a>'s
-      <a data-link-type="dfn"
-        href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-feature-policy"
-        >feature policy</a>
+      <p>A [=document=]'s [=Document/feature policy=]
       determines whether any content in that document is allowed to use
-      <code>getUserMedia</code> to request camera or microphone respectively. If
-      disabled in any document, no content in the document will be
-      <a data-link-type="dfn"
-        href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use"
-        >allowed to use</a>
-      <code>getUserMedia</code> to request the camera or microphone
-      respectively. This is enforced by the <a>request permission to use</a>
+      {{MediaDevices/getUserMedia}} to request camera or microphone respectively. If
+      disabled in any document, no content in the document will be [=allowed to use=]
+      {{MediaDevices/getUserMedia}} to request the camera or microphone
+      respectively. This is enforced by the [=request permission to use=]
       algorithm.
       </p>
-      <p>Additionally, <code>enumerateDevices</code> will only enumerate devices
-      the document is <a data-link-type="dfn"
-        href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use"
-        >allowed to use</a>.</p>
+      <p>Additionally, {{MediaDevices/enumerateDevices}} will only enumerate devices
+      the document is [=allowed to use=].</p>
     </div>
   </section>
   <section>
@@ -5212,7 +4966,7 @@ window.onload = async () =&gt; {
     identifiers for the devices are designed to not be useful for a fingerprint
     that can track the user between origins, but the number and grouping of
     devices adds to the fingerprint surface. It recommends to treat the
-    per-origin persistent identifier <code>deviceId</code> as other persistent
+    per-origin persistent identifier {{MediaDeviceInfo/deviceId}} as other persistent
     storage (e.g. cookies) are treated.</p>
     <p>When authorization is given, this document describes how to get access
     to, and use, media data from the devices mentioned. This data may be
@@ -5230,7 +4984,7 @@ window.onload = async () =&gt; {
     origins that have also been granted authorization, and thus potentially
     provide a way to track a given device across time and origins.</p>
     <p>For origins to which permission has been granted, the
-    <code><a>devicechange</a></code> event will be emitted across browsing
+    <code class=event><a>devicechange</a></code> event will be emitted across browsing
     contexts and origins each time a new media device is added or removed; user
     agents can mitigate the risk of correlation of browsing activity across
     origins by fuzzing the timing of these events.</p>
@@ -5299,37 +5053,36 @@ window.onload = async () =&gt; {
       <p>At a minimum, defining a new media type would require</p>
       <ul>
         <li>adding a new getXXXXTracks() method for the type to the
-        <code><a>MediaStream</a></code> interface,</li>
+        {{MediaStream}} interface,</li>
         <li>describing what a muted or disabled track of that type will render
         (see <a href="#life-cycle-and-media-flow"></a>),
         </li>
         <li>adding the new type as an additional legal value for the
-        <code><a href="#dom-mediastreamtrack-kind">kind</a></code> attribute on
-        the <code><a>MediaStreamTrack</a></code> interface,</li>
+        {{MediaStreamTrack/kind}} attribute on
+        the {{MediaStreamTrack}} interface,</li>
         <li>defining any constrainable properties (see <a href=
         "#constrainable-properties"></a>) that are applicable to the media
         type,
         </li>
-        <li>updating how the <code>HTMLMediaElement</code> works with a <code>
-          <a>MediaStream</a></code> containing a track of the new media type
+        <li>updating how the {{HTMLMediaElement}} works with a
+          {{MediaStream}} containing a track of the new media type
           (see <a href="#mediastreams-in-media-elements"></a>), including
           adding a corollary to <a href="#stream-audible">audible</a>/inaudible
           for the new media type,
         </li>
-        <li>updating <code><a>MediaDeviceKind</a></code> if the new type has
+        <li>updating {{MediaDeviceKind}} if the new type has
         enumerable devices,</li>
-        <li>updating the <code>getCapabilities()</code> and
-        <code>getUserMedia()</code> descriptions,</li>
+        <li>updating the {{MediaStreamTrack/getCapabilities()}} and
+        {{MediaDevices/getUserMedia()}} descriptions,</li>
         <li>adding the new type to the
-        <code><a>MediaStreamConstraints</a></code> dictionary,</li>
+        {{MediaStreamConstraints}} dictionary,</li>
         <li>describing any new security and/or privacy considerations (see
         <a href="#privacy-and-security-considerations"></a>) introduced by the
         new type, and
         </li>
         <li>if the new type requires user authorization, defining new
         permissions for it, including a new PermissionDescriptor name
-        associated with the new <code><a href=
-        "#dom-mediastreamtrack-kind">kind</a></code>, and defining how these
+        associated with the new {{MediaStreamTrack/kind}}, and defining how these
         permissions, along with access starting and ending, as well as
         muting/disabling, affect any new and/or existing "on-air" and "device
         accessible" indicator states (see <a href="#mediadevices"></a>).
@@ -5341,9 +5094,8 @@ window.onload = async () =&gt; {
         </li>
         <li>the list of media stream <a>consumer</a>s,
         </li>
-        <li>the description of the <code><a href=
-        "#dom-mediastreamtrack-label">label</a></code> attribute on the
-        <code><a>MediaStreamTrack</a></code> interface,</li>
+        <li>the description of the {{MediaStreamTrack/label}} attribute on the
+        {{MediaStreamTrack}} interface,</li>
         <li>the list of sinks (see <a href=
         "#the-model-sources-sinks-constraints-and-settings"></a>), and
         </li>
@@ -5356,7 +5108,7 @@ window.onload = async () =&gt; {
         <li>explaining how the media is expected to be used by potential
         <a>consumer</a>s, and
         </li>
-        <li>giving examples in <code><a>MediaStreamTrackState</a></code> of how
+        <li>giving examples in {{MediaStreamTrackState}} of how
         such a track might become ended.</li>
       </ul>
     </section>
@@ -5365,12 +5117,12 @@ window.onload = async () =&gt; {
       <p>This will require thinking through and defining how Constraints,
       Capabilities, and Settings for the property (see <a href=
       "#terminology"></a>) will work. The relevant text in
-      <code><a>MediaTrackSupportedConstraints</a></code>,
-      <code><a>MediaTrackCapabilities</a></code>,
-      <code><a>MediaTrackConstraints</a></code>,
-      <code><a>MediaTrackSettings</a></code>, <a href=
+      {{MediaTrackSupportedConstraints}},
+      {{MediaTrackCapabilities}},
+      {{MediaTrackConstraints}},
+      {{MediaTrackSettings}}, <a href=
       "#constrainable-properties"></a>, and
-      <code><a>MediaStreamConstraints</a></code> are the model to use.</p>
+      {{MediaStreamConstraints}} are the model to use.</p>
       <p>Creators of extension specifications are strongly encouraged to notify
       the Media Capture Task Force of their extension by emailing the list at
       public-media-capture@w3.org.<br>
@@ -5379,15 +5131,15 @@ window.onload = async () =&gt; {
       aware of in an attempt to reduce potential usage conflicts.</p>
     </section>
     <p>&nbsp;</p>
-    <p>It is also likely that new consumers of <code><a>MediaStream</a></code>s
-    or <code><a>MediaStreamTrack</a></code>s will be defined in the future. The
+    <p>It is also likely that new consumers of {{MediaStream}}s
+    or {{MediaStreamTrack}}s will be defined in the future. The
     following section provides guidance.</p>
     <section>
       <h2>Defining new consumers of MediaStreams and MediaStreamTracks</h2>
       <p>At a minimum, any new consumer of a
-      <code><a>MediaStreamTrack</a></code> will need to define</p>
+      {{MediaStreamTrack}} will need to define</p>
       <ul>
-        <li>how a <code><a>MediaStreamTrack</a></code> will render in the
+        <li>how a {{MediaStreamTrack}} will render in the
         various states in which it can be, including muted and disabled (see
         <a href="#life-cycle-and-media-flow"></a>).
         </li>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -190,10 +190,8 @@
       [[WEBRTC]].</dd>
       <dt>Permissions</dt>
       <dd>
-        <p>The terms [=permission=], [=retrieve the permission
-        state=], [=request permission to
-        use=] and [=create a permission storage
-        entry=] are defined in [[!permissions]].</p>
+        <p>The terms <dfn data-cite="permissions#reading-current-states">reading current permission state</dfn> and [=request permission to
+        use=]  are defined in [[!permissions]].</p>
       </dd>
     </dl>
   </section>
@@ -621,7 +619,7 @@ interface MediaStream : EventTarget {
         </li>
         <li>
           <p>If the result of <a data-lt=
-          "retrieve the permission state">retrieving the permission state</a>
+          "reading current permission state">reading the current permission state</a>
           of the permission associated with the device's kind and
           <var>deviceId</var>, is not {{PermissionState/"granted"}}, then set
           <a>[[\devicesAccessibleMap]]</a>[<var>deviceId</var>] to
@@ -2673,9 +2671,9 @@ interface MediaStreamTrackEvent : Event {
           "MediaDevices">getUserMedia()</a> exposes, set
           <a>[[\kindsAccessibleMap]]</a><var>[kind]</var> either to <code>true</code>
           if the result of <a data-lt=
-          "retrieve the permission state">retrieving the permission state</a>
-          of the permission associated with <var>kind</var> (e.g. "camera",
-          "microphone"), is "granted", or to <code>false</code> otherwise.</p>
+          "reading current permission state">reading the permission state</a>
+          of the permission associated with <var>kind</var> (e.g. {{PermissionName/"camera"}},
+          {{PermissionName/"microphone"}}), is {{PermissionState/"granted"}}, or to <code>false</code> otherwise.</p>
         </li>
         <li>
           <p>For each individual device that <a data-link-for=
@@ -2684,41 +2682,39 @@ interface MediaStreamTrackEvent : Event {
           <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> to <code>false</code>, and
           set <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> either to
           <code>true</code> if the result of <a data-lt=
-          "retrieve the permission state">retrieving the permission state</a>
+          "reading current permission state">reading the permission state</a>
           of the permission associated with the device’s kind and
-          <var>deviceId</var>, is “granted”, or to false otherwise.</p>
+          <var>deviceId</var>, is {{PermissionState/"granted"}}, or to false otherwise.</p>
         </li>
       </ol>
-      <p>For each kind of device, <var>kind</var>, that <a data-link-for=
-      "MediaDevices">getUserMedia()</a> exposes, <a data-lt=
-      "retrieve the permission state">whenever a transition occurs of the
+      <p>For each kind of device, <var>kind</var>, that {{MediaDevices/getUserMedia()}} exposes, <a data-lt=
+      "reading current permission state">whenever a transition occurs of the
       permission state</a> of the permission associated with <var>kind</var>,
       run the following steps:</p>
       <ol>
         <li>
-          <p>If the transition is to “granted” from another value, then set
+          <p>If the transition is to {{PermissionState/"granted"}} from another value, then set
           <a>[[\kindsAccessibleMap]]</a><var>[kind]</var> to <code>true</code>.</p>
         </li>
         <li>
-          <p>If the transition is from “granted” to another value, then set
+          <p>If the transition is from {{PermissionState/"granted"}} to another value, then set
           <a>[[\kindsAccessibleMap]]</a><var>[kind]</var> to <code>false</code>.</p>
         </li>
       </ol>
-      <p>For each device that <a data-link-for=
-      "MediaDevices">getUserMedia()</a> exposes, <a data-lt=
-      "retrieve the permission state">whenever a transition occurs of the
+      <p>For each device that {{MediaDevices/getUserMedia()}} exposes, <a data-lt=
+      "reading current permission state">whenever a transition occurs of the
       permission state</a> of the permission associated with the device's kind
       and the device's deviceId, <var>deviceId</var>, run the following
       steps:</p>
       <ol>
         <li>
-          <p>If the transition is to “granted” from another value, then set
+          <p>If the transition is to {{PermissionState/"granted"}} from another value, then set
           <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> to <code>true</code>,
           if it isn’t already <code>true</code>.</p>
         </li>
         <li>
-          <p>If the transition is from “granted” to another value, and the
-          device is currently <a href="#source-stopped">stopped</a>, then set
+          <p>If the transition is from {{PermissionState/"granted"}} to another value, and the
+          device is currently <a>stopped</a>, then set
           <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> to
           <code>false</code>.</p>
         </li>
@@ -3440,7 +3436,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           a fingerprinting surface.</p>
                         </li>
                         <li>
-                          <p><a>Retrieve the permission state</a> for all
+                          <p><a data-lt="reading current permission state">Read the current permission state</a> for all
                           candidate devices in <var>candidateSet</var> that are
                           not attached to a live {{MediaStreamTrack}}
                           in the current browsing context. Remove from
@@ -3719,8 +3715,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
         <dfn id="stored-permissions" class="practicelab">Stored
         Permission</dfn>s
         <p class="practicedesc">When permission is requested for a device, the
-        User Agent may choose to [=create a
-        permission storage entry=] for later use by the same origin, so that
+        User Agent may choose to store this permission for later use by the same origin, so that
         the user does not need to grant permission again at a later time.
         It is a User Agent choice whether it offers functionality to store
         permission to each device separately, all devices of a given class, or

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -5140,7 +5140,7 @@ window.onload = async () =&gt; {
       that kind.</li>
       <li>Define any<var>&lt;kind&gt;Live</var> (e.g. <var>anyAudioLive</var>,
       <var>anyVideoLive</var>) to be the logical OR of the
-      <a>[[\kindsLiveMap]]</a><var>[kind]</var> value and all the
+      <a>[[\kindsAccessibleMap]]</a><var>[kind]</var> value and all the
       <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> values for devices of that
       kind.</li>
     </ul>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -643,7 +643,7 @@ interface MediaStream : EventTarget {
           <p>Let <var>deviceId</var> be the device's deviceId.</p>
         </li>
         <li>
-          <p>Set [[\devicesLiveMap]]<var>[deviceId]</var> to
+          <p>Set [[\devicesLiveMap]]</a><var>[deviceId]</var> to
           <code>false</code>.</p>
         </li>
         <li>
@@ -651,7 +651,7 @@ interface MediaStream : EventTarget {
           "retrieve the permission state">retrieving the permission state</a>
           of the permission associated with the device's kind and
           <var>deviceId</var>, is not “granted”, then set
-          [[\devicesAccessibleMap]]<var>[deviceId]</var> to
+          [[\devicesAccessibleMap]]</a><var>[deviceId]</var> to
           <code>false</code>.</p>
         </li>
       </ol>
@@ -721,7 +721,7 @@ interface MediaStream : EventTarget {
         muted or disabled, and this brings all tracks connected to the device
         to be either muted, disabled, or stopped, then the UA MAY, using the
         device's deviceId, <var>deviceId</var>, set
-        [[\devicesLiveMap]]<var>[deviceId]</var> to <code>false</code>,
+        [[\devicesLiveMap]]</a><var>[deviceId]</var> to <code>false</code>,
         provided the UA sets it back to <code>true</code> as soon as any
         unstopped track connected to this device becomes un-muted or enabled
         again.</p>
@@ -2833,16 +2833,16 @@ interface MediaStreamTrackEvent : Event {
           object</a>, run the following steps:</p>
           <ol>
             <li>
-              <p>Create three internal slots: [[\devicesLiveMap]],
-              [[\devicesAccessibleMap]], and [[\kindsAccessibleMap]], each
+              <p>Create three internal slots: <dfn>[[\devicesLiveMap]]</dfn>,
+              <dfn>[[\devicesAccessibleMap]]</dfn>, and <dfn>[[\kindsAccessibleMap]]</dfn>, each
               initialized to a different empty object.</p>
             </li>
             <li>
-              <p>Create one internal slot: [[\storedDeviceList]], initialized
+              <p>Create one internal slot: <dfn>[[\storedDeviceList]]</dfn>, initialized
               to null.</p>
             </li>
             <li>
-              <p>Create one internal slot: [[\canExposeDeviceInfo]], initialized
+              <p>Create one internal slot: <dfn>[[\canExposeDeviceInfo]]</dfn>, initialized
               to <code>false</code>.</p>
             </li>
           </ol>
@@ -2850,7 +2850,7 @@ interface MediaStreamTrackEvent : Event {
         <li>
           <p>For each kind of device, <var>kind</var>, that <a data-link-for=
           "MediaDevices">getUserMedia()</a> exposes, set
-          [[\kindsAccessibleMap]]<var>[kind]</var> either to <code>true</code>
+          <a>[[\kindsAccessibleMap]]</a><var>[kind]</var> either to <code>true</code>
           if the result of <a data-lt=
           "retrieve the permission state">retrieving the permission state</a>
           of the permission associated with <var>kind</var> (e.g. "camera",
@@ -2860,8 +2860,8 @@ interface MediaStreamTrackEvent : Event {
           <p>For each individual device that <a data-link-for=
           "MediaDevices">getUserMedia()</a> exposes, using the device's
           deviceId, <var>deviceId</var>, set
-          [[\devicesLiveMap]]<var>[deviceId]</var> to <code>false</code>, and
-          set [[\devicesAccessibleMap]]<var>[deviceId]</var> either to
+          <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> to <code>false</code>, and
+          set <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> either to
           <code>true</code> if the result of <a data-lt=
           "retrieve the permission state">retrieving the permission state</a>
           of the permission associated with the device’s kind and
@@ -2876,11 +2876,11 @@ interface MediaStreamTrackEvent : Event {
       <ol>
         <li>
           <p>If the transition is to “granted” from another value, then set
-          [[\kindsAccessibleMap]]<var>[kind]</var> to <code>true</code>.</p>
+          <a>[[\kindsAccessibleMap]]</a><var>[kind]</var> to <code>true</code>.</p>
         </li>
         <li>
           <p>If the transition is from “granted” to another value, then set
-          [[\kindsAccessibleMap]]<var>[kind]</var> to <code>false</code>.</p>
+          <a>[[\kindsAccessibleMap]]</a><var>[kind]</var> to <code>false</code>.</p>
         </li>
       </ol>
       <p>For each device that <a data-link-for=
@@ -2892,13 +2892,13 @@ interface MediaStreamTrackEvent : Event {
       <ol>
         <li>
           <p>If the transition is to “granted” from another value, then set
-          [[\devicesAccessibleMap]]<var>[deviceId]</var> to <code>true</code>,
+          <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> to <code>true</code>,
           if it isn’t already <code>true</code>.</p>
         </li>
         <li>
           <p>If the transition is from “granted” to another value, and the
           device is currently <a href="#source-stopped">stopped</a>, then set
-          [[\devicesAccessibleMap]]<var>[deviceId]</var> to
+          <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> to
           <code>false</code>.</p>
         </li>
       </ol>
@@ -2910,7 +2910,7 @@ interface MediaStreamTrackEvent : Event {
       but in no other contexts:</p>
       <ol>
         <li>
-          <p>Set [[\storedDeviceList]] to null.</p>
+          <p>Set <a>[[\storedDeviceList]]</a> to null.</p>
         </li>
         <li>
           <p>Queue a task that fires a simple event named <code><a href=
@@ -2925,7 +2925,7 @@ interface MediaStreamTrackEvent : Event {
       <p>The User Agent MAY combine firing multiple events into firing one
       event when several events are due or when multiple devices are added or
       removed at the same time, e.g. a camera with a microphone.</p>
-      <p>[[\storedDeviceList]] before these two steps can potentially list
+      <p><a>[[\storedDeviceList]]</a> before these two steps can potentially list
       the exact same set of devices in the same order as the list of devices
       generated by a call to <code>enumerateDevices</code> after the two above steps.
       In that case, if the "device-info" permission is not "granted", the User Agent
@@ -2999,10 +2999,10 @@ interface MediaDevices : EventTarget {
                     </li>
                     <li><p>Let <var>resultList</var> be an empty list.</p></li>
                     <li>
-                      <p>If [[\storedDeviceList]] is not null, run the following sub steps:</p>
+                      <p>If <a>[[\storedDeviceList]]</a> is not null, run the following sub steps:</p>
                       <ol>
                         <li>
-                          <p>For each <code><a>MediaDeviceInfo</a></code> object in [[\storedDeviceList]],
+                          <p>For each <code><a>MediaDeviceInfo</a></code> object in <a>[[\storedDeviceList]]</a>,
                           <var>storedDeviceInfo</var>:
                           <ul>
                              <li>
@@ -3081,7 +3081,7 @@ interface MediaDevices : EventTarget {
                       </ol>
                     </li>
                     <li>
-                      <p>Set [[\storedDeviceList]] to
+                      <p>Set <a>[[\storedDeviceList]]</a> to
                       <var>resultList</var>.</p>
                     </li>
                     <li>
@@ -3093,7 +3093,7 @@ interface MediaDevices : EventTarget {
                           <code>live</code> MediaStreamTrack in the current
                           browsing context, set <var>list-permission</var> to
                           "granted", otherwise set <var>list-permission</var>
-                          to "granted" if [[\canExposeDeviceInfo]] is
+                          to "granted" if <a>[[\canExposeDeviceInfo]]</a> is
                           <code>true</code> and "denied" otherwise.</p>
                         </li>
                         <li>
@@ -3168,7 +3168,7 @@ interface MediaDevices : EventTarget {
         "device-information-can-be-exposed">device information can be exposed check</dfn>,
         run the following steps:</p>
         <ol>
-          <li>If [[\canExposeDeviceInfo]] is <code>true</code>, return <code>true</code>.
+          <li>If <a>[[\canExposeDeviceInfo]]</a> is <code>true</code>, return <code>true</code>.
           </li>
           <li>If the <a>current settings object</a>'s <a>responsible
           document</a> is <a data-cite="!HTML/#fully-active">fully
@@ -3184,7 +3184,7 @@ interface MediaDevices : EventTarget {
         "set-device-information-exposure">set the device information exposure</dfn>,
         with a <code>value</code> of type boolean, run the following steps:</p>
         <ol>
-          <li>Set [[\canExposeDeviceInfo]] to <code>value</code>.</li>
+          <li>Set <a>[[\canExposeDeviceInfo]]</a> to <code>value</code>.</li>
         </ol>
         <div class="note">
           <p>A User Agent MAY at any point set the device information exposure back to <code>false</code>,
@@ -3730,10 +3730,10 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           pre-recorded media files.</p>
                           <p>If the result of the request is "granted", then using
                           the granted device's deviceId, <var>deviceId</var>, set
-                          [[\devicesLiveMap]]<var>[deviceId]</var> to
+                          <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> to
                           <code>true</code>, if it isn’t already <code>true</code>,
                           and set the
-                          [[\devicesAccessibleMap]]<var>[deviceId]</var> to
+                          <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> to
                           <code>true</code>, if it isn’t already
                           <code>true</code>.</p>
                           <p>If the result is "denied", jump to the step labeled
@@ -3761,7 +3761,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                       tracks in <var>stream</var> with the appropriate
                       constraints. Should this fail, let
                       <var>failedConstraint</var> be the result of the
-                      algorithm that failed if [[\canExposeDeviceInfo]] is <code>true</code>,
+                      algorithm that failed if <a>[[\canExposeDeviceInfo]]</a> is <code>true</code>,
                       or <code>undefined</code> otherwise, and jump to the step
                       labeled <em>Constraint Failure</em> below.</p>
                     </li>
@@ -5135,13 +5135,13 @@ window.onload = async () =&gt; {
     <ul>
       <li>Define <var>any&lt;kind&gt;Accessible</var> (e.g.
       <var>anyAudioAccessible</var>, <var>anyVideoAccessible</var>) as the
-      logical OR of the [[\kindsAccessibleMap]]<var>[kind]</var> value and all
-      the [[\devicesAccessibleMap]]<var>[deviceId]</var> values for devices of
+      logical OR of the <a>[[\kindsAccessibleMap]]</a><var>[kind]</var> value and all
+      the <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> values for devices of
       that kind.</li>
       <li>Define any<var>&lt;kind&gt;Live</var> (e.g. <var>anyAudioLive</var>,
       <var>anyVideoLive</var>) to be the logical OR of the
-      [[\kindsLiveMap]]<var>[kind]</var> value and all the
-      [[\devicesLiveMap]]<var>[deviceId]</var> values for devices of that
+      <a>[[\kindsLiveMap]]</a><var>[kind]</var> value and all the
+      <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> values for devices of that
       kind.</li>
     </ul>
     <p>Define <var>anyAccessible</var> to be the logical OR of all
@@ -5160,8 +5160,8 @@ window.onload = async () =&gt; {
       when the value changes.</li>
       <li>If the User Agent provides indication to the user per
       <var>device</var>, then for each
-      [[\devicesAccessibleMap]]<var>[deviceId]</var> value and
-      [[\devicesLiveMap]]<var>[deviceId]</var> value, it MUST at minimum
+      <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> value and
+      <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> value, it MUST at minimum
       indicate when the value changes.</li>
       <li>Any false-to-true transition indicated MUST remain observable for a
       sufficient time that a reasonably-observant user could become aware of
@@ -5185,11 +5185,11 @@ window.onload = async () =&gt; {
       match the corresponding any<var>&lt;kind&gt;Live</var> value.</li>
       <li>If the User Agent provides indication to the user per
       <var>device</var>, then for each
-      [[\devicesAccessibleMap]]<var>[deviceId]</var> value and
-      [[\devicesLiveMap]]<var>[deviceId]</var> value, it is encouraged to
+      <a>[[\devicesAccessibleMap]]</a><var>[deviceId]</var> value and
+      <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> value, it is encouraged to
       provide ongoing indication of the current state of the value. It is also
       encouraged to make any device-specific hardware indicator light match the
-      corresponding [[\devicesLiveMap]]<var>[deviceId]</var> value.</li>
+      corresponding <a>[[\devicesLiveMap]]</a><var>[deviceId]</var> value.</li>
       <li>Any of the above ongoing indications MAY be used instead of the
       corresponding required transition indication provided the false-to-true
       transition requirement is met.</li>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -38,7 +38,7 @@
     <p>Implementations that use ECMAScript [[ECMA-262]] to implement the APIs
     defined in this specification must implement them in a manner consistent
     with the ECMAScript Bindings defined in the Web IDL specification
-    [[!WEBIDL-1]], as this specification uses that specification and
+    [[WEBIDL]], as this specification uses that specification and
     terminology.</p>
   </section>
   <section>
@@ -62,7 +62,7 @@
         <p>The terms <dfn data-lt="fulfill|fulfillment">fulfilled</dfn>,
         <dfn data-lt="reject|rejection|rejecting">rejected</dfn> and
         <dfn data-lt="resolve">resolved</dfn> used in the context of Promises
-        are defined in [[!ES6]].</p>
+        are defined in [[ECMA-262]].</p>
       </dd>
       <dt>DOM</dt>
       <dd>
@@ -185,9 +185,9 @@
         application authors are strongly encouraged to use <a>required
         constraints</a> sparingly.</p>
       </dd>
-      <dt><a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a></dt>
-      <dd><a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a> is defined in
-      [[WEBRTC]].</dd>
+      <dt><a data-cite="?WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a></dt>
+      <dd><a data-cite="?WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a> is defined in
+      [[?WEBRTC]].</dd>
       <dt>Permissions</dt>
       <dd>
         <p>The terms <dfn data-cite="permissions#reading-current-states">reading current permission state</dfn> and [=request permission to
@@ -215,7 +215,7 @@
       synchronized.</p>
       <p class="note">While the intent is to synchronize tracks, it could be
       better in some circumstances to permit tracks to lose synchronization. In
-      particular, when tracks are remotely sourced and real-time [[WEBRTC]],
+      particular, when tracks are remotely sourced and real-time [[?WEBRTC]],
       it can be better to allow loss of synchronization than to accumulate
       delays or risk glitches and other artifacts. Implementations are expected
       to understand the implications of choices regarding synchronization of
@@ -224,7 +224,7 @@
       multi-channel content, such as stereo or 5.1 audio or stereoscopic video,
       where the channels have a well defined relationship to each other.
       Information about channels might be exposed through other APIs, such as
-      [[WEBAUDIO]], but this specification provides no direct access to
+      [[?WEBAUDIO]], but this specification provides no direct access to
       channels.</p>
       <p>A {{MediaStream}} object has an input and an output
       that represent the combined input and output of all the object's tracks.
@@ -249,10 +249,10 @@
       independent of the instance it is cloned from, which allows media from
       the same source to have different constraints applied for different
       <a>consumer</a>s. The {{MediaStream}} object is also used in
-      contexts outside {{MediaDevices/getUserMedia}}, such as [[WEBRTC]].</p>
+      contexts outside {{MediaDevices/getUserMedia}}, such as [[?WEBRTC]].</p>
     </section>
     <section>
-      <h2>MediaStream</h2>
+      <h2>{{MediaStream}}</h2>
       <p id=
       "mediastream-constructor">The MediaStream <dfn data-idl data-dfn-for=MediaStream>constructor</dfn> composes a new
       stream out of existing tracks. It takes an optional argument of type
@@ -327,10 +327,10 @@
       {{MediaStream}} consumers currently include media
       elements (such as [^video^] and
       [^audio^]) [[HTML]], Web Real-Time Communications
-      (WebRTC; <code class=fixme>RTCPeerConnection</code>) [[WEBRTC]], media recording
-      (<code class=fixme>MediaRecorder</code>) [[mediastream-recording]], image capture
-      (<code class=fixme>ImageCapture</code>) [[image-capture]], and web audio
-      ({{MediaStreamAudioSourceNode}}) [[WEBAUDIO]].</p>
+      (WebRTC; <code class=fixme>RTCPeerConnection</code>) [[?WEBRTC]], media recording
+      (<code class=fixme>MediaRecorder</code>) [[?mediastream-recording]], image capture
+      (<code class=fixme>ImageCapture</code>) [[?image-capture]], and web audio
+      ({{MediaStreamAudioSourceNode}}) [[?WEBAUDIO]].</p>
       <p class="note">{{MediaStream}} consumers must be able to
       handle tracks being added and removed. This behavior is specified per
       consumer.</p>
@@ -351,7 +351,7 @@
       "#track-set">track set</a> in response to, for example, an external
       event. This specification does not specify any such cases, but other
       specifications using the MediaStream API may. One such example is the
-      WebRTC 1.0 [[WEBRTC]] specification where the <a href=
+      WebRTC 1.0 [[?WEBRTC]] specification where the <a href=
       "#track-set">track set</a> of a {{MediaStream}}, received
       from another peer, can be updated as a result of changes to the media
       session.</p>
@@ -589,7 +589,7 @@ interface MediaStream : EventTarget {
       </div>
     </section>
     <section>
-      <h2>MediaStreamTrack</h2>
+      <h2>{{MediaStreamTrack}}</h2>
       <p>A {{MediaStreamTrack}} object represents a media
       source in the User Agent. An example source is a device connected to the
       User Agent. Other specifications may define sources for
@@ -903,7 +903,7 @@ interface MediaStreamTrack : EventTarget {
                 <p>An example of an algorithm that specifies how the track id
                 must be initialized is the algorithm to represent an incoming
                 network component with a {{MediaStreamTrack}}
-                object. [[WEBRTC]]</p>
+                object. [[?WEBRTC]]</p>
                 <p><dfn data-idl>id</dfn> attribute MUST return the value
                 to which it was initialized when the object was created.</p>
               </dd>
@@ -1833,7 +1833,7 @@ interface MediaStreamTrack : EventTarget {
       </section>
     </section>
     <section>
-      <h3>MediaStreamTrackEvent</h3>
+      <h3>{{MediaStreamTrackEvent}}</h3>
       <p>The {{addtrack}}
       and {{removetrack}} events use the
       {{MediaStreamTrackEvent}} interface.</p>
@@ -1924,20 +1924,20 @@ interface MediaStreamTrackEvent : Event {
     </div>
     <p>Note that {{MediaStream}} sinks (such as
     <code>&lt;video&gt;</code>, <code>&lt;audio&gt;</code>, and even
-    <a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>) will continue to have mechanisms to further
+    <a data-cite="?WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>) will continue to have mechanisms to further
     transform the source stream beyond that which the <a>Settings</a>,
     <a>Capabilities</a>, and <a>Constraints</a> described in this specification
     offer. (The sink transformation options, including those of
-    <a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>, are outside the scope of this
+    <a data-cite="?WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>, are outside the scope of this
     specification.)</p>
     <p>The act of changing or applying a track constraint may affect the
     <code><a>settings</a></code> of all tracks sharing that source and
     consequently all down-level sinks that are using that source. Many sinks
     may be able to take these changes in stride, such as the
-    <code>&lt;video&gt;</code> element or <a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>.
+    <code>&lt;video&gt;</code> element or <a data-cite="?WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a>.
     Others like the Recorder API may fail as a result of a source setting
     change.</p>
-    <p>The <a data-cite="WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a> is an interesting object because it
+    <p>The <a data-cite="?WEBRTC#dom-rtcpeerconnection">RTCPeerConnection</a> is an interesting object because it
     acts simultaneously as both a sink <strong>and</strong> a source for
     over-the-network streams. As a sink, it has source transformational
     capabilities (e.g., lowering bit-rates, scaling-up / down resolutions, and
@@ -2297,26 +2297,26 @@ interface MediaStreamTrackEvent : Event {
   <section>
     <h2>Error Handling</h2>
     <p>This section and its subsections extend the list of Error subclasses
-    defined in [[!ES6]] following the pattern for NativeError in section 19.5.6
+    defined in [[ECMA-262]] following the pattern for NativeError in section 19.5.6
     of that specification. Assume the following:</p>
     <ul>
       <li>that use of syntax such as [[\something]] and %something% is as used
-      in [[!ES6]].</li>
-      <li>that the rules for ECMAScript standard built-in objects ([[!ES6]],
+      in [[ECMA-262]].</li>
+      <li>that the rules for ECMAScript standard built-in objects ([[ECMA-262]],
       section 17) are in effect in this section.</li>
       <li>that the new intrinsic objects %OverconstrainedError% and
       %OverconstrainedErrorPrototype% are available as if they had been
-      included in ([[!ES6]], Table 7) and all referencing sections, e.g.
-      ([[!ES6]], section 8.2.2), thus behave appropriately.</li>
+      included in ([[ECMA-262]], Table 7) and all referencing sections, e.g.
+      ([[ECMA-262]], section 8.2.2), thus behave appropriately.</li>
     </ul>
     <section>
       <h2>ECMAScript 6 Terminology</h2>
-      <p>The following terms used in this section are defined in [[!ES6]].</p>
+      <p>The following terms used in this section are defined in [[ECMA-262]].</p>
       <table>
         <thead>
           <tr>
             <th>Term/Notation</th>
-            <th>Section in [[!ES6]]</th>
+            <th>Section in [[ECMA-262]]</th>
           </tr>
         </thead>
         <tbody>
@@ -2640,8 +2640,8 @@ interface MediaStreamTrackEvent : Event {
       </div>
     </section>
     <section>
-      <h3>MediaDevices</h3>
-      <p>The <dfn data-dfn-for="">MediaDevices</dfn> object is the entry point
+      <h3>{{MediaDevices}}</h3>
+      <p>The <dfn>MediaDevices</dfn> object is the entry point
       to the API used to examine and get access to media devices available to
       the User Agent.</p>
       <p>On page load, run the following steps:</p>
@@ -3172,7 +3172,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
     media input devices available to the User Agent.</p>
     <p>Alternatively, a local {{MediaStream}} can be captured
     from certain types of DOM elements, such as the video element
-    [[mediacapture-fromelement]]. This can be useful for automated testing.</p>
+    [[?mediacapture-fromelement]]. This can be useful for automated testing.</p>
     <p>When on an insecure origin [[mixed-content]], User Agents are encouraged
     to warn about usage of <code>navigator.mediaDevices.getUserMedia</code>,
     <code>navigator.getUserMedia</code>, and any prefixed variants in their
@@ -3285,29 +3285,29 @@ interface InputDeviceInfo : MediaDeviceInfo {
       </div>
     </section>
     <section>
-      <h3>MediaDevices Interface Extensions</h3>
+      <h3>{{MediaDevices}} Interface Extensions</h3>
       <div class="note">
-        The definition of getUserMedia() in this section reflects two major
-        changes from the method definition that has existed under Navigator for
+        The definition of {{Navigator/getUserMedia()}} in this section reflects two major
+        changes from the method definition that has existed under {{Navigator}} for
         many months.
-        <p>First, the official definition for the getUserMedia() method, and
+        <p>First, the official definition for the {{MediaDevices/getUserMedia()}} method, and
         the one which developers are encouraged to use, is now the one defined
-        here under MediaDevices. This decision reflected consensus as long as
+        here under {{MediaDevices}}. This decision reflected consensus as long as
         the original API remained available at <a>Navigator.getUserMedia</a>
-        under the Navigator object for backwards compatibility reasons, since
+        under the {{Navigator}} object for backwards compatibility reasons, since
         the working group acknowledges that early users of these APIs have been
         encouraged to define getUserMedia as "var getUserMedia =
         navigator.getUserMedia || navigator.webkitGetUserMedia ||
         navigator.mozGetUserMedia;" in order for their code to be functional
         both before and after official implementations of getUserMedia() in
         popular browsers. To ensure functional equivalence, the getUserMedia()
-        method under Navigator is defined in terms of the method here.</p>
+        method under {{Navigator}} is defined in terms of the method here.</p>
         <p>Second, the method defined here is Promises-based, while the one
-        defined under Navigator is currently still callback-based. Developers
+        defined under {{Navigator}} is currently still callback-based. Developers
         expecting to find getUserMedia() defined under Navigator are strongly
         encouraged to read the detailed Note given there.</p>
       </div>
-      <p>The <code>getSupportedConstraints</code> method is provided to allow
+      <p>The {{MediaDevices/getSupportedConstraints}} method is provided to allow
       the application to determine which constraints the User Agent
       recognizes.</p>
       <div>
@@ -3587,7 +3587,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
       </div>
     </section>
     <section>
-      <h2>MediaStreamConstraints</h2>
+      <h2>{{MediaStreamConstraints}}</h2>
       <p>The <dfn>MediaStreamConstraints</dfn> dictionary is used to instruct
       the User Agent what sort of {{MediaStreamTrack}}s to include in the
       <a>MediaStream</a> returned by <a data-link-for=
@@ -4818,7 +4818,7 @@ startBtn.onclick = async () =&gt; {
     </div>-->
     <div>
       <p>This example allows people to take photos of themselves from the local
-      video camera. Note that the Image Capture specification [[image-capture]]
+      video camera. Note that the Image Capture specification [[?image-capture]]
       provides a simpler way to accomplish this.</p>
       <pre class="example">
 &lt;script&gt;
@@ -5130,7 +5130,7 @@ window.onload = async () =&gt; {
     or {{MediaStreamTrack}}s will be defined in the future. The
     following section provides guidance.</p>
     <section>
-      <h2>Defining new consumers of MediaStreams and MediaStreamTracks</h2>
+      <h2>Defining new consumers of {{MediaStream}}s and {{MediaStreamTrack}}s</h2>
       <p>At a minimum, any new consumer of a
       {{MediaStreamTrack}} will need to define</p>
       <ul>

--- a/getusermedia.js
+++ b/getusermedia.js
@@ -71,6 +71,7 @@ var respecConfig = {
    // Team Contact.
    wgPatentURI:   ["https://www.w3.org/2004/01/pp-impl/47318/status"],
    github: "https://github.com/w3c/mediacapture-main/",
+  xref: ["dom", "html", "webidl", "permissions", "webrtc", "feature-policy", "webaudio"],
    otherLinks: [
     {
       key: "Participate",

--- a/getusermedia.js
+++ b/getusermedia.js
@@ -71,7 +71,7 @@ var respecConfig = {
    // Team Contact.
    wgPatentURI:   ["https://www.w3.org/2004/01/pp-impl/47318/status"],
    github: "https://github.com/w3c/mediacapture-main/",
-  xref: ["dom", "html", "webidl", "permissions", "webrtc", "feature-policy", "webaudio"],
+  xref: ["dom", "html", "webidl", "permissions", "feature-policy", "webaudio"],
    otherLinks: [
     {
       key: "Participate",


### PR DESCRIPTION
Use respec autolinks as much as possible
align with latest terminology of Permission API
fix a couple of bugs in the process
align references and their statuses with reality (mediarecorder, imagecapture, webrtc, and webaudio aren't normative references)