### PR TITLE
Fix link for toJSON() in MediaDeviceInfo

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3136,7 +3136,7 @@ interface MediaDeviceInfo {
           class="methods">
             <dt><dfn>toJSON</dfn></dt>
             <dd>
-              When called, run [[!WEBIDL]]'s <a>default toJSON operation</a>.
+              When called, run [[!WEBIDL]]'s <a>default toJSON steps</a>.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
This PR simply fixes the link to `toJSON()` in MediaDeviceInfo as it has been renamed [recently](https://github.com/w3c/respec/pull/2875/).

![image](https://user-images.githubusercontent.com/634478/87164616-45979b00-c2c9-11ea-8ea0-e203b4295e08.png)
