### PR TITLE
Add `SecureContext` attribute to `InputDeviceInfo`.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3323,7 +3323,7 @@ interface MediaDeviceInfo {
       capabilities of the input device it represents.</p>
       <div>
         <pre class="idl"
->[Exposed=Window]
+>[Exposed=Window, SecureContext]
 interface InputDeviceInfo : MediaDeviceInfo {
   MediaTrackCapabilities getCapabilities();
 };</pre>


### PR DESCRIPTION
Per [the WebIDL spec](https://webidl.spec.whatwg.org/#SecureContext), "An interface without the [SecureContext] extended attribute must not inherit from another interface that does specify [SecureContext]." Since `MediaDeviceInfo` has the `SecureContext` attribute, so must `InputDeviceInfo`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dogben/mediacapture-main/pull/901.html" title="Last updated on Sep 22, 2022, 2:09 PM UTC (68cdfeb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/901/e84ad3e...dogben:68cdfeb.html" title="Last updated on Sep 22, 2022, 2:09 PM UTC (68cdfeb)">Diff</a>