### PR TITLE
Update enumerateDevices algorithm to make use of device-kind specific exposure checks when building cameraList and microphoneList.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2933,16 +2933,12 @@ interface MediaDevices : EventTarget {
                   </ol>
                 </li>
                 <li>
-                  <p>If [=device information can be exposed=] is <code>false</code>,
-                  run the following sub steps:<p>
-                  <ol>
-                    <li>
-                      <p>If <var>microphoneList</var> is not empty, truncate <var>microphoneList</var> to its first item.</p>
-                    </li>
-                    <li>
-                      <p>If <var>cameraList</var> is not empty, truncate <var>cameraList</var> to its first item.</p>
-                    </li>
-                  </ol>
+                  <p>If [=microphone information can be exposed=] is <code>false</code>,
+                    truncate <var>microphoneList</var> to its first item.</p>
+                </li>
+                <li>
+                  <p>If [=camera information can be exposed=] is <code>false</code>,
+                    truncate <var>cameraList</var> to its first item.</p>
                 </li>
                 <li>
                   <p>Run the following sub steps for each discovered device in <var>deviceList</var>, <var>device</var>:</p>


### PR DESCRIPTION
This ensures we do not get dummy similar audioinput or camera devices if only camera or only microphone is used.

Fixes https://github.com/w3c/mediacapture-main/issues/898


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/900.html" title="Last updated on Oct 6, 2022, 2:30 PM UTC (a8699aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/900/e84ad3e...youennf:a8699aa.html" title="Last updated on Oct 6, 2022, 2:30 PM UTC (a8699aa)">Diff</a>