### PR TITLE
Prevent remove-a-track to recurse.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -337,7 +337,7 @@
           <p>If <var>track</var> is not in <var>stream's</var> [=track set=], then abort these steps.</p>
         </li>
         <li>
-          <p>Remove <var>track</var> from <var>stream</var>'s [=track set=].</p>
+          <p>[=set/Remove=] <var>track</var> from <var>stream</var>'s [=track set=].</p>
         </li>
         <li>
           <p>[= Fire a track event =] named {{removetrack}} with

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -337,7 +337,7 @@
           <p>If <var>track</var> is not in <var>stream's</var> [=track set=], then abort these steps.</p>
         </li>
         <li>
-          <p>[=MediaStream/Remove a track|Remove=] <var>track</var> from <var>stream</var>'s [=track set=].</p>
+          <p>Remove <var>track</var> from <var>stream</var>'s [=track set=].</p>
         </li>
         <li>
           <p>[= Fire a track event =] named {{removetrack}} with


### PR DESCRIPTION
The remove-a-track algorithm currently uses a link to itself in its step 2, making it an endless loop.
Here we're not calling that algorithm again, we're just using the track set's remove method (from infra: https://infra.spec.whatwg.org/#list-remove).

(Ps: [editorial] and [non-substantive])


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 3, 2024, 8:10 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
Timed out after waiting 30000ms
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/mediacapture-main%231022.)._
</details>
