### PR TITLE
Define the fitness distance for all required constrains.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4271,15 +4271,13 @@ interface ConstrainablePattern {
                 either contains no member named 'ideal', or, if bare values are
                 to be treated as 'ideal', isn't a bare value), the fitness
                 distance is 0.</li>
-                <li>For all positive numeric
-                <a data-lt="required">non-required</a> constraints (such as
+                <li>For all positive numeric constraints (such as
                 height, width, frameRate, aspectRatio, sampleRate and
                 sampleSize), the fitness distance is the result of the formula
                   <pre>
 (actual == ideal) ? 0 : |actual - ideal| / max(|actual|, |ideal|)</pre>
                 </li>
-                <li>For all string and enum
-                <a data-lt="required">non-required</a> constraints (e.g.
+                <li>For all string, enum and boolean constraints (e.g.
                 deviceId, groupId, facingMode, resizeMode, echoCancellation),
                 the fitness distance is the result of the formula
                   <pre>(actual == ideal) ? 0 : 1</pre>


### PR DESCRIPTION
This CL defines the fitness distance also for required constrains whose
value contains a member named 'ideal' in addition to members named
'exact', 'max' and/or 'min'.

Lets take a **width** constraint `{ideal: 1920, min: 320}` as an example and lets assume that the browser supports the constraint and that there are settings dictionaries which satisfy the constraint (so fitness distance algorithm steps 1 and 2 can be ignores).
Then,
* the step 3 does not apply because the constraint is required (has 'min'),
* the step 4 does not apply because the ideal value is specified, and
* the steps 5 and 6 do not apply because the constraint is not non-required but required,

thus the fitness distance is undefined.

Clearly, the step 5 should apply and the fitness distance should be positive infinity for settings dictionaries with width less than 320, 0 for settings dictionaries with width of 1920 and  |actual - 1920| / max(|actual|, 1920) for other settings dictionaries.