### PR TITLE
Fix DeviceChangeEventInit WebIDL definition

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3471,7 +3471,7 @@ interface DeviceChangeEvent : Event {
       <div>
         <pre class="idl"
 >dictionary DeviceChangeEventInit : EventInit {
-  sequence&lt;MediaStream&gt; streams = [];
+  sequence&lt;MediaDeviceInfo&gt; devices = [];
 };</pre>
         <section>
           <h2>Dictionary <dfn>DeviceChangeEventInit</dfn> Members</h2>


### PR DESCRIPTION
This PR is intended to fix a tiny typo introduced here: https://github.com/w3c/mediacapture-main/pull/996/files#diff-1217ca1c44ff30a33dd50c49d03b5cadc9633c789df8ff9370ed4a42859e1211R3468-R3470.

I guess it would also resolve #999.