### PR TITLE
Reorder steps to not set privacy indicator for device that fails to open.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3643,16 +3643,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                         </li>
                         <li>
                           <p>The result of the request is {{PermissionState/"granted"}}.
-                          Using the granted device's deviceId, <var>deviceId</var>, set
-                          <a>[[\devicesLiveMap]]</a>[<var>deviceId</var>] to
-                          <code>true</code>, if it isn’t already <code>true</code>,
-                          and set the
-                          <a>[[\devicesAccessibleMap]]</a>[<var>deviceId</var>] to
-                          <code>true</code>, if it isn’t already
-                          <code>true</code>.</p>
-                        </li>
-                        <li>
-                          <p>If a hardware error such as an OS/program/webpage lock prevents access,
+                          If a hardware error such as an OS/program/webpage lock prevents access,
                           remove <var>track</var> from <var>finalSet</var>.
                           If <var>finalSet</var> has no track of type <var>kind</var>,
                           <a>reject</a> <var>p</var> with a new
@@ -3667,6 +3658,15 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           object whose {{DOMException/name}} attribute has the
                           value {{"AbortError"}} and abort these steps.
                           Otherwise, restart these sub steps with the updated <var>finalSet</var>.</p>
+                        </li>
+                        <li>
+                          <p>Using the granted device's deviceId, <var>deviceId</var>, set
+                          <a>[[\devicesLiveMap]]</a>[<var>deviceId</var>] to
+                          <code>true</code>, if it isn’t already <code>true</code>,
+                          and set the
+                          <a>[[\devicesAccessibleMap]]</a>[<var>deviceId</var>] to
+                          <code>true</code>, if it isn’t already
+                          <code>true</code>.</p>
                         </li>
                         <li>
                           <p>Add <var>track</var> to <var>stream</var>'s track set.</p>


### PR DESCRIPTION
A follow-up fix to a bug introduced by https://github.com/w3c/mediacapture-main/pull/717.