### PR TITLE
Add native res + decimated frameRate example, handling rotation.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4543,6 +4543,43 @@ async function specifyCamera() {
   });
 }
       </pre>
+      <p>Here's an example of "I want a native 16:9 resolution near 720p, but
+      with a decimated frame-rate". This needs to be done in two steps, and
+      shows how to derive constraints from current settings, which may be
+      rotated:</p>
+      <pre class="example">
+async function nativeResolutionButDecimatedFrameRate() {
+  const supports = navigator.mediaDevices.getSupportedConstraints();
+  if (!supports.width || !supports.height || !supports.resizeMode) {
+    // Treat like an error (aspectRatio optional, for demonstration only)
+  }
+  const stream = await navigator.mediaDevices.getUserMedia({
+    video: {
+      width: 1280,
+      height: 720
+      aspectRatio: 16 / 9, // avoid exact with aspect ratios in case of rounding
+      resizeMode: {exact: 'none'} // may give native frame rates only
+    }
+  });
+  const [track] = stream.getVideoTracks();
+  const {width, height, aspectRatio} = track.getSettings();
+
+  // Constraints are in landscape, but settings may be rotated (portrait)
+  if (width < height) {
+    [width, height] = [height, width];
+    aspectRatio = 1 / aspectRatio;
+  }
+  await track.applyConstraints({
+    width: {exact: width},
+    height: {exact: height},
+    aspectRatio,
+    frameRate: 10,
+    resizeMode: 'crop-and-scale'
+  });
+}
+      </pre>
+      <div class="note">This example assumes the <a>primary orientation</a> is
+      landscape.</div>
     </section>
     <section>
       <h2>Types for Constrainable Properties</h2>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4556,7 +4556,7 @@ async function nativeResolutionButDecimatedFrameRate() {
   const stream = await navigator.mediaDevices.getUserMedia({
     video: {
       width: 1280,
-      height: 720
+      height: 720,
       aspectRatio: 16 / 9, // aspect ratios may not be exactly accurate
       resizeMode: 'none' // gives native frame rates only
     }

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4558,7 +4558,7 @@ async function nativeResolutionButDecimatedFrameRate() {
       width: 1280,
       height: 720
       aspectRatio: 16 / 9, // aspect ratios may not be exactly accurate
-      resizeMode: {exact: 'none'} // may give native frame rates only
+      resizeMode: 'none' // gives native frame rates only
     }
   });
   const [track] = stream.getVideoTracks();

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4557,7 +4557,7 @@ async function nativeResolutionButDecimatedFrameRate() {
     video: {
       width: 1280,
       height: 720
-      aspectRatio: 16 / 9, // avoid exact with aspect ratios in case of rounding
+      aspectRatio: 16 / 9, // aspect ratios may not be exactly accurate
       resizeMode: {exact: 'none'} // may give native frame rates only
     }
   });


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/761.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/771.html" title="Last updated on Feb 4, 2021, 3:30 PM UTC (1437b8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/771/6b782b5...jan-ivar:1437b8c.html" title="Last updated on Feb 4, 2021, 3:30 PM UTC (1437b8c)">Diff</a>