### PR TITLE
Audio output device default change should also trigger devicechange event

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2695,7 +2695,7 @@ interface OverconstrainedError : DOMException {
       </ol>
       <p>Additionally, when new media input and/or output devices are made
       available, or any available input and/or output device becomes unavailable,
-      or the system default for camera or microphone changed, the User Agent MUST
+      or the system default for input and/or output devices changed, the User Agent MUST
       run the [=device change notification steps=] in browsing contexts for
       which [=device enumeration can proceed=] is <code>true</code> and
       [=device information can be exposed=] is <code>true</code>, but in no


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/809


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/815.html" title="Last updated on Aug 26, 2021, 4:27 PM UTC (d9d8ca3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/815/5614349...youennf:d9d8ca3.html" title="Last updated on Aug 26, 2021, 4:27 PM UTC (d9d8ca3)">Diff</a>