### PR TITLE
Add requirements to support downsampling and frame decimation

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1661,7 +1661,7 @@ interface MediaStreamTrack : EventTarget {
               should span the video source's pre-set frame rate values with
               min being equal to 0 and max being the largest frame rate.
               The User Agent MUST support frame rates obtained from
-              integral decimation between 1 and the native resolution frame rate.
+              integral decimation of the native resolution frame rate.
               If this frame rate cannot be determined (e.g. the source does not
               natively provide a frame rate, or the frame rate cannot be
               determined from the source stream), then this value MUST refer to

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1660,7 +1660,7 @@ interface MediaStreamTrack : EventTarget {
               If video source's pre-set can determine frame rate values, the range, as a capacity,
               should span the video source's pre-set frame rate values with
               min being equal to 0 and max being the largest frame rate.
-              The User Agent MUST support integral frame rates obtained from
+              The User Agent MUST support frame rates obtained from
               integral decimation between 1 and the native resolution frame rate.
               If this frame rate cannot be determined (e.g. the source does not
               natively provide a frame rate, or the frame rate cannot be

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1640,21 +1640,28 @@ interface MediaStreamTrack : EventTarget {
               <td>{{ConstrainULong}}</td>
               <td>The width or width range, in pixels. As a capability, the
               range should span the video source's pre-set width values with
-              min being the smallest width and max being the largest
-              width.</td>
+              min being equal to 1 and max being the largest
+              width. The User Agent MUST support downsampling to any value
+              between the min width range value and the native resolution width.</td>
             </tr>
             <tr id="def-constraint-height">
               <td><dfn>height</dfn></td>
               <td>{{ConstrainULong}}</td>
               <td>The height or height range, in pixels. As a capability, the
               range should span the video source's pre-set height values with
-              min being the smallest height and max being the largest
-              height.</td>
+              min being equal to 1 and max being the largest
+              height. The User Agent MUST support downsampling to any value
+              between the min height range value and the native resolution height.</td>
             </tr>
             <tr id="def-constraint-frameRate">
               <td><dfn>frameRate</dfn></td>
               <td>{{ConstrainDouble}}</td>
               <td>The exact frame rate (frames per second) or frame rate range.
+              If video source's pre-set can determine frame rate values, the range, as a capacity,
+              should span the video source's pre-set frame rate values with
+              min being equal to 1 and max being the largest frame rate.
+              The User Agent MUST support integral frame rates obtained from
+              integral decimation between 1 and the native resolution frame rate.
               If this frame rate cannot be determined (e.g. the source does not
               natively provide a frame rate, or the frame rate cannot be
               determined from the source stream), then this value MUST refer to

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1659,7 +1659,7 @@ interface MediaStreamTrack : EventTarget {
               <td>The exact frame rate (frames per second) or frame rate range.
               If video source's pre-set can determine frame rate values, the range, as a capacity,
               should span the video source's pre-set frame rate values with
-              min being equal to 1 and max being the largest frame rate.
+              min being equal to 0 and max being the largest frame rate.
               The User Agent MUST support integral frame rates obtained from
               integral decimation between 1 and the native resolution frame rate.
               If this frame rate cannot be determined (e.g. the source does not


### PR DESCRIPTION
This also mandates min width, min height and min frame rate to be 1.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/731.html" title="Last updated on Dec 3, 2020, 3:38 PM UTC (c1861fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/731/ea45c6a...youennf:c1861fd.html" title="Last updated on Dec 3, 2020, 3:38 PM UTC (c1861fd)">Diff</a>