### PR TITLE
Mark track/ended as exported definition

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -758,7 +758,7 @@ interface MediaStream : EventTarget {
         {{MediaStreamTrack/stop()}} method on
         the {{MediaStreamTrack}} object, or because the User
         Agent has instructed the track to end for any reason) it is said to be
-        <dfn id="track-ended" data-dfn-for="track">ended</dfn>.</p>
+        <dfn id="track-ended" data-dfn-for="track" data-export>ended</dfn>.</p>
         <p>When a {{MediaStreamTrack}} <var>track</var>
         <dfn data-lt="track ended by the User agent" data-for=MediaStreamTrack data-export id="ends-nostop">ends for any reason other than the {{MediaStreamTrack/stop()}} method being
         invoked</dfn>, the User Agent MUST queue a task that runs the following


### PR DESCRIPTION
Needed e.g. in screen capture - cf https://github.com/w3c/mediacapture-screen-share/pull/153