### PR TITLE
Allow upscaling to conceal concurrent use.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1807,7 +1807,7 @@ interface MediaStreamTrack : EventTarget {
                 the UA. In other words, whether the UA is allowed to use
                 cropping and downscaling on the camera output.
                 <p class="fingerprint">The UA MAY disguise concurrent use of
-                the camera, by cropping and/or downscaling to mimic native
+                the camera, by downscaling, upscaling, and/or cropping to mimic native
                 resolutions when "none" is used, but only when the camera is in
                 use in another [=navigable=].</p>Note that
                 <code><a data-link-for=

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1809,7 +1809,7 @@ interface MediaStreamTrack : EventTarget {
                 <p class="fingerprint">The UA MAY disguise concurrent use of
                 the camera, by downscaling, upscaling, and/or cropping to mimic native
                 resolutions when "none" is used, but only when the camera is in
-                use in another [=navigable=].</p>Note that
+                use in another application outside the User Agent.</p>Note that
                 <code><a data-link-for=
                 "ConstrainablePattern">getConstraints</a></code> may not return
                 exactly the same string for strings not in this enum. This
@@ -1928,7 +1928,7 @@ interface MediaStreamTrack : EventTarget {
                   occur in the input source, except as noted below.</p>
                   <p class="fingerprint">Note: The UA MAY upscale to
                   disguise concurrent use, but only when the camera is in use
-                  in another [=navigable=].</p>
+                  in another application outside the User Agent.</p>
                 </td>
               </tr>
             </tbody>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1809,7 +1809,7 @@ interface MediaStreamTrack : EventTarget {
                 <p class="fingerprint">The UA MAY disguise concurrent use of
                 the camera, by downscaling, upscaling, and/or cropping to mimic native
                 resolutions when "none" is used, but only when the camera is in
-                use in another application outside the User Agent.</p>Note that
+                use in another application outside the [=User Agent=].</p>Note that
                 <code><a data-link-for=
                 "ConstrainablePattern">getConstraints</a></code> may not return
                 exactly the same string for strings not in this enum. This
@@ -1928,7 +1928,7 @@ interface MediaStreamTrack : EventTarget {
                   occur in the input source, except as noted below.</p>
                   <p class="fingerprint">Note: The UA MAY upscale to
                   disguise concurrent use, but only when the camera is in use
-                  in another application outside the User Agent.</p>
+                  in another application outside the [=User Agent=].</p>
                 </td>
               </tr>
             </tbody>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1925,7 +1925,10 @@ interface MediaStreamTrack : EventTarget {
                   camera resolution by the [=User Agent=], or its frame rate is
                   decimated by the [=User Agent=]. The media MUST NOT be
                   upscaled, stretched or have fake data created that did not
-                  occur in the input source.</p>
+                  occur in the input source, except as noted below.</p>
+                  <p class="fingerprint">Note: The UA MAY upscale to
+                  disguise concurrent use, but only when the camera is in use
+                  in another [=navigable=].</p>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/584.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/971.html" title="Last updated on Sep 21, 2023, 6:07 PM UTC (eb4e0c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/971/6f3e93f...jan-ivar:eb4e0c8.html" title="Last updated on Sep 21, 2023, 6:07 PM UTC (eb4e0c8)">Diff</a>