### PR TITLE
Remove UUID recommendation for deviceId and groupId.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3750,7 +3750,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
         <span class="practicelab" id="handling-devices">Generating deviceIds</span>
         <p class="practicedesc">An efficient practice for generating a
         {{MediaDeviceInfo/deviceId}} is to generate a cryptographic hash from
-        a generated privately key + (origin or origin + top-level origin, based
+        a generated private key + (origin or origin + top-level origin, based
         on the user agents' partitioning rules) + salt + device's underlying
         (hardware) id in the driver, presented as an alphanumeric string. Using
         32 bits or lower is recommended, but not much lower, to avoid risk of

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3752,10 +3752,11 @@ interface InputDeviceInfo : MediaDeviceInfo {
         {{MediaDeviceInfo/deviceId}} is to generate a cryptographic hash from
         a private key + (origin or origin + top-level origin, based on the user
         agents' partitioning rules) + salt + device's underlying (hardware) id
-        in the driver, presented as an alphanumeric string. Using 32 bits or
-        lower is recommended, but not much lower, to avoid risk of collision.
+        in the driver, and then present it as an alphanumeric string. Using 32
+        bits or less the id is recommended, but not much lower, to avoid risk of
+        collision.
         </p>
-        <p class="practicedesc">A better (lower-entropy) alternative, at the
+        <p class="practicedesc">A better, lower-entropy, alternative, at the
         cost storage, is to assign the numbers 0 through 255 randomly to each
         new device encountered for each origin or origin + top-level origin,
         based on the User Agent's partitioning rules, retiring the number that

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3013,7 +3013,7 @@ interface MediaDeviceInfo {
               MUST be the same in documents of the same origin in [=top-level browsing contexts=].
               In [=nested browsing contexts=],
               the decision of whether or not the identifier is the same across
-              documents, MUST follow the user agents' partitioning rules for
+              documents, MUST follow the User Agent's partitioning rules for
               storage (such as {{WindowLocalStorage/localStorage}}), if any,
               to not interfere with mitigations for cross-site correlation.
               If the identifier can uniquely
@@ -3041,9 +3041,9 @@ interface MediaDeviceInfo {
               across browsing sessions and to reduce its potential as a
               fingerprinting mechanism, {{deviceId}} is to be treated
               as other persistent storage mechanisms such as cookies
-              [[COOKIES]], in that user agents MUST NOT persist device
+              [[COOKIES]], in that User Agents MUST NOT persist device
               identifiers for sites that are blocked from using cookies, and
-              user agents MUST rotate per-origin device identifiers when other
+              User Agents MUST rotate per-origin device identifiers when other
               persistent storage are cleared.</p>
             </dd>
             <dt id="def-mediadeviceinfo-kind"><dfn>kind</dfn> of
@@ -3758,7 +3758,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
         <p class="practicedesc">A better (lower-entropy) alternative, at the
         cost storage, is to assign the numbers 0 through 255 randomly to each
         new device encountered for each origin or origin + top-level origin,
-        based on the user agents' partitioning rules, retiring the number that
+        based on the User Agent's partitioning rules, retiring the number that
         hasn't been seen the longest if numbers run out.</p>
       </div>
     </section>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3749,13 +3749,15 @@ interface InputDeviceInfo : MediaDeviceInfo {
       <div class="practice">
         <span class="practicelab" id="handling-devices">Generating deviceIds</span>
         <p class="practicedesc">An efficient practice for generating a
-        {{MediaDeviceInfo/deviceId}} is to generate a hash from (origin or
-         origin + top-level origin, based on the user agents' partitioning rules)
-         + salt + device's underlying (hardware) id in the driver, presented as
-         an alpha-numeric string.</p>
+        {{MediaDeviceInfo/deviceId}} is to generate a cryptographic hash from
+        a private key + (origin or origin + top-level origin, based on the user
+        agents' partitioning rules) + salt + device's underlying (hardware) id
+        in the driver, presented as an alpha-numeric string.</p>
         <p class="practicedesc">Another practice may be to assign the numbers
-        0 through 255 randomly to each new device encountered, retiring the
-        number that hasn't been seen the longest if numbers run out.</p>
+        0 through 255 randomly to each new device encountered for each origin or
+        origin + top-level origin, based on the user agents' partitioning rules,
+        retiring the number that hasn't been seen the longest if numbers run
+        out.</p>
       </div>
     </section>
   </section>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3752,12 +3752,13 @@ interface InputDeviceInfo : MediaDeviceInfo {
         {{MediaDeviceInfo/deviceId}} is to generate a cryptographic hash from
         a private key + (origin or origin + top-level origin, based on the user
         agents' partitioning rules) + salt + device's underlying (hardware) id
-        in the driver, presented as an alpha-numeric string.</p>
-        <p class="practicedesc">Another practice may be to assign the numbers
-        0 through 255 randomly to each new device encountered for each origin or
-        origin + top-level origin, based on the user agents' partitioning rules,
-        retiring the number that hasn't been seen the longest if numbers run
-        out.</p>
+        in the driver, presented as an alpha-numeric string. Using 32 bits or
+        lower is recommended, but not much lower, to avoid risk of collision.</p>
+        <p class="practicedesc">A better (lower-entropy) alternative, at the
+        cost storage, is to assign the numbers 0 through 255 randomly to each
+        new device encountered for each origin or origin + top-level origin,
+        based on the user agents' partitioning rules, retiring the number that
+        hasn't been seen the longest if numbers run out.</p>
       </div>
     </section>
   </section>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3750,10 +3750,11 @@ interface InputDeviceInfo : MediaDeviceInfo {
         <span class="practicelab" id="handling-devices">Generating deviceIds</span>
         <p class="practicedesc">An efficient practice for generating a
         {{MediaDeviceInfo/deviceId}} is to generate a cryptographic hash from
-        a private key + (origin or origin + top-level origin, based on the user
-        agents' partitioning rules) + salt + device's underlying (hardware) id
-        in the driver, presented as an alpha-numeric string. Using 32 bits or
-        lower is recommended, but not much lower, to avoid risk of collision.</p>
+        a generated privately key + (origin or origin + top-level origin, based
+        on the user agents' partitioning rules) + salt + device's underlying
+        (hardware) id in the driver, presented as an alphanumeric string. Using
+        32 bits or lower is recommended, but not much lower, to avoid risk of
+        collision.</p>
         <p class="practicedesc">A better (lower-entropy) alternative, at the
         cost storage, is to assign the numbers 0 through 255 randomly to each
         new device encountered for each origin or origin + top-level origin,

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2858,7 +2858,8 @@ interface MediaDevices : EventTarget {
                           <p>If a stored {{MediaDeviceInfo/deviceId}} exists for
                           <var>device</var>, initialize <var>deviceInfo</var>.{{MediaDeviceInfo/deviceId}} to that value.
                           Otherwise, let <var>deviceInfo</var>.{{MediaDeviceInfo/deviceId}} be a
-                          newly generated unique identifier.</p>
+                          newly generated unique identifier as described under
+                          {{MediaDeviceInfo/deviceId}}.</p>
                         </li>
                         <li>
                           <p>If <var>device</var> belongs to the same physical
@@ -2868,13 +2869,6 @@ interface MediaDevices : EventTarget {
                           existing {{MediaDeviceInfo}} object.
                           Otherwise, let <var>deviceInfo</var>.{{MediaDeviceInfo/groupId}} be a
                           newly generated unique identifier.</p>
-
-                          <p>A good practice for generating {{MediaDeviceInfo/deviceId}}
-                          and {{MediaDeviceInfo/groupId}}
-                          values is to use a UUID [[rfc4122]], which is 36
-                          characters long in its canonical form. To avoid
-                          fingerprinting, implementations SHOULD use the forms in
-                          section 4.4 or 4.5 of RFC 4122.</p>
                         </li>
                         <li>
                           <p>If <var>device</var> is the system default camera or the system default
@@ -3022,10 +3016,8 @@ interface MediaDeviceInfo {
               documents, MUST follow the user agents' partitioning rules for
               storage (such as {{WindowLocalStorage/localStorage}}), if any,
               to not interfere with mitigations for cross-site correlation.
-              The identifier SHOULD be origin-unique,
-              in which case some sort of UUID is recommended.
-              If the identifier can uniquely identify the user, as is usually
-              the case with UUID, it MUST be un-guessable by browsing contexts
+              The identifier SHOULD be origin-unique. If the identifier can uniquely
+              identify the user, then it MUST be un-guessable by browsing contexts
               of other origins to prevent the identifier from being used to
               correlate the same user across different origins. An identifier
               can be reused across origins as long as it is not tied to the user
@@ -3051,7 +3043,7 @@ interface MediaDeviceInfo {
               as other persistent storage mechanisms such as cookies
               [[COOKIES]], in that user agents MUST NOT persist device
               identifiers for sites that are blocked from using cookies, and
-              user agents MUST reset per-origin device identifiers when other
+              user agents MUST rotate per-origin device identifiers when other
               persistent storage are cleared.</p>
             </dd>
             <dt id="def-mediadeviceinfo-kind"><dfn>kind</dfn> of

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3756,8 +3756,8 @@ interface InputDeviceInfo : MediaDeviceInfo {
         Using 32 bits or fewer for the hash is recommended, but not much lower,
         to avoid risk of collision.
         </p>
-        <p class="practicedesc">A better, lower-entropy, alternative, at the
-        cost storage, is to assign the numbers 0 through 255 randomly to each
+        <p class="practicedesc">A lower-entropy alternative, at the cost of
+        storage, is to assign the numbers 0 through 255 randomly to each
         new device encountered for each origin or origin + top-level origin,
         based on the User Agent's partitioning rules, retiring the number that
         hasn't been seen the longest if numbers run out.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3746,6 +3746,17 @@ interface InputDeviceInfo : MediaDeviceInfo {
         dialog interaction. The constraints on each getUserMedia call can be
         used to decide which stream gets which media sources.</p>
       </div>
+      <div class="practice">
+        <span class="practicelab" id="handling-devices">Generating deviceIds</span>
+        <p class="practicedesc">An efficient practice for generating a
+        {{MediaDeviceInfo/deviceId}} is to generate a hash from (origin or
+         origin + top-level origin, based on the user agents' partitioning rules)
+         + salt + device's underlying (hardware) id in the driver, presented as
+         an alpha-numeric string.</p>
+        <p class="practicedesc">Another practice may be to assign the numbers
+        0 through 255 randomly to each new device encountered, retiring the
+        number that hasn't been seen the longest if numbers run out.</p>
+      </div>
     </section>
   </section>
   <section id="constrainable-interface">

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3747,14 +3747,14 @@ interface InputDeviceInfo : MediaDeviceInfo {
         used to decide which stream gets which media sources.</p>
       </div>
       <div class="practice">
-        <span class="practicelab" id="handling-devices">Generating deviceIds</span>
+        <span class="practicelab" id="generating-deviceids">Generating deviceIds</span>
         <p class="practicedesc">An efficient practice for generating a
         {{MediaDeviceInfo/deviceId}} is to generate a cryptographic hash from
-        a generated private key + (origin or origin + top-level origin, based
-        on the user agents' partitioning rules) + salt + device's underlying
-        (hardware) id in the driver, presented as an alphanumeric string. Using
-        32 bits or lower is recommended, but not much lower, to avoid risk of
-        collision.</p>
+        a private key + (origin or origin + top-level origin, based on the user
+        agents' partitioning rules) + salt + device's underlying (hardware) id
+        in the driver, presented as an alphanumeric string. Using 32 bits or
+        lower is recommended, but not much lower, to avoid risk of collision.
+        </p>
         <p class="practicedesc">A better (lower-entropy) alternative, at the
         cost storage, is to assign the numbers 0 through 255 randomly to each
         new device encountered for each origin or origin + top-level origin,

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3017,7 +3017,7 @@ interface MediaDeviceInfo {
               storage (such as {{WindowLocalStorage/localStorage}}), if any,
               to not interfere with mitigations for cross-site correlation.
               If the identifier can uniquely
-              identify the user, then it MUST be un-guessable by documents from
+              identify the user, then it MUST be un-guessable in documents from
               other origins to prevent the identifier from being used to
               correlate the same user across different origins. An identifier
               can be reused across origins as long as it is not tied to the user

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3016,7 +3016,7 @@ interface MediaDeviceInfo {
               documents, MUST follow the user agents' partitioning rules for
               storage (such as {{WindowLocalStorage/localStorage}}), if any,
               to not interfere with mitigations for cross-site correlation.
-              The identifier SHOULD be origin-unique. If the identifier can uniquely
+              If the identifier can uniquely
               identify the user, then it MUST be un-guessable by browsing contexts
               of other origins to prevent the identifier from being used to
               correlate the same user across different origins. An identifier

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3017,8 +3017,8 @@ interface MediaDeviceInfo {
               storage (such as {{WindowLocalStorage/localStorage}}), if any,
               to not interfere with mitigations for cross-site correlation.
               If the identifier can uniquely
-              identify the user, then it MUST be un-guessable by browsing contexts
-              of other origins to prevent the identifier from being used to
+              identify the user, then it MUST be un-guessable by documents from
+              other origins to prevent the identifier from being used to
               correlate the same user across different origins. An identifier
               can be reused across origins as long as it is not tied to the user
               and can be guessed by other means, like the User-Agent string.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3752,9 +3752,9 @@ interface InputDeviceInfo : MediaDeviceInfo {
         {{MediaDeviceInfo/deviceId}} is to generate a cryptographic hash from
         a private key + (origin or origin + top-level origin, based on the user
         agents' partitioning rules) + salt + device's underlying (hardware) id
-        in the driver, and then present it as an alphanumeric string. Using 32
-        bits or less the id is recommended, but not much lower, to avoid risk of
-        collision.
+        in the driver, and present the resulting hash as an alphanumeric string.
+        Using 32 bits or fewer for the hash is recommended, but not much lower,
+        to avoid risk of collision.
         </p>
         <p class="practicedesc">A better, lower-entropy, alternative, at the
         cost storage, is to assign the numbers 0 through 255 randomly to each


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/682.