### PR TITLE
Explicitly copy readyState when cloning a track

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -703,6 +703,10 @@ interface MediaStream : EventTarget {
           </p>
         </li>
         <li>
+          <p>Set <var>trackClone</var>'s {{MediaStreamTrack/[[ReadyState]]}} to
+            <var>track</var>'s {{MediaStreamTrack/[[ReadyState]]}} value.</p>
+        </li>
+        <li>
           <p>Set <var>trackClone</var>'s
           <a data-link-for="constrainable object"
              data-link-type="attribute">[[\Capabilities]]</a> to a clone of


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/852


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/853.html" title="Last updated on Jan 14, 2022, 2:52 PM UTC (75a7d21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/853/961f7e6...youennf:75a7d21.html" title="Last updated on Jan 14, 2022, 2:52 PM UTC (75a7d21)">Diff</a>