### PR TITLE
Add an algorithm to determine whether a document is capturing or not.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3151,6 +3151,32 @@ interface MediaDevices : EventTarget {
         <p>By default, it returns <code>false</code>.</p>
         <p>Other specifications can define the algorithm for specific device types.
       </section>
+      <section>
+        <h2>Context capturing state</h2>
+        <p>To perform a <dfn data-export id="context-is-capturing">context is capturing</dfn> check
+        for <var>context</var>, run the following steps:</p>
+        <ol>
+          <li>
+           <p>For each <var>source</var> in <var>context</var>'s {{MediaDevices/[[mediaStreamTrackSources]]}},
+           run the following sub steps:</p>
+           <ol>
+             <li>
+               <p>If <var>source</var> is [=source/stopped=] or [=muted=], abort these steps.</p>
+             </li>
+             <li>
+               <p>Let <var>deviceId</var> be <var>source</var>'s device's deviceId.</p>
+             </li>
+             <li>
+               <p>If <var>context</var>'s {{MediaDevices/[[devicesLiveMap]]}}[<var>deviceId</var>] is
+               <code>true</code>, return <code>true</code>.</p>
+             </li>
+           </ol>
+         </li>
+         <li>
+           <p>Return <code>false</code>.</p>
+         </li>
+        </ol>
+      </section>
     </section>
     <section>
       <h2>Device Info</h2>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3176,6 +3176,7 @@ interface MediaDevices : EventTarget {
            <p>Return <code>false</code>.</p>
          </li>
         </ol>
+        <p class="note">This algorithm covers all capture tracks, including microphone, camera and display.</p>
       </section>
     </section>
     <section>


### PR DESCRIPTION
A document is said to be capturing if one of its track source is a capture source and is live.
A capture source is created either by getUserMedia or getDisplayMedia.

Fixes https://github.com/w3c/mediacapture-main/issues/887


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/890.html" title="Last updated on Aug 18, 2022, 2:50 PM UTC (e86e63f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/890/7b093a3...youennf:e86e63f.html" title="Last updated on Aug 18, 2022, 2:50 PM UTC (e86e63f)">Diff</a>