### PR TITLE
Add back Initialize the underlying source algorithm as it is needed for transferring a MediaStreamTrack

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -649,7 +649,7 @@ interface MediaStream : EventTarget {
       to <var>source</var>, run the following steps:</p>
       <ol>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/[[Source]]}} to
-          <var>dataHolder</var>.`[[Source]]`.</p></li>
+          <var>source</var>.</p></li>
         <li><p>Initialize <var>track</var>'s <a data-link-for="constrainable object"
             data-link-type="attribute">[[\Capabilities]]</a>,
           <a data-link-for="constrainable object"

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -645,6 +645,19 @@ interface MediaStream : EventTarget {
         </li>
         <li><p>Return <var>track</var>.</p></li>
       </ol>
+      <p>To <dfn data-export>initialize the underlying source</dfn> of <var>track</var>
+      to <var>source</var>, run the following steps:</p>
+      <ol>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/[[Source]]}} to
+          <var>dataHolder</var>.`[[Source]]`.</p></li>
+        <li><p>Initialize <var>track</var>'s <a data-link-for="constrainable object"
+            data-link-type="attribute">[[\Capabilities]]</a>,
+          <a data-link-for="constrainable object"
+             data-link-type="attribute">[[\Constraints]]</a>, and
+          <a data-link-for="constrainable object"
+             data-link-type="attribute">[[\Settings]]</a>, as
+          specified in the {{ConstrainablePattern}}.</p></li>
+      </ol>
       <p>To <dfn>tie track source to context</dfn> with <var>source</var>, run
       the following steps:
       <ol>


### PR DESCRIPTION
See error in https://w3c.github.io/mediacapture-extensions/.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/877.html" title="Last updated on Apr 7, 2022, 2:42 PM UTC (c9821c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/877/0490a4e...youennf:c9821c4.html" title="Last updated on Apr 7, 2022, 2:42 PM UTC (c9821c4)">Diff</a>