### PR TITLE
Make sure to have the default audio output device be the first device in enumerateDevices list that is not a microphone and not a camera

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2762,7 +2762,7 @@ interface MediaDevices : EventTarget {
                       be the list of all discovered devices.</p>
                     </li>
                     <li>
-                      <p>Let <var>microphoneList</var> and <var>cameraList</var> be empty lists.</p>
+                      <p>Let <var>microphoneList</var>, <var>cameraList</var> and <var>otherDeviceList</var> be empty lists.</p>
                     </li>
                     <li>
                       <p>Run the following sub steps for each discovered device in <var>deviceList</var>, <var>device</var>:</p>
@@ -2818,12 +2818,6 @@ interface MediaDevices : EventTarget {
                       <p>Otherwise, run the following steps:<p>
                       <ol>
                         <li>
-                          <p>Append to <var>resultList</var> all devices of <var>microphoneList</var> in order.</p>
-                        </li>
-                        <li>
-                          <p>Append to <var>resultList</var> all devices of <var>cameraList</var> in order.</p>
-                        </li>
-                        <li>
                           <p>Run the following sub steps for each discovered device in <var>deviceList</var>, <var>device</var>:</p>
                           <ol>
                             <li>
@@ -2841,9 +2835,20 @@ interface MediaDevices : EventTarget {
                               <a>creating a device info object</a> to represent <var>device</var>.</p>
                             </li>
                             <li>
-                              <p>Append <var>deviceInfo</var> to <var>resultList</var>.</p>
+                              <p>If <var>device</var> is the system default audio output,
+                              prepend <var>deviceInfo</var> to <var>otherDeviceList</var>.
+                              Otherwise, append <var>deviceInfo</var> to <var>otherDeviceList</var>.</p>
                             </li>
                           </ol>
+                        </li>
+                        <li>
+                          <p>Append to <var>resultList</var> all devices of <var>microphoneList</var> in order.</p>
+                        </li>
+                        <li>
+                          <p>Append to <var>resultList</var> all devices of <var>cameraList</var> in order.</p>
+                        </li>
+                        <li>
+                          <p>Append to <var>resultList</var> all devices of <var>otherDeviceList</var> in order.</p>
                         </li>
                       </ol>
                     </li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/756


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/757.html" title="Last updated on Dec 17, 2020, 9:38 AM UTC (8a2caca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/757/826b76a...youennf:8a2caca.html" title="Last updated on Dec 17, 2020, 9:38 AM UTC (8a2caca)">Diff</a>