### PR TITLE
Remove focus from mute/unmute SHOULD prose to match #912 best practice.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -801,11 +801,11 @@ interface MediaStream : EventTarget {
         becomes both [= track/muted | unmuted =] and
         [= track/enabled =] again, provided that track's
         [=relevant global object=]'s [=associated `Document`=]
-        <a data-cite="!HTML/#gains-focus">has focus</a> at that time. If the
-        document does not <a data-cite="!HTML/#gains-focus">have focus</a> at that time,
+        [=is in view=] at that time. If the
+        document is not [=is in view|in view=] at that time,
         the UA SHOULD instead queue a task to <a data-lt=muted>mute</a> the
         track, and not queue a task to <a data-lt=muted>unmute</a> it until
-        the document <a data-cite="!HTML/#gains-focus">regains focus</a>.
+        the document comes [=is in view|into view=].
         If reacquiring the device fails, the UA MUST
         [= track ended by the User agent | end the track =] (The UA MAY end it earlier
         should it detect a device problem, like the device being physically


### PR DESCRIPTION
Some house cleaning after #912.

#912 removed the focus requirement from _[Best Practice 5: Device muting initiated by User Agent](https://w3c.github.io/mediacapture-main/getusermedia.html#muting-devices)_, but forgot to do the same for the normative SHOULD language. This PR addresses that.