### PR TITLE
Remove outdated mentions of Media Capture Task Force

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -5372,10 +5372,8 @@ window.onload = async () =&gt; {
       "#constrainable-properties"></a>, and
       <code><a>MediaStreamConstraints</a></code> are the model to use.</p>
       <p>Creators of extension specifications are strongly encouraged to notify
-      the Media Capture Task Force of their extension by emailing the list at
-      public-media-capture@w3.org.<br>
-      Future versions of this specification and others created by the Media
-      Capture Task Force will take into consideration all extensions they are
+      the specification maintainers on <a href="https://github.com/w3c/mediacapture-main/issues">the specification repository</a>.<br>
+      Future versions of this specification and others created by the WebRTC Working Group will take into consideration all extensions they are
       aware of in an attempt to reduce potential usage conflicts.</p>
     </section>
     <p>&nbsp;</p>


### PR DESCRIPTION
Spec now fully owned by WebRTC
Also, point to github repo rather than mailing list