### PR TITLE
Mark up IDL from constrainable patterns as non-normative

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4772,7 +4772,7 @@ async function specifyCamera() {
       specification using the Constrainable Pattern should not subclass the
       below dictionary, but instead provide its own definition. See
       {{MediaTrackCapabilities}} for an example.
-      <div class=example>
+      <div class=example>Template:
         <pre class="idl">dictionary Capabilities {};</pre>
       </div>
     </section>
@@ -4800,7 +4800,7 @@ async function specifyCamera() {
 }
       </pre>A specification using the Constrainable Pattern should not subclass
 the below dictionary, but instead provide its own definition. See {{MediaTrackSettings}} for an example.
-      <div class=example>
+      <div class=example>Template:
         <pre class="idl">dictionary Settings {};</pre>
       </div>
     </section>
@@ -4812,7 +4812,7 @@ the below dictionary, but instead provide its own definition. See {{MediaTrackSe
       own definitions that follow this pattern. See <a href=
       "#media-track-constraints">MediaTrackConstraints</a> for an example of
       this.</p>
-      <div class=example>
+      <div class=example>Template:
         <pre class="idl">dictionary ConstraintSet {};</pre>
       </div>
       <p>Each member of a <dfn>ConstraintSet</dfn> corresponds to a
@@ -4822,11 +4822,12 @@ the below dictionary, but instead provide its own definition. See {{MediaTrackSe
       the specified values or ranges of values. A given property MAY occur both
       in the basic Constraints set and in the advanced ConstraintSets list, and
       MAY occur at most once in each ConstraintSet in the advanced list.</p>
-      <div class=example>
+      <div class=example>Template:
         <pre class="idl"
 >dictionary Constraints : ConstraintSet {
   sequence&lt;ConstraintSet&gt; advanced;
 };</pre>
+      </div>
         <section>
           <h2>Dictionary <dfn>Constraints</dfn> Members</h2>
           <dl data-link-for="Constraints" data-dfn-for="Constraints" class=

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4772,7 +4772,7 @@ async function specifyCamera() {
       specification using the Constrainable Pattern should not subclass the
       below dictionary, but instead provide its own definition. See
       {{MediaTrackCapabilities}} for an example.
-      <div>
+      <div class=example>
         <pre class="idl">dictionary Capabilities {};</pre>
       </div>
     </section>
@@ -4800,7 +4800,7 @@ async function specifyCamera() {
 }
       </pre>A specification using the Constrainable Pattern should not subclass
 the below dictionary, but instead provide its own definition. See {{MediaTrackSettings}} for an example.
-      <div>
+      <div class=example>
         <pre class="idl">dictionary Settings {};</pre>
       </div>
     </section>
@@ -4812,7 +4812,7 @@ the below dictionary, but instead provide its own definition. See {{MediaTrackSe
       own definitions that follow this pattern. See <a href=
       "#media-track-constraints">MediaTrackConstraints</a> for an example of
       this.</p>
-      <div>
+      <div class=example>
         <pre class="idl">dictionary ConstraintSet {};</pre>
       </div>
       <p>Each member of a <dfn>ConstraintSet</dfn> corresponds to a
@@ -4822,7 +4822,7 @@ the below dictionary, but instead provide its own definition. See {{MediaTrackSe
       the specified values or ranges of values. A given property MAY occur both
       in the basic Constraints set and in the advanced ConstraintSets list, and
       MAY occur at most once in each ConstraintSet in the advanced list.</p>
-      <div>
+      <div class=example>
         <pre class="idl"
 >dictionary Constraints : ConstraintSet {
   sequence&lt;ConstraintSet&gt; advanced;


### PR DESCRIPTION
The Capabilities, Settings, Constraints and ConstraintSet dictionaries are not meant to be directly implemented - they document the Constrainable pattern.

To avoid having them be considered as part of the normative surface of the spec, they're marked-up with the example class - similar to what we do with ConstrainablePattern.

This in particular helps with automatically extracted IDL fragments as done by webref / reffy https://github.com/w3c/webref/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/pull/769.html" title="Last updated on Jan 29, 2021, 1:27 PM UTC (b348d7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/769/6b782b5...b348d7b.html" title="Last updated on Jan 29, 2021, 1:27 PM UTC (b348d7b)">Diff</a>