### PR TITLE
Clarify that frameRate as a setting is the configured value, not a measurement.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1774,7 +1774,7 @@ interface MediaStreamTrack : EventTarget {
             <tr id="def-constraint-frameRate">
               <td><dfn>frameRate</dfn></td>
               <td>{{ConstrainDouble}}</td>
-              <td>The exact frame rate (frames per second) or frame rate range.
+              <td><p>The exact frame rate (frames per second) or frame rate range.
               If video source's pre-set can determine frame rate values, the range, as a capacity,
               should span the video source's pre-set frame rate values with
               min being equal to 0 and max being the largest frame rate.
@@ -1783,7 +1783,14 @@ interface MediaStreamTrack : EventTarget {
               If this frame rate cannot be determined (e.g. the source does not
               natively provide a frame rate, or the frame rate cannot be
               determined from the source stream), then this value MUST refer to
-              the [=User Agent=]'s vsync display rate.</td>
+              the [=User Agent=]'s vsync display rate.</p>
+              <p>As a setting, this value represents the configured frame rate.
+              If decimation is used, this is that value rather than the native
+              frame rate. For example, if the setting is 25 frames per second
+              via decimation, the native frame rate of the camera is 30 frames
+              per second but due to lighting conditions only 20 frames per
+              second is achieved, {{frameRate}} reports the setting: 25 frames
+              per second.</p></td>
             </tr>
             <tr id="def-constraint-aspect">
               <td><dfn>aspectRatio</dfn></td>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1774,7 +1774,7 @@ interface MediaStreamTrack : EventTarget {
             <tr id="def-constraint-frameRate">
               <td><dfn>frameRate</dfn></td>
               <td>{{ConstrainDouble}}</td>
-              <td><p>The exact frame rate (frames per second) or frame rate range.
+              <td><p>The frame rate (frames per second) or frame rate range.
               If video source's pre-set can determine frame rate values, the range, as a capacity,
               should span the video source's pre-set frame rate values with
               min being equal to 0 and max being the largest frame rate.


### PR DESCRIPTION
Fixes #906.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mediacapture-main/pull/908.html" title="Last updated on Oct 12, 2022, 10:44 AM UTC (435f338)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/908/e83b870...henbos:435f338.html" title="Last updated on Oct 12, 2022, 10:44 AM UTC (435f338)">Diff</a>