### PR TITLE
Fitness distance for bool placeholder & constraints not supported by device.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4247,16 +4247,12 @@ interface ConstrainablePattern {
                   distance is positive infinity.</p>
                 </li>
                 <li>
-                  <p>If the constraint is
-                  <a data-lt="required">not required</a>, and does not apply for
-                  this type of object, the fitness distance is 0 (that is, the
-                  constraint does not influence the fitness distance).</p>
+                  <p>If the constraint does not apply for this type of object,
+                  the fitness distance is 0 (that is, the constraint does not
+                  influence the fitness distance).</p>
                 </li>
                 <li>
-                  <p>If the constraint is
-                  <a data-lt="required">not required</a>, applies for this type
-                  of object (but not necessarily this specific instance), and
-                  the <a>settings dictionary</a>'s <var>constraintName</var>
+                  <p>If the <a>settings dictionary</a>'s <var>constraintName</var>
                   member does [= map/exist | not exist=], the fitness distance
                   is 1.</p>
                 </li>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1111,7 +1111,11 @@ interface MediaStreamTrack : EventTarget {
                             unchangeable device properties as members unless
                             they are in the <a>list of inherent constrainable
                             track properties</a> (to avoid a "broken clock being
-                            right twice a day" problem).
+                            right twice a day" problem), or otherwise include
+                            device properties that <dfn>must not be exposed</dfn>.
+                            <p class="note">Other specifications may define
+                            constrainable properties that at times <a>must not
+                            be exposed</a>.</p>
                           </li>
                         </ul>
                       </li>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4252,6 +4252,14 @@ interface ConstrainablePattern {
                   influence the fitness distance).</p>
                 </li>
                 <li>
+                  <p>If <var>constraintValue</var> is boolean, but the
+                  constrainable property is not, then the fitness distance is
+                  based on whether the <a>settings dictionary</a>'s
+                  <var>constraintName</var> member [= map/exist | exists =] or
+                  not, from the formula
+                  <pre>(constraintValue == exists) ? 0 : 1</pre>
+                </li>
+                <li>
                   <p>If the <a>settings dictionary</a>'s <var>constraintName</var>
                   member does [= map/exist | not exist=], the fitness distance
                   is 1.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1107,7 +1107,11 @@ interface MediaStreamTrack : EventTarget {
                           <li>
                             <a>settings dictionary</a> refers to a possible
                             instance of the {{MediaTrackSettings}}
-                            dictionary.
+                            dictionary. The User Agent MUST NOT include inherent
+                            unchangeable device properties as members unless
+                            they are in the <a>list of inherent constrainable
+                            track properties</a> (to avoid a "broken clock being
+                            right twice a day" problem).
                           </li>
                         </ul>
                       </li>
@@ -4234,14 +4238,23 @@ interface ConstrainablePattern {
                   either contains one or more members named 'min', 'max', or
                   'exact', or is itself a bare value and bare values are to be
                   treated as 'exact'), and the <a>settings dictionary</a>'s
-                  value for the constraint does not satisfy the constraint, the
-                  fitness distance is positive infinity.</p>
+                  <var>constraintName</var> member does not [= map/exist =], or
+                  its value does not satisfy the constraint, the fitness
+                  distance is positive infinity.</p>
                 </li>
                 <li>
                   <p>If the constraint is
                   <a data-lt="required">not required</a>, and does not apply for
-                  this type of device, the fitness distance is 0 (that is, the
+                  this type of object, the fitness distance is 0 (that is, the
                   constraint does not influence the fitness distance).</p>
+                </li>
+                <li>
+                  <p>If the constraint is
+                  <a data-lt="required">not required</a>, applies for this type
+                  of object (but not necessarily this specific instance), and
+                  the <a>settings dictionary</a>'s <var>constraintName</var>
+                  member does [= map/exist | not exist=], the fitness distance
+                  is 1.</p>
                 </li>
                 <li>If no ideal value is specified (<var>constraintValue</var>
                 either contains no member named 'ideal', or, if bare values are

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4242,9 +4242,9 @@ interface ConstrainablePattern {
                   either contains one or more members named 'min', 'max', or
                   'exact', or is itself a bare value and bare values are to be
                   treated as 'exact'), and the <a>settings dictionary</a>'s
-                  <var>constraintName</var> member does not [= map/exist =], or
-                  its value does not satisfy the constraint, the fitness
-                  distance is positive infinity.</p>
+                  <var>constraintName</var> member's value does not satisfy the
+                  constraint or doesn't [= map/exist =], the fitness distance is
+                  positive infinity.</p>
                 </li>
                 <li>
                   <p>If the constraint does not apply for this type of object,

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4252,7 +4252,7 @@ interface ConstrainablePattern {
                   influence the fitness distance).</p>
                 </li>
                 <li>
-                  <p>If <var>constraintValue</var> is boolean, but the
+                  <p>If <var>constraintValue</var> is a boolean, but the
                   constrainable property is not, then the fitness distance is
                   based on whether the <a>settings dictionary</a>'s
                   <var>constraintName</var> member [= map/exist | exists =] or

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1110,8 +1110,7 @@ interface MediaStreamTrack : EventTarget {
                             dictionary. The User Agent MUST NOT include inherent
                             unchangeable device properties as members unless
                             they are in the <a>list of inherent constrainable
-                            track properties</a> (to avoid a "broken clock being
-                            right twice a day" problem), or otherwise include
+                            track properties</a>, or otherwise include
                             device properties that <dfn>must not be exposed</dfn>.
                             <p class="note">Other specifications may define
                             constrainable properties that at times <a>must not


### PR DESCRIPTION
Replaces https://github.com/w3c/mediacapture-main/pull/742 as partial fix to https://github.com/w3c/mediacapture-image/issues/256.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/766.html" title="Last updated on Jan 19, 2021, 6:52 PM UTC (8f5f129)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/766/aa0eae1...jan-ivar:8f5f129.html" title="Last updated on Jan 19, 2021, 6:52 PM UTC (8f5f129)">Diff</a>