### PR TITLE
Mention mobile operating systems and add a requirement for User Agents to update muted when OS decides to mute/unmute

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -896,7 +896,7 @@ interface MediaStream : EventTarget {
         control in the operating system, the user clicking a mute button in the
         User Agent chrome, the User Agent (on behalf of the user) mutes, etc.</p>
         <p>On some operating systems, microphone access may
-        get stolen from the User Agent when another native application gets access to it,
+        get stolen from the User Agent when another application with higher-audio priority gets access to it,
         for instance in case of an incoming phone call. The User Agent SHOULD provide
         this information to the web application through {{MediaStreamTrack/muted}} and
         its associated events.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -897,7 +897,7 @@ interface MediaStream : EventTarget {
         User Agent chrome, the User Agent (on behalf of the user) mutes, etc.</p>
         <p>On some operating systems, microphone access may
         get stolen from the User Agent when another application with higher-audio priority gets access to it,
-        for instance in case of an incoming phone call. The User Agent SHOULD provide
+        for instance in case of an incoming phone call on mobile OS. The User Agent SHOULD provide
         this information to the web application through {{MediaStreamTrack/muted}} and
         its associated events.</p>
 

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -887,7 +887,7 @@ interface MediaStream : EventTarget {
         "track-muted">Muted</dfn> refers to the input to the
         {{MediaStreamTrack}}. If live samples are not made
         available to the {{MediaStreamTrack}} it is muted.</p>
-        <p>Muted is out of control for the application, but can be observed by
+        <p>Muted is out of control for the web application, but can be observed by
         the application by reading the {{MediaStreamTrack/muted}} attribute and listening
         to the associated events {{mute}} and {{unmute}}. There can be
         several reasons for a {{MediaStreamTrack}} to be muted:
@@ -895,6 +895,12 @@ interface MediaStream : EventTarget {
         closing a laptop lid with an embedded camera, the user toggling a
         control in the operating system, the user clicking a mute button in the
         User Agent chrome, the User Agent (on behalf of the user) mutes, etc.</p>
+        <p>On mobile operating systems, it is often the case that microphone access may
+        get stolen from the User Agent when another native application gets access to it,
+        for instance in case of an incoming phone call. The User Agent SHOULD provide
+        this information to the web application through {{MediaStreamTrack/muted}} and
+        its associated events.</p>
+
         <p>Whenever the User Agent initiates such a change, it MUST queue a
         task, using the user interaction task source, to [=set a track's muted
         state=] to the state desired by the user.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -895,7 +895,7 @@ interface MediaStream : EventTarget {
         closing a laptop lid with an embedded camera, the user toggling a
         control in the operating system, the user clicking a mute button in the
         User Agent chrome, the User Agent (on behalf of the user) mutes, etc.</p>
-        <p>On mobile operating systems, it is often the case that microphone access may
+        <p>On some operating systems, microphone access may
         get stolen from the User Agent when another native application gets access to it,
         for instance in case of an incoming phone call. The User Agent SHOULD provide
         this information to the web application through {{MediaStreamTrack/muted}} and


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/838.html" title="Last updated on Dec 9, 2021, 2:34 PM UTC (0b63702)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/838/5af9608...youennf:0b63702.html" title="Last updated on Dec 9, 2021, 2:34 PM UTC (0b63702)">Diff</a>