### PR TITLE
Fix invalid capability in Example 12.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -5101,7 +5101,7 @@ async function getFrontCameraRes() {
 {
   width: {min: 640, max: 800},
   height: {min: 480, max: 600},
-  aspectRatio: 4/3
+  aspectRatio: {min: 4/3, max: 4/3}
 }
       </pre>
       <p>Note in the example above that the aspectRatio would make clear that


### PR DESCRIPTION
[aspectRatio](https://w3c.github.io/mediacapture-main/#dom-mediatrackcapabilities-aspectratio) has been a [DoubleRange](https://w3c.github.io/mediacapture-main/#dom-doublerange) since https://github.com/w3c/mediacapture-main/issues/408.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/916.html" title="Last updated on Nov 4, 2022, 2:32 PM UTC (04e33bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/916/8248a8c...jan-ivar:04e33bd.html" title="Last updated on Nov 4, 2022, 2:32 PM UTC (04e33bd)">Diff</a>