### PR TITLE
Missed a spot that should use HTMLMediaElement's potentially playing definition

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2419,7 +2419,7 @@ interface MediaStreamTrackEvent : Event {
           <td>{{double}}</td>
           <td>Any non-negative integer. The initial value is <code>0</code> and
           the values increments linearly in real time whenever the stream is
-          playing.</td>
+          <a data-cite="!HTML/#potentially-playing">potentially playing</a>.</td>
           <td>
             The value is the <a data-cite=
             "!HTML/#official-playback-position">

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2418,7 +2418,7 @@ interface MediaStreamTrackEvent : Event {
           </td>
           <td>{{double}}</td>
           <td>Any non-negative integer. The initial value is <code>0</code> and
-          the values increments linearly in real time whenever the stream is
+          the values increments linearly in real time whenever the element is
           <a data-cite="!HTML/#potentially-playing">potentially playing</a>.</td>
           <td>
             The value is the <a data-cite=

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -2419,7 +2419,7 @@ interface MediaStreamTrackEvent : Event {
           <td>{{double}}</td>
           <td>Any non-negative integer. The initial value is <code>0</code> and
           the values increments linearly in real time whenever the element is
-          <a data-cite="!HTML/#potentially-playing">potentially playing</a>.</td>
+          [=media element/potentially playing=].</td>
           <td>
             The value is the <a data-cite=
             "!HTML/#official-playback-position">


### PR DESCRIPTION
Fixes #1024.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/1025.html" title="Last updated on Dec 19, 2024, 3:41 PM UTC (83e2e36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1025/97bb70a...jan-ivar:83e2e36.html" title="Last updated on Dec 19, 2024, 3:41 PM UTC (83e2e36)">Diff</a>