### PR TITLE
OverconstrainedError extends DOMException + algo fixes

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2363,7 +2363,7 @@ interface OverconstrainedError : DOMException {
               </li>
               <li>
                 <p>Let <var>e</var> be a new
-                <code><a>OverconstrainedError</a></code> object.</p>
+                {{OverconstrainedError}} object.</p>
               </li>
               <li>
                 <p>Invoke the {{DOMException}} constructor of

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2332,230 +2332,68 @@ interface MediaStreamTrackEvent : Event {
   </section>
   <section>
     <h2>Error Handling</h2>
-    <p>This section and its subsections extend the list of Error subclasses
-    defined in [[ECMA-262]] following the pattern for NativeError in section 19.5.6
-    of that specification. Assume the following:</p>
-    <ul>
-      <li>that use of syntax such as [[\something]] and %something% is as used
-      in [[ECMA-262]].</li>
-      <li>that the rules for ECMAScript standard built-in objects ([[ECMA-262]],
-      section 17) are in effect in this section.</li>
-      <li>that the new intrinsic objects %OverconstrainedError% and
-      %OverconstrainedErrorPrototype% are available as if they had been
-      included in ([[ECMA-262]], Table 7) and all referencing sections, e.g.
-      ([[ECMA-262]], section 8.2.2), thus behave appropriately.</li>
-    </ul>
+    <p>Some operations throw or fire <code>OverconstrainedError</code>. This is
+    an extension of <code>DOMException</code> that carries additional
+    information related to constraints failure.</p>
     <section>
-      <h2>ECMAScript 6 Terminology</h2>
-      <p>The following terms used in this section are defined in [[ECMA-262]].</p>
-      <table>
-        <thead>
-          <tr>
-            <th>Term/Notation</th>
-            <th>Section in [[ECMA-262]]</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Type(X)</td>
-            <td>6</td>
-          </tr>
-          <tr>
-            <td>intrinsic object</td>
-            <td>6.1.7.4</td>
-          </tr>
-          <tr>
-            <td>[[\ErrorData]]</td>
-            <td>19.5.1</td>
-          </tr>
-          <tr>
-            <td>internal slot</td>
-            <td>6.1.7.2</td>
-          </tr>
-          <tr>
-            <td>NewTarget</td>
-            <td>various uses, but no definition</td>
-          </tr>
-          <tr>
-            <td>active function object</td>
-            <td>8.3</td>
-          </tr>
-          <tr>
-            <td>OrdinaryCreateFromConstructor()</td>
-            <td>9.1.14</td>
-          </tr>
-          <tr>
-            <td>ReturnIfAbrupt()</td>
-            <td>6.2.2.4</td>
-          </tr>
-          <tr>
-            <td>Assert</td>
-            <td>5.2</td>
-          </tr>
-          <tr>
-            <td>String</td>
-            <td>4.3.17-19, depending on context</td>
-          </tr>
-          <tr>
-            <td>PropertyDescriptor</td>
-            <td>6.2.4</td>
-          </tr>
-          <tr>
-            <td>[[\Value]]</td>
-            <td>6.1.7.1</td>
-          </tr>
-          <tr>
-            <td>[[\Writable]]</td>
-            <td>6.1.7.1</td>
-          </tr>
-          <tr>
-            <td>[[\Enumerable]]</td>
-            <td>6.1.7.1</td>
-          </tr>
-          <tr>
-            <td>[[\Configurable]]</td>
-            <td>6.1.7.1</td>
-          </tr>
-          <tr>
-            <td>DefinePropertyOrThrow()</td>
-            <td>7.3.7</td>
-          </tr>
-          <tr>
-            <td>abrupt completion</td>
-            <td>6.2.2</td>
-          </tr>
-          <tr>
-            <td>ToString()</td>
-            <td>7.1.12</td>
-          </tr>
-          <tr>
-            <td>[[\Prototype]]</td>
-            <td>9.1</td>
-          </tr>
-          <tr>
-            <td>%Error%</td>
-            <td>19.5.1</td>
-          </tr>
-          <tr>
-            <td>Error</td>
-            <td>19.5</td>
-          </tr>
-          <tr>
-            <td>%ErrorPrototype%</td>
-            <td>19.5.3</td>
-          </tr>
-          <tr>
-            <td>Object.prototype.toString</td>
-            <td>19.1.3.6</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-    <section>
-      <h2>OverconstrainedError Object</h2>
+      <h2>OverconstrainedError Interface</h2>
+      <div>
+        <pre class="idl" data-tests
+>[Exposed=Window]
+interface OverconstrainedError : DOMException {
+  constructor(DOMString constraint, optional DOMString message = "");
+  readonly attribute DOMString constraint;
+};</pre>
+      </div>
       <section>
-        <h2>OverconstrainedError Constructor</h2>
-        <p>The OverconstrainedError Constructor is the %OverconstrainedError%
-        intrinsic object. When <code>OverconstrainedError</code> is called as a
-        function rather than as a constructor, it creates and initializes a new
-        OverconstrainedError object. A call of the object as a function is
-        equivalent to calling it as a constructor with the same arguments. Thus
-        the function call <code><b>OverconstrainedError(</b>...<b>)</b></code>
-        is equivalent to the object creation expression <code><b>new
-        OverconstrainedError(</b>...<b>)</b></code> with the same
-        arguments.</p>
-        <p>The <code>OverconstrainedError</code> constructor is designed to be
-        subclassable. It may be used as the value of an <code>extends</code>
-        clause of a class definition. Subclass constructors that intend to
-        inherit the specified <code>OverconstrainedError</code> behaviour must
-        include a <code>super</code> call to the
-        <code>OverconstrainedError</code> constructor to create and initialize
-        the subclass instance with an [[\ErrorData]] internal slot.</p>
-        <section>
-          <h2>OverconstrainedError ( constraint, message )</h2>
-          <p>When the <code><dfn>OverconstrainedError</dfn></code> function is
-          called with arguments <i>constraint</i> and <i>message</i> the
-          following steps are taken:</p>
-          <ol>
-            <li>If NewTarget is <b>undefined</b>, let <i>newTarget</i> be the
-            active function object, else let <i>newTarget</i> be
-            NewTarget.</li>
-            <li>Let <i>O</i> be OrdinaryCreateFromConstructor(<i>newTarget</i>,
-            <code>"%OverconstrainedErrorPrototype%"</code>, «[[\ErrorData]]»
-            ).</li>
-            <li>ReturnIfAbrupt(<i>O</i>).</li>
-            <li>If <i>constraint</i> is not <b>undefined</b>, then
-              <ol>
-                <li>Let <i>constraintDesc</i> be the
-                PropertyDescriptor{[[\Value]]: <i>constraint</i>,
-                [[\Writable]]: <b>false</b>, [[\Enumerable]]: <b>false</b>,
-                [[\Configurable]]: <b>false</b>}.</li>
-                <li>Let <i>cStatus</i> be DefinePropertyOrThrow(O,
-                "<code>constraint</code>", <i>constraintDesc</i>).</li>
-                <li>Assert: <i>cStatus</i> is not an abrupt completion.</li>
-              </ol>
-            </li>
-            <li>If <i>message</i> is not <b>undefined</b>, then
-              <ol>
-                <li>Let <i>msg</i> be ToString(<i>message</i>).</li>
-                <li>Let <i>msgDesc</i> be the PropertyDescriptor{[[\Value]]:
-                <i>msg</i>, [[\Writable]]: <b>true</b>, [[\Enumerable]]:
-                <b>false</b>, [[\Configurable]]: <b>true</b>}.</li>
-                <li>Let <i>mStatus</i> be DefinePropertyOrThrow(O,
-                "<code>message</code>", <i>msgDesc</i>).</li>
-                <li>Assert: <i>mStatus</i> is not an abrupt completion.</li>
-              </ol>
-            </li>
-            <li>Return <i>O</i>.</li>
-          </ol>
-        </section>
+        <h2>Constructors</h2>
+        <dl data-link-for="OverconstrainedError" data-dfn-for="OverconstrainedError"
+        class="constructors">
+          <dt><dfn data-idl><code>OverconstrainedError</code></dfn></dt>
+          <dd>
+            <p>Run the following steps:</p>
+            <ol>
+              <li>
+                <p>Let <var>constraint</var> be the constructor's first
+                argument.</p>
+              </li>
+              <li>
+                <p>Let <var>message</var> be the constructor's second argument.
+                </p>
+              </li>
+              <li>
+                <p>Let <var>e</var> be a new
+                <code><a>OverconstrainedError</a></code> object.</p>
+              </li>
+              <li>
+                <p>Invoke the <code><a>DOMException</a></code> constructor of
+                <var>e</var> with the <code>message</code> argument set to
+                <var>message</var> and the <code>name</code> argument set to
+                <code>"OverconstrainedError"</code>.</p>
+                <p class="note">This name does not have a mapping to a legacy
+                code so <var>e</var>'s <code>code</code> attribute will return
+                0.</p>
+              </li>
+              <li>
+                <p>Set <var>e.constraint</var> to <var>constraint</var>.</p>
+              </li>
+              <li>
+                <p>Return <var>e</var>.</p>
+              </li>
+            </ol>
+          </dd>
+        </dl>
       </section>
       <section>
-        <h2>Properties of the OverconstrainedError Constructor</h2>
-        <p>The value of the [[\Prototype]] internal slot of the
-        OverconstrainedError constructor is the intrinsic object %Error%.</p>
-        <p>Besides the <code>length</code> property (whose value is <b>1</b>),
-        the OverconstrainedError constructor has the following properties:</p>
-        <section>
-          <h2>OverconstrainedError.prototype</h2>
-          <p>The initial value of <code>OverconstrainedError.prototype</code>
-          is the <a href=
-          "#properties-of-the-overconstrainederror-prototype-object">OverconstrainedError
-          prototype object</a>. This property has the attributes {
-          [[\Writable]]: <b>false</b>, [[\Enumerable]]: <b>false</b>,
-          [[\Configurable]]: <b>false</b> }.</p>
-        </section>
-      </section>
-      <section>
-        <h2>Properties of the OverconstrainedError Prototype Object</h2>
-        <p>The OverconstrainedError prototype object is an ordinary object. It
-        is not an Error instance and does not have an [[\ErrorData]] internal
-        slot.</p>
-        <p>The value of the [[\Prototype]] internal slot of the
-        OverconstrainedError prototype object is the intrinsic object
-        %ErrorPrototype%.</p>
-        <section>
-          <h2>OverconstrainedError.prototype.constructor</h2>
-          <p>The initial value of the constructor property of the prototype for
-          the OverconstrainedError constructor is the intrinsic object <a href=
-          "#error-handling">%OverconstrainedError%</a>.</p>
-        </section>
-        <section>
-          <h2>OverconstrainedError.prototype.constraint</h2>
-          <p>The initial value of the constraint property of the prototype for
-          the OverconstrainedError constructor is the empty String.</p>
-        </section>
-        <section>
-          <h2>OverconstrainedError.prototype.message</h2>
-          <p>The initial value of the message property of the prototype for the
-          OverconstrainedError constructor is the empty String.</p>
-        </section>
-        <section>
-          <h2>OverconstrainedError.prototype.name</h2>
-          <p>The initial value of the name property of the prototype for the
-          OverconstrainedError constructor is
-          <code>"<b>OverconstrainedError</b>"</code>.</p>
-        </section>
+        <h2>Attributes</h2>
+        <dl data-link-for="OverconstrainedError" data-dfn-for="OverconstrainedError" class="attributes">
+          <dt><dfn data-idl><code>constraint</code></dfn> of type <span
+          class="idlAttrType"><a>DOMStrng</a></span>, readonly</dt>
+          <dd>
+            <p>The name of a constraint associated with this error, or
+            <code>""</code> if no specific constraint name is revealed.</p>
+          </dd>
+        </dl>
       </section>
     </section>
   </section>
@@ -3552,7 +3390,8 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           <a data-lt="required constraints">required constraint</a>
                           whose fitness distance was infinity for
                           all settings dictionaries examined while executing
-                          the <a>SelectSettings</a> algorithm, and jump to the
+                          the <a>SelectSettings</a> algorithm, or
+                          <code>""</code> if there isn't one, and jump to the
                           step labeled <em>Constraint Failure</em> below.</p>
                           <p class="fingerprint">This error gives information
                           about what the underlying device is not capable of
@@ -3678,12 +3517,10 @@ interface InputDeviceInfo : MediaDeviceInfo {
                     <li>
                       <p>Run the <a>ApplyConstraints algorithm</a> on all
                       tracks in <var>stream</var> with the appropriate
-                      constraints. Should this fail, let
-                      <var>failedConstraint</var> be the result of the
-                      algorithm that failed if
-                      <a>device information can be exposed</a> is <code>true</code>,
-                      or <code>undefined</code> otherwise, and jump to the step
-                      labeled <em>Constraint Failure</em> below.</p>
+                      constraints. If any of them returns something other than
+                      <code>undefined</code>, let <var>failedConstraint</var> be
+                      that result and jump to the step labeled
+                      <em>Constraint Failure</em> below.</p>
                     </li>
                     <li>
                       <p><a>Set the device information exposure</a> to <code>true</code>.</p>
@@ -3701,10 +3538,14 @@ interface InputDeviceInfo : MediaDeviceInfo {
                     <li>
                       <p><em>Constraint Failure</em>: Let <var>message</var> be
                       either <code>undefined</code> or an informative
-                      human-readable message, and then <a>reject</a>
+                      human-readable message, let <var>constraint</var> be
+                      <var>failedConstraint</var> if
+                      <a>device information can be exposed</a> is
+                      <code>true</code>, or <code>""</code> otherwise,
+                      and then <a>reject</a>
                       <var>p</var> with a new <code>OverconstrainedError</code>
                       created by calling
-                      <code>OverconstrainedError(<var>failedConstraint</var>,
+                      <code>OverconstrainedError(<var>constraint</var>,
                       <var>message</var>)</code>.</p>
                     </li>
                   </ol>
@@ -4475,8 +4316,9 @@ interface ConstrainablePattern {
                   any <a data-lt="required constraints">required constraint</a>
                   whose fitness distance was infinity
                   for all settings dictionaries examined while executing the
-                  <a>SelectSettings</a> algorithm, return
-                  <var>failedConstraint</var>, and abort these steps.</p>
+                  <a>SelectSettings</a> algorithm, or <code>""</code> if there
+                  isn't one, and then return
+                  <var>failedConstraint</var> and abort these steps.</p>
                 </li>
                 <li>In a single operation, remove the existing constraints from
                 <var>object</var>, apply <var>newConstraints</var>, and apply

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2333,7 +2333,7 @@ interface MediaStreamTrackEvent : Event {
   <section>
     <h2>Error Handling</h2>
     <p>Some operations throw or fire <code>OverconstrainedError</code>. This is
-    an extension of <code>DOMException</code> that carries additional
+    an extension of {{DOMException}} that carries additional
     information related to constraints failure.</p>
     <section>
       <h2>OverconstrainedError Interface</h2>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2388,7 +2388,7 @@ interface OverconstrainedError : DOMException {
         <h2>Attributes</h2>
         <dl data-link-for="OverconstrainedError" data-dfn-for="OverconstrainedError" class="attributes">
           <dt><dfn data-idl><code>constraint</code></dfn> of type <span
-          class="idlAttrType"><a>DOMString</a></span>, readonly</dt>
+          class="idlAttrType">{{DOMString}}</span>, readonly</dt>
           <dd>
             <p>The name of a constraint associated with this error, or
             <code>""</code> if no specific constraint name is revealed.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3650,13 +3650,13 @@ interface InputDeviceInfo : MediaDeviceInfo {
       <h2><dfn>NavigatorUserMediaErrorCallback</dfn></h2>
       <div>
         <pre class="idl"
->callback NavigatorUserMediaErrorCallback = undefined (MediaStreamError error);</pre>
+>callback NavigatorUserMediaErrorCallback = undefined (DOMException error);</pre>
         <section>
           <h2>Callback <a class="idlType">NavigatorUserMediaErrorCallback</a>
           Parameters</h2>
           <dl data-link-for="NavigatorUserMediaErrorCallback" data-dfn-for=
           "NavigatorUserMediaErrorCallback" class="callback-members">
-            <dt>error of type {{MediaStreamError}}</dt>
+            <dt>error of type {{DOMException}}</dt>
             <dd>
               Error in obtaining a {{MediaStream}} as described
               in the failure steps of the {{Navigator.getUserMedia}}
@@ -3664,14 +3664,6 @@ interface InputDeviceInfo : MediaDeviceInfo {
             </dd>
           </dl>
         </section>
-      </div>
-      <div>
-        <pre class="idl">typedef object MediaStreamError;</pre>
-        <div class="idlTypedefDesc">
-          A <dfn>MediaStreamError</dfn> object is either a
-          {{DOMException}} object or an
-          <code><a>OverconstrainedError</a></code> object.
-        </div>
       </div>
     </section>
     <section class="informative">

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2366,7 +2366,7 @@ interface OverconstrainedError : DOMException {
                 <code><a>OverconstrainedError</a></code> object.</p>
               </li>
               <li>
-                <p>Invoke the <code><a>DOMException</a></code> constructor of
+                <p>Invoke the {{DOMException}} constructor of
                 <var>e</var> with the <code>message</code> argument set to
                 <var>message</var> and the <code>name</code> argument set to
                 <code>"OverconstrainedError"</code>.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2388,7 +2388,7 @@ interface OverconstrainedError : DOMException {
         <h2>Attributes</h2>
         <dl data-link-for="OverconstrainedError" data-dfn-for="OverconstrainedError" class="attributes">
           <dt><dfn data-idl><code>constraint</code></dfn> of type <span
-          class="idlAttrType"><a>DOMStrng</a></span>, readonly</dt>
+          class="idlAttrType"><a>DOMString</a></span>, readonly</dt>
           <dd>
             <p>The name of a constraint associated with this error, or
             <code>""</code> if no specific constraint name is revealed.</p>

--- a/getusermedia.js
+++ b/getusermedia.js
@@ -70,15 +70,6 @@ var respecConfig = {
       ]
     }
   ],
-   localBiblio: {
-     ES6: {
-       title:  "ECMAScript 2015",
-       href: "http://www.ecma-international.org/ecma-262/6.0/",
-       authors: ["Allen Wirfs-Brock"],
-       status: "Standard",
-       publisher: "Ecma International"
-     }
-   },
     afterEnd: function markFingerprinting () {
         Array.prototype.forEach.call(
             document.querySelectorAll(".fingerprint"),


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/568.

I made the `constraint` argument always present and `""` in cases where the constraint name is either filtered out or undetermined. This matches Safari and Firefox at least (I wasn't able to provoke the absence of a constraint in Chrome).

I also fixed some bugs in the algorithms around `failedConstraint` in the process.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/746.html" title="Last updated on Nov 9, 2020, 11:23 PM UTC (61257f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/746/87cb2f7...jan-ivar:61257f4.html" title="Last updated on Nov 9, 2020, 11:23 PM UTC (61257f4)">Diff</a>