### PR TITLE
Fix default allowlist link that broke.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -5462,7 +5462,8 @@ window.onload = async () =&gt; {
     <h1 id=permissions-policy-integration>Permissions Policy Integration</h1>
     <p>This specification defines two [=policy-controlled features=]
     identified by the strings <a>"camera"</a> and <a>"microphone"</a>.
-    Both have a [=default allowlist=] of <code class=permissionspolicy>"self"</code>.
+    Both have a [=policy-controlled feature/default allowlist=] of
+    <code class=permissionspolicy>"self"</code>.
     <div class="note">
       <p>A [=document=]'s [=Document/permissions policy=]
       determines whether any content in that document is allowed to use


### PR DESCRIPTION
Fixes respec error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/925.html" title="Last updated on Jan 12, 2023, 5:53 PM UTC (52fbe71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/925/9a249e7...jan-ivar:52fbe71.html" title="Last updated on Jan 12, 2023, 5:53 PM UTC (52fbe71)">Diff</a>