### PR TITLE
Allow gUM prompt ahead of focus + deterministic "visible" enumeration wo/focus

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2876,7 +2876,7 @@ interface MediaDevices : EventTarget {
                   <p>Run the following steps in parallel:</p>
                   <ol>
                     <li>
-                      <p>If <var>proceed</var> is `false`, the [=User Agent=]
+                      <p>While <var>proceed</var> is `false`, the [=User Agent=]
                       MUST wait to proceed to the next step until a task queued
                       to set <var>proceed</var> to the result of
                       [=device enumeration can proceed=], sets
@@ -3487,7 +3487,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
                   <p>Run the following steps in parallel:</p>
                   <ol>
                     <li>
-                      <p>If <var>inForeground</var> is `false`, the [=User Agent=]
+                      <p>While <var>inForeground</var> is `false`, the [=User Agent=]
                       MUST wait to proceed to the next step until a task queued
                       to set <var>inForeground</var> to the result of the
                       [=in the foreground=]</a> algorithm, sets

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3142,7 +3142,7 @@ interface MediaDevices : EventTarget {
         steps:</p>
         <ol>
           <li>
-            <p>If the [=relevant global object=]'s [=associated `Document`=]'s
+            <p>If the [=relevant global object=]'s [=browsing context=]'s
             [=top-level browsing context=] has
             <a data-cite="!HTML/#tlbc-system-focus">system focus</a>, return
             `true`. Otherwise, return `false`.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3616,9 +3616,9 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           MUST disclose whether permission will be granted only to
                           the device chosen, or to all devices of that
                           <var>kind</var>.</p>
-                        </li>
-                        <li>
-                          <p>If the user never responds, this algorithm stalls on this step.</p>
+                          <div class="note">
+                            <p>If the user never responds, this algorithm stalls on this step.</p>
+                          </div>
                         </li>
                         <li>
                           <p>If the result of the request is {{PermissionState/"denied"}},

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3230,7 +3230,7 @@ interface MediaDeviceInfo {
               uniquely identified by its identifier and its {{MediaDeviceInfo/kind}}.</p>
               <p>To to ensure stored identifiers are recognized, the identifier
               MUST be the same in documents of the same origin in [=top-level browsing contexts=].
-              In [=nested browsing contexts=],
+              In [=child navigables=],
               the decision of whether or not the identifier is the same across
               documents, MUST follow the [=User Agent=]'s partitioning rules for
               storage (such as {{WindowLocalStorage/localStorage}}), if any,

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3129,6 +3129,15 @@ interface MediaDevices : EventTarget {
             <p>Return {{MediaDevices/[[canExposeMicrophoneInfo]]}}.</p>
           </li>
         </ol>
+        <p>To perform an <dfn>is in view</dfn> check, run the following
+        steps:</p>
+        <ol>
+          <li>
+            <p>If the [=relevant global object=]'s [=associated `Document`=] is
+            [=Document/fully active=] and its [=Document/visibility state=]
+            is `"visible"`, return `true`. Otherwise, return `false`.</p>
+          </li>
+        </ol>
       </section>
       <section>
         <h2>Set device information exposure</h2>
@@ -3474,11 +3483,8 @@ interface InputDeviceInfo : MediaDeviceInfo {
                     jump to the step labeled <em>Permission Failure</em> below.</p>
                 </li>
                 <li>
-                  <p>Let <var>inForeground</var> be the result of the following
-                  <dfn>in the foreground</dfn> algorithm, which returns `true` if
-                  the [=relevant global object=]'s [=associated `Document`=] is
-                  [=Document/fully active=] and its [=Document/visibility state=]
-                  is `"visible"`.</p>
+                  <p>Let <var>isInView</var> be the result of the
+                  <a>is in view</a> algorithm.</p>
                 </li>
                 <li>
                   <p>Let <var>p</var> be a new promise.</p>
@@ -3487,11 +3493,11 @@ interface InputDeviceInfo : MediaDeviceInfo {
                   <p>Run the following steps in parallel:</p>
                   <ol>
                     <li>
-                      <p>While <var>inForeground</var> is `false`, the [=User Agent=]
+                      <p>While <var>isInView</var> is `false`, the [=User Agent=]
                       MUST wait to proceed to the next step until a task queued
-                      to set <var>inForeground</var> to the result of the
-                      [=in the foreground=]</a> algorithm, sets
-                      <var>inForeground</var> to `true`.</p>
+                      to set <var>isInView</var> to the result of the
+                      [=is in view=]</a> algorithm, would set
+                      <var>isInView</var> to `true`.</p>
                     </li>
                     <li>
                       <p>Let <var>finalSet</var> be an (initially) empty
@@ -4118,10 +4124,10 @@ interface InputDeviceInfo : MediaDeviceInfo {
             continuing capture in situations that may surprise users.</p>
           </li>
           <li>
-            <p>A web page not [=in the foreground=]
+            <p>A web page not [=is in view|in view=]
             <a data-lt=enabled>re-enables</a> a track when all tracks from that
             source are <a data-lt=enabled>disabled</a>, in order to delay
-            resumption of capture until the page is [=in the foreground=].
+            resumption of capture until the page [=is in view=].
             </p>
           </li>
         </ul>
@@ -4137,7 +4143,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
             user's awareness of the earlier capture session.</p>
           </li>
           <li>
-            <p>A web page comes [=in the foreground|into the foreground=] and
+            <p>A web page comes [=is in view|into view=] and
             has one or more <a data-lt=enabled>enabled</a> tracks that are also
             [= muted =].
             </p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2865,16 +2865,22 @@ interface MediaDevices : EventTarget {
                   <p>Let <var>p</var> be a new promise.</p>
                 </li>
                 <li>
+                  <p>Let <var>proceed</var> be the result of
+                  [=device enumeration can proceed=].</p>
+                </li>
+                <li>
+                  <p>Let <var>document</var> be the [=relevant global object=]'s
+                  [=associated `Document`=].</p>
+                </li>
+                <li>
                   <p>Run the following steps in parallel:</p>
                   <ol>
                     <li>
-
-                      <p>Let <var>document</var> be the [=relevant global object=]'s
-                      [=associated `Document`=].</p>
-                    </li>
-                    <li>
-                      <p>The [=User Agent=] MUST wait to proceed to the next step until
-                      [=device enumeration can proceed=] is <code>true</code>.</p>
+                      <p>If <var>proceed</var> is `false`, the [=User Agent=]
+                      MUST wait to proceed to the next step until a task queued
+                      to set <var>proceed</var> to the result of
+                      [=device enumeration can proceed=], sets
+                      <var>proceed</var> to `true`.</p>
                     </li>
                     <li>
                       <p>Let <var>resultList</var> be the result of
@@ -3468,16 +3474,24 @@ interface InputDeviceInfo : MediaDeviceInfo {
                     jump to the step labeled <em>Permission Failure</em> below.</p>
                 </li>
                 <li>
+                  <p>Let <var>inForeground</var> be the result of the following
+                  <dfn>in the foreground</dfn> algorithm, which returns `true` if
+                  the [=relevant global object=]'s [=associated `Document`=] is
+                  [=Document/fully active=] and its [=Document/visibility state=]
+                  is `"visible"`.</p>
+                </li>
+                <li>
                   <p>Let <var>p</var> be a new promise.</p>
                 </li>
                 <li>
                   <p>Run the following steps in parallel:</p>
                   <ol>
                     <li>
-                      <p>The [=User Agent=] MUST wait to proceed to the next step until
-                      the [=relevant global object=]'s [=associated `Document`=] is
-                      [=Document/fully active=] and
-                      <a data-cite="!HTML/#gains-focus">has focus.</a></p>
+                      <p>If <var>inForeground</var> is `false`, the [=User Agent=]
+                      MUST wait to proceed to the next step until a task queued
+                      to set <var>inForeground</var> to the result of the
+                      [=in the foreground=]</a> algorithm, sets
+                      <var>inForeground</var> to `true`.</p>
                     </li>
                     <li>
                       <p>Let <var>finalSet</var> be an (initially) empty
@@ -3596,6 +3610,16 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           MUST disclose whether permission will be granted only to
                           the device chosen, or to all devices of that
                           <var>kind</var>.</p>
+                        </li>
+                        <li>
+                          <p>The [=User Agent=] MUST wait to proceed to the next
+                          step until a task queued to set <var>systemFocus</var>
+                          to `true` if the [=top-level browsing context=] has
+                          <a data-cite="!HTML/#tlbc-system-focus">system focus</a>,
+                          or `false` otherwise, sets <var>systemFocus</var> to
+                          `true`.</p>
+                        </li>
+                        <li>
                           <p>Let <var>finalCandidate</var> be the provided media, which
                           MUST be precisely one <a>candidate</a> of type <var>kind</var> from
                           <var>finalSet</var>. The decision of which candidate to
@@ -4094,11 +4118,10 @@ interface InputDeviceInfo : MediaDeviceInfo {
             continuing capture in situations that may surprise users.</p>
           </li>
           <li>
-            <p>A web page <a data-cite="!HTML/#gains-focus">without focus</a>
+            <p>A web page not [=in the foreground=]
             <a data-lt=enabled>re-enables</a> a track when all tracks from that
             source are <a data-lt=enabled>disabled</a>, in order to delay
-            resumption of capture until the page
-            <a data-cite="!HTML/#gains-focus">gains focus</a>.
+            resumption of capture until the page is [=in the foreground=].
             </p>
           </li>
         </ul>
@@ -4114,7 +4137,7 @@ interface InputDeviceInfo : MediaDeviceInfo {
             user's awareness of the earlier capture session.</p>
           </li>
           <li>
-            <p>A web page <a data-cite="!HTML/#gains-focus">gains focus</a> and
+            <p>A web page comes [=in the foreground|into the foreground=] and
             has one or more <a data-lt=enabled>enabled</a> tracks that are also
             [= muted =].
             </p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2879,7 +2879,7 @@ interface MediaDevices : EventTarget {
                       <p>While <var>proceed</var> is `false`, the [=User Agent=]
                       MUST wait to proceed to the next step until a task queued
                       to set <var>proceed</var> to the result of
-                      [=device enumeration can proceed=], sets
+                      [=device enumeration can proceed=], would set
                       <var>proceed</var> to `true`.</p>
                     </li>
                     <li>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3612,6 +3612,13 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           <var>kind</var>.</p>
                         </li>
                         <li>
+                          <p>If the user never responds, this algorithm stalls on this step.</p>
+                        </li>
+                        <li>
+                          <p>If the result of the request is {{PermissionState/"denied"}},
+                          jump to the step labeled <em>Permission Failure</em> below.</p>
+                        </li>
+                        <li>
                           <p>The [=User Agent=] MUST wait to proceed to the next
                           step until a task queued to set <var>systemFocus</var>
                           to `true` if the [=top-level browsing context=] has
@@ -3636,13 +3643,6 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           (when possible). [=User Agents=]
                           MAY allow users to use any media source, including
                           pre-recorded media files.</p>
-                        </li>
-                        <li>
-                          <p>If the user never responds, this algorithm stalls on this step.</p>
-                        </li>
-                        <li>
-                          <p>If the result of the request is {{PermissionState/"denied"}},
-                          jump to the step labeled <em>Permission Failure</em> below.</p>
                         </li>
                         <li>
                           <p>The result of the request is {{PermissionState/"granted"}}.

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3138,6 +3138,16 @@ interface MediaDevices : EventTarget {
             is `"visible"`, return `true`. Otherwise, return `false`.</p>
           </li>
         </ol>
+        <p>To perform a <dfn>has system focus</dfn> check, run the following
+        steps:</p>
+        <ol>
+          <li>
+            <p>If the [=relevant global object=]'s [=associated `Document`=]'s
+            [=top-level browsing context=] has
+            <a data-cite="!HTML/#tlbc-system-focus">system focus</a>, return
+            `true`. Otherwise, return `false`.</p>
+          </li>
+        </ol>
       </section>
       <section>
         <h2>Set device information exposure</h2>
@@ -3625,11 +3635,14 @@ interface InputDeviceInfo : MediaDeviceInfo {
                           jump to the step labeled <em>Permission Failure</em> below.</p>
                         </li>
                         <li>
-                          <p>The [=User Agent=] MUST wait to proceed to the next
-                          step until a task queued to set <var>systemFocus</var>
-                          to `true` if the [=top-level browsing context=] has
-                          <a data-cite="!HTML/#tlbc-system-focus">system focus</a>,
-                          or `false` otherwise, sets <var>systemFocus</var> to
+                          <p>Let <var>hasSystemFocus</var> be `false`.</p>
+                        </li>
+                        <li>
+                          <p>While <var>hasSystemFocus</var> is `false`, the
+                          [=User Agent=] MUST wait to proceed to the next step
+                          until a task queued to set <var>hasSystemFocus</var>
+                          to the result of the [=has system focus=]</a>
+                          algorithm, would set <var>hasSystemFocus</var> to
                           `true`.</p>
                         </li>
                         <li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/752:
1. Relax document (iframe) focus to tlbc [system focus](https://html.spec.whatwg.org/multipage/interaction.html#tlbc-system-focus) (a step in the right direction)
2. Allow Safari prompts in foreground tabs, while maintaining focus requirement on allow, per https://github.com/w3c/mediacapture-main/issues/752#issuecomment-921352150
3. Remove focus requirement on enumerateDevices, per https://github.com/w3c/mediacapture-main/issues/752#issuecomment-1293797299
4. Fix race spotted in https://github.com/w3c/mediacapture-main/issues/905#issuecomment-1293812378 which prevented deterministic visibility-success checks:
   ```js
   if (document.visibilityState == "visible") {
     await navigator.mediaDevices.enumerateDevices(); // won't block on hidden thanks to if
   }
   ```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/912.html" title="Last updated on Dec 15, 2022, 8:02 PM UTC (944b94f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/912/8248a8c...jan-ivar:944b94f.html" title="Last updated on Dec 15, 2022, 8:02 PM UTC (944b94f)">Diff</a>