### PR TITLE
Add class="informative" to "Legacy GetUserMedia interface" section

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3906,10 +3906,9 @@ interface InputDeviceInfo : MediaDeviceInfo {
         </section>
       </div>
     </section>
-    <section>
+    <section class="informative">
       <h3>Legacy GetUserMedia interface</h3>
       <div class="note">
-        <p>This section is non-normative.</p>
         <p>
         The definition of getUserMedia() in this section reflects the call format
         that was originally proposed; it is only documented here for browsers that


### PR DESCRIPTION
This will prevent the WebIDL being extracted by reffy (and other tools) as part of the normative definition of the spec.

This will remove the (incorrect) subtests of https://wpt.fyi/results/mediacapture-streams/idlharness.https.window.html?run_id=5194214102532096&run_id=5194810834550784&run_id=5176276909817856 (e.g., `Navigator interface: operation getUserMedia(MediaStreamConstraints, NavigatorUserMediaSuccessCallback, NavigatorUserMediaErrorCallback)`), because these are not normatively part of the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gsnedders/mediacapture-main/pull/990.html" title="Last updated on Mar 4, 2024, 6:57 PM UTC (1960c81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/990/da36d40...gsnedders:1960c81.html" title="Last updated on Mar 4, 2024, 6:57 PM UTC (1960c81)">Diff</a>