### PR TITLE
Reference relevant global object directly.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -781,7 +781,7 @@ interface MediaStream : EventTarget {
         device as soon as any live track sourced by the device
         becomes both [= track/muted | unmuted =] and
         [= track/enabled =] again, provided that track's
-        [=relevant settings object=]'s [=relevant global object=]'s [=associated `Document`=]
+        [=relevant global object=]'s [=associated `Document`=]
         <a data-cite="!HTML/#gains-focus">has focus</a> at that time. If the
         document does not <a data-cite="!HTML/#gains-focus">have focus</a> at that time,
         the UA SHOULD instead queue a task to <a data-lt=muted>mute</a> the
@@ -2740,7 +2740,6 @@ interface OverconstrainedError : DOMException {
           <p>Let <var>lastExposedDevices</var> be the result of
           [=creating a list of device info objects=] for
           {{MediaDevices/[[storedDeviceList]]}} and the
-          [=relevant settings object=]'s
           [=relevant global object=]'s [=associated `Document`=].</p>
         </li>
         <li>
@@ -2750,8 +2749,8 @@ interface OverconstrainedError : DOMException {
         <li>
           <p>Let <var>newExposedDevices</var> be the result of
           [=creating a list of device info objects=] for
-          <var>deviceList</var> and the [=relevant settings object=]'s
-          [=relevant global object=]'s [=associated `Document`=].</p>
+          <var>deviceList</var> and the [=relevant global object=]'s
+          [=associated `Document`=].</p>
         </li>
         <li>
           <p>If the {{MediaDeviceInfo}} objects in <var>newExposedDevices</var>
@@ -2835,8 +2834,8 @@ interface MediaDevices : EventTarget {
                   <ol>
                     <li>
 
-                      <p>Let <var>document</var> be the [=relevant settings object=]'s
-                      [=relevant global object=]'s [=associated `Document`=].</p>
+                      <p>Let <var>document</var> be the [=relevant global object=]'s
+                      [=associated `Document`=].</p>
                     </li>
                     <li>
                       <p>The [=User Agent=] MUST wait to proceed to the next step until
@@ -2958,7 +2957,8 @@ interface MediaDevices : EventTarget {
               information across browsing sessions and origins via the availability
               of media capture devices, it adds to the
               fingerprinting surface exposed by the [=User Agent=].</p>
-              <p class="fingerprint">As long as the [=relevant settings object=]'s [=relevant global object=]'s [=associated `Document`=] did not capture, this method will
+              <p class="fingerprint">As long as the [=relevant global object=]'s
+              [=associated `Document`=] did not capture, this method will
               limit exposure to two bits of information: whether there is a camera
               and whether there is a microphone. A [=User Agent=] may mitigate this by
               pretending the system has a camera and a microphone, for instance until the
@@ -3042,7 +3042,8 @@ interface MediaDevices : EventTarget {
             [=device information can be exposed=] is <code>true</code>.
           </li>
           <li>
-            <p>If the [=relevant settings object=]'s [=relevant global object=]'s [=associated `Document`=] is [=Document/fully active=] and
+            <p>If the [=relevant global object=]'s [=associated `Document`=] is
+            [=Document/fully active=] and
             <a data-cite="!HTML/#gains-focus">has focus</a>, return
             <code>true</code>.</p>
           </li>
@@ -3071,9 +3072,8 @@ interface MediaDevices : EventTarget {
         <ol>
           <li>
             <p>If any of the local devices of kind "videoinput" are attached to a live
-            {{MediaStreamTrack}} in the [=relevant settings object=]'s
-            [=relevant global object=]'s [=associated `Document`=], return
-            <code>true</code>.</p>
+            {{MediaStreamTrack}} in the [=relevant global object=]'s
+            [=associated `Document`=], return <code>true</code>.</p>
           </li>
           <li>
             <p>Return {{MediaDevices/[[canExposeCameraInfo]]}}.</p>
@@ -3085,9 +3085,8 @@ interface MediaDevices : EventTarget {
         <ol>
           <li>
             <p>If any of the local devices of kind "audioinput" are attached to a live
-            {{MediaStreamTrack}} in the [=relevant settings object=]'s
-            [=relevant global object=]'s [=associated `Document`=], return
-            <code>true</code>.</p>
+            {{MediaStreamTrack}} in the [=relevant global object=]'s
+            [=associated `Document`=], return <code>true</code>.</p>
           </li>
           <li>
             <p>Return {{MediaDevices/[[canExposeMicrophoneInfo]]}}.</p>
@@ -3493,8 +3492,8 @@ interface InputDeviceInfo : MediaDeviceInfo {
                   succeed.</p>
                 </li>
                 <li>
-                  <p>Let <var>document</var> be the [=relevant settings object=]'s
-                  [=relevant global object=]'s [=associated `Document`=].</p>
+                  <p>Let <var>document</var> be the [=relevant global object=]'s
+                  [=associated `Document`=].</p>
                 </li>
                 <li>
                   <p>If <var>document</var> is NOT
@@ -3522,8 +3521,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                   <ol>
                     <li>
                       <p>The [=User Agent=] MUST wait to proceed to the next step until
-                      the [=relevant settings object=]'s
-                      [=relevant global object=]'s [=associated `Document`=] is
+                      the [=relevant global object=]'s [=associated `Document`=] is
                       [=Document/fully active=] and
                       <a data-cite="!HTML/#gains-focus">has focus.</a></p>
                     </li>


### PR DESCRIPTION
Follow-up to https://github.com/w3c/mediacapture-main/pull/876 — a platform object's [relevant global object](https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global) can be referenced directly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/880.html" title="Last updated on May 3, 2022, 10:03 PM UTC (3f82c08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/880/09ee520...jan-ivar:3f82c08.html" title="Last updated on May 3, 2022, 10:03 PM UTC (3f82c08)">Diff</a>