### PR TITLE
Add permission revocation algorithm

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -789,7 +789,7 @@ interface MediaStream : EventTarget {
         </ol>
         <p>If the end of the track was reached due to a user request, the event
         source for this event is the user interaction event source.</p>
-        <p>To invoke the <dfn>permission revocation algorithm</dfn> with
+        <p>To invoke the <dfn>device permission revocation algorithm</dfn> with
         {{PermissionName}} <var>permissionName</var> and
         {{DevicePermissionDescriptor/deviceId}} <var>deviceId</var>, run the
         following steps:</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -789,6 +789,33 @@ interface MediaStream : EventTarget {
         </ol>
         <p>If the end of the track was reached due to a user request, the event
         source for this event is the user interaction event source.</p>
+        <p>To invoke the <dfn>permission revocation algorithm</dfn> with
+        {{PermissionName}} <var>permissionName</var> and
+        {{DevicePermissionDescriptor/deviceId}} <var>deviceId</var>, run the
+        following steps:</p>
+        <ol>
+          <li>
+            <p>Let <var>tracks</var> be the set of all currently
+            {{MediaStreamTrackState/"live"}} <code>MediaStreamTrack</code>s
+            that fit the following criteria:</p>
+            <ul>
+              <li>
+                If <var>deviceId</var> is not <code>undefined</code>, tracks
+                whose associated <a>deviceId</a> matches <var>deviceId</var>
+              </li>
+              <li>
+                If <var>deviceId</var> is <code>undefined</code>, tracks whose
+                permission associated with this kind of track (e.g.
+                {{PermissionName/"camera"}}, {{PermissionName/"microphone"}})
+                matches <var>permissionName</var>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>For each <var>track</var> in <var>tracks</var>,
+            <a href="#ends-nostop">end</a> the track.</p>
+          </li>
+        </ol>
         <h4>Media Flow</h4>
         <p>There are two dimensions related to the media flow for a
         {{MediaStreamTrackState/"live"}} {{MediaStreamTrack}} : muted / not


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/439 once I add a PR to permissions that invokes it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/745.html" title="Last updated on Nov 4, 2020, 10:36 PM UTC (f2cf6e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/745/87cb2f7...jan-ivar:f2cf6e4.html" title="Last updated on Nov 4, 2020, 10:36 PM UTC (f2cf6e4)">Diff</a>