### PR TITLE
Have resizeMode: 'none' mean native frame rate as well.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1825,8 +1825,8 @@ interface MediaStreamTrack : EventTarget {
                 <td><dfn id=
                 "idl-def-VideoResizeModeEnum.user">none</dfn></td>
                 <td>
-                  <p>This resolution is offered by the camera, its driver, or
-                  the OS.</p>
+                  <p>This resolution and frame rate is offered by the camera,
+                  its driver, or the OS.</p>
                   <p class="fingerprint">Note: The UA MAY report this value to
                   disguise concurrent use, but only when the camera is in use
                   in another browsing context.</p>
@@ -1837,7 +1837,8 @@ interface MediaStreamTrack : EventTarget {
                 "idl-def-VideoResizeModeEnum.right">crop-and-scale</dfn></td>
                 <td>
                   <p>This resolution is downscaled and/or cropped from a higher
-                  camera resolution by the User Agent. The media MUST NOT be
+                  camera resolution by the User Agent, or its frame rate is
+                  decimated by the User Agent. The media MUST NOT be
                   upscaled, stretched or have fake data created that did not
                   occur in the input source.</p>
                 </td>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/762.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/770.html" title="Last updated on Feb 4, 2021, 2:30 PM UTC (d9c7ad2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/770/6b782b5...jan-ivar:d9c7ad2.html" title="Last updated on Feb 4, 2021, 2:30 PM UTC (d9c7ad2)">Diff</a>