### PR TITLE
Replace usage of "responsible document"

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -768,7 +768,7 @@ interface MediaStream : EventTarget {
         device as soon as any live track sourced by the device
         becomes both [= track/muted | unmuted =] and
         [= track/enabled =] again, provided that track's
-        [=relevant settings object=]'s [=environment settings object/responsible document=]
+        [=relevant settings object=]'s [=relevant global object=]'s [=associated `Document`=]
         <a data-cite="!HTML/#gains-focus">has focus</a> at that time. If the
         document does not <a data-cite="!HTML/#gains-focus">have focus</a> at that time,
         the UA SHOULD instead queue a task to <a data-lt=muted>mute</a> the
@@ -2728,7 +2728,7 @@ interface OverconstrainedError : DOMException {
           [=creating a list of device info objects=] for
           {{MediaDevices/[[storedDeviceList]]}} and the
           [=relevant settings object=]'s
-          [=environment settings object/responsible document=].</p>
+          [=relevant global object=]'s [=associated `Document`=].</p>
         </li>
         <li>
           <p>Let <var>deviceList</var> be the list of all media input and/or
@@ -2738,7 +2738,7 @@ interface OverconstrainedError : DOMException {
           <p>Let <var>newExposedDevices</var> be the result of
           [=creating a list of device info objects=] for
           <var>deviceList</var> and the [=relevant settings object=]'s
-          [=environment settings object/responsible document=].</p>
+          [=relevant global object=]'s [=associated `Document`=].</p>
         </li>
         <li>
           <p>If the {{MediaDeviceInfo}} objects in <var>newExposedDevices</var>
@@ -2823,7 +2823,7 @@ interface MediaDevices : EventTarget {
                     <li>
 
                       <p>Let <var>document</var> be the [=relevant settings object=]'s
-                      [=environment settings object/responsible document=].</p>
+                      [=relevant global object=]'s [=associated `Document`=].</p>
                     </li>
                     <li>
                       <p>The [=User Agent=] MUST wait to proceed to the next step until
@@ -2945,14 +2945,13 @@ interface MediaDevices : EventTarget {
               information across browsing sessions and origins via the availability
               of media capture devices, it adds to the
               fingerprinting surface exposed by the [=User Agent=].</p>
-              <p class="fingerprint">As long as the [=environment settings
-              object/responsible document=] did not capture, this method will
+              <p class="fingerprint">As long as the [=relevant settings object=]'s [=relevant global object=]'s [=associated `Document`=] did not capture, this method will
               limit exposure to two bits of information: whether there is a camera
               and whether there is a microphone. A [=User Agent=] may mitigate this by
               pretending the system has a camera and a microphone, for instance until the
-              [=environment settings object/responsible document=] calls
+              [=relevant global object=]'s [=associated `Document`=] calls
               {{MediaDevices/getUserMedia()}} with constraints deemed reasonable.</p>
-              <p class="fingerprint">After the [=environment settings object/responsible document=]
+              <p class="fingerprint">After the [=relevant global object=]'s [=associated `Document`=]
               started capture, it provides additional persistent
               cross-origin information via the list of all media capture devices,
               including their grouping and human readable labels associated
@@ -2970,7 +2969,7 @@ interface MediaDevices : EventTarget {
       <section>
         <h2>Access control model</h2>
         <p>The algorithm described above means that the access to media device
-        information depends on whether or not the [=environment settings object/responsible document=] did capture.</p>
+        information depends on whether or not the [=relevant global object=]'s [=associated `Document`=] did capture.</p>
         <p>For camera and microphone devices, if the browsing context did not capture
         (i.e. {{MediaDevices/getUserMedia()}} was not called or never resolved successfully), the
         {{MediaDeviceInfo}} object will contain a valid value for {{MediaDeviceInfo/kind}} but empty strings
@@ -3030,8 +3029,7 @@ interface MediaDevices : EventTarget {
             [=device information can be exposed=] is <code>true</code>.
           </li>
           <li>
-            <p>If the [=relevant settings object=]'s [=environment settings
-            object/responsible document=] is [=Document/fully active=] and
+            <p>If the [=relevant settings object=]'s [=relevant global object=]'s [=associated `Document`=] is [=Document/fully active=] and
             <a data-cite="!HTML/#gains-focus">has focus</a>, return
             <code>true</code>.</p>
           </li>
@@ -3061,7 +3059,7 @@ interface MediaDevices : EventTarget {
           <li>
             <p>If any of the local devices of kind "videoinput" are attached to a live
             {{MediaStreamTrack}} in the [=relevant settings object=]'s
-            [=environment settings object/responsible document=], return
+            [=relevant global object=]'s [=associated `Document`=], return
             <code>true</code>.</p>
           </li>
           <li>
@@ -3075,7 +3073,7 @@ interface MediaDevices : EventTarget {
           <li>
             <p>If any of the local devices of kind "audioinput" are attached to a live
             {{MediaStreamTrack}} in the [=relevant settings object=]'s
-            [=environment settings object/responsible document=], return
+            [=relevant global object=]'s [=associated `Document`=], return
             <code>true</code>.</p>
           </li>
           <li>
@@ -3483,7 +3481,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                 </li>
                 <li>
                   <p>Let <var>document</var> be the [=relevant settings object=]'s
-                  [=environment settings object/responsible document=].</p>
+                  [=relevant global object=]'s [=associated `Document`=].</p>
                 </li>
                 <li>
                   <p>If <var>document</var> is NOT
@@ -3512,7 +3510,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                     <li>
                       <p>The [=User Agent=] MUST wait to proceed to the next step until
                       the [=relevant settings object=]'s
-                      [=environment settings object/responsible document=] is
+                      [=relevant global object=]'s [=associated `Document`=] is
                       [=Document/fully active=] and
                       <a data-cite="!HTML/#gains-focus">has focus.</a></p>
                     </li>


### PR DESCRIPTION
close #871
Following model of https://github.com/w3c/mediacapture-screen-share/pull/210/files"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/pull/876.html" title="Last updated on Apr 25, 2022, 10:00 AM UTC (2ffc466)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/876/0490a4e...2ffc466.html" title="Last updated on Apr 25, 2022, 10:00 AM UTC (2ffc466)">Diff</a>