### PR TITLE
UA s/SHOULD/MUST/ use one with the smallest fitness distance

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4350,7 +4350,7 @@ interface ConstrainablePattern {
                 <li>
                   <p>Select one settings dictionary from <var>candidates</var>,
                   and return it as the result of the <a>SelectSettings</a>
-                  algorithm. The UA MUST use one with the smallest
+                  algorithm. The User Agent MUST use one with the smallest
                   <a>fitness distance</a>, as calculated in step 3. If more than
                   one settings dictionary have the smallest fitness distance,
                   the user agent choses one of them.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4350,10 +4350,10 @@ interface ConstrainablePattern {
                 <li>
                   <p>Select one settings dictionary from <var>candidates</var>,
                   and return it as the result of the <a>SelectSettings</a>
-                  algorithm. The UA SHOULD use the one with the smallest
-                  <a>fitness distance</a>, as calculated in step 3, but
-                  MAY prefer ones with <a>resizeMode</a> set to
-                  <code>"none"</code> over <code>"crop-and-scale"</code>.</p>
+                  algorithm. The UA MUST use one with the smallest
+                  <a>fitness distance</a>, as calculated in step 3. If more than
+                  one settings dictionary have the smallest fitness distance,
+                  the user agent choses one of them.</p>
                 </li>
               </ol>
               <p>To apply the <dfn data-export>ApplyConstraints algorithm</dfn> to an

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4353,7 +4353,7 @@ interface ConstrainablePattern {
                   algorithm. The User Agent MUST use one with the smallest
                   <a>fitness distance</a>, as calculated in step 3. If more than
                   one settings dictionary have the smallest fitness distance,
-                  the user agent choses one of them.</p>
+                  the User Agent chooses one of them.</p>
                 </li>
               </ol>
               <p>To apply the <dfn data-export>ApplyConstraints algorithm</dfn> to an


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/729.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/768.html" title="Last updated on Jan 28, 2021, 3:31 PM UTC (08692dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/768/5390462...jan-ivar:08692dc.html" title="Last updated on Jan 28, 2021, 3:31 PM UTC (08692dc)">Diff</a>