### PR TITLE
Check for permission policy synchronously when getUserMedia is called

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3491,11 +3491,26 @@ interface InputDeviceInfo : MediaDeviceInfo {
                   succeed.</p>
                 </li>
                 <li>
-                  <p>If the [=relevant settings object=]'s
-                  [=environment settings object/responsible document=] is NOT
+                  <p>Let <var>document</var> be the [=relevant settings object=]'s
+                  [=environment settings object/responsible document=].</p>
+                </li>
+                <li>
+                  <p>If <var>document</var> is NOT
                   [=Document/fully active=], return a promise <a>rejected</a>
                   with a {{DOMException}} object whose {{DOMException/name}}
                   attribute has the value {{"InvalidStateError"}}.</p>
+                </li>
+                <li>
+                  <p>If <var>requestedMediaTypes</var> contains "audio" and
+                    <var>document</var> is not [=allowed to use=] the
+                    feature identified by the "microphone" permission name,
+                    jump to the step labeled <em>Permission Failure</em> below.</p>
+                </li>
+                <li>
+                  <p>If <var>requestedMediaTypes</var> contains "video" and
+                    <var>document</var> is not [=allowed to use=] the
+                    feature identified by the "camera" permission name,
+                    jump to the step labeled <em>Permission Failure</em> below.</p>
                 </li>
                 <li>
                   <p>Let <var>p</var> be a new promise.</p>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/847


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/851.html" title="Last updated on Jan 10, 2022, 11:10 AM UTC (263d037)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/851/961f7e6...youennf:263d037.html" title="Last updated on Jan 10, 2022, 11:10 AM UTC (263d037)">Diff</a>