### PR TITLE
Define MediaStreamTrack.[[Restrictable]]

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -651,6 +651,9 @@ interface MediaStream : EventTarget {
                  data-link-type="attribute">[[\Settings]]</a>, all initialized as
               specified in the {{ConstrainablePattern}}.</p>
             </li>
+            <li>
+              <p><dfn class="export">[[\Restrictable]]</dfn>, initialized to <code>false</code>.</p>
+            </li>
           </ul>
         </li>
         <li>


### PR DESCRIPTION
Define `MediaStreamTrack.[[Restrictable]]`, an internal slot that allows [Element Capture](https://screen-share.github.io/element-capture/) to differentiate between tracks that are valid target to `restrictTo()` and those which are not.

A respective PR will be produced on the [getViewportMedia](https://w3c.github.io/mediacapture-viewport/) spec, setting `[[Restrictable]]` to `true`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/pull/1015.html" title="Last updated on Sep 26, 2024, 9:44 PM UTC (fe2fc77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1015/48b8708...fe2fc77.html" title="Last updated on Sep 26, 2024, 9:44 PM UTC (fe2fc77)">Diff</a>