### PR TITLE
Privacy indicator false-to-true transition SHOULD be 3 seconds.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -5136,7 +5136,7 @@ window.onload = async () =&gt; {
       indicate when the value changes.</li>
       <li>Any false-to-true transition indicated MUST remain observable for a
       sufficient time that a reasonably-observant user could become aware of
-      it.</li>
+      it (this SHOULD be 3 seconds).</li>
       <li>Any of the above transition indications MAY be combined as long as
       the combined indication cannot transition to false if any of its
       component indications are still true.</li>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -5136,7 +5136,7 @@ window.onload = async () =&gt; {
       indicate when the value changes.</li>
       <li>Any false-to-true transition indicated MUST remain observable for a
       sufficient time that a reasonably-observant user could become aware of
-      it (this SHOULD be 3 seconds).</li>
+      it. This SHOULD be at least 3 seconds.</li>
       <li>Any of the above transition indications MAY be combined as long as
       the combined indication cannot transition to false if any of its
       component indications are still true.</li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/724.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/734.html" title="Last updated on Nov 12, 2020, 3:23 PM UTC (8476eca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/734/ea45c6a...jan-ivar:8476eca.html" title="Last updated on Nov 12, 2020, 3:23 PM UTC (8476eca)">Diff</a>