### PR TITLE
Add guidelines for garbage collecting MediaStream and MediaStreamTrack objects

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -210,6 +210,7 @@
       the same source to have different constraints applied for different
       <a>consumer</a>s. The {{MediaStream}} object is also used in
       contexts outside {{MediaDevices/getUserMedia}}, such as [[?WEBRTC]].</p>
+      <p>A {{MediaStream}} object has a [[\CanFireEvent\]] slot initialized to <code>false</code> by default.</p>
     </section>
     <section>
       <h2>{{MediaStream}}</h2>
@@ -538,6 +539,14 @@ interface MediaStream : EventTarget {
               </ol>
             </dd>
           </dl>
+        </section>
+        <section>
+          <h2>Garbage Collection</h2>
+          <p>
+            A {{MediaStream}} object MUST not be garbage collected if its [[\CanFireEvent]]
+            slot is <code>true</code> and there are any event listeners registered for addtrack
+            events or removetrack events.
+          </p>
         </section>
       </div>
     </section>
@@ -2034,6 +2043,22 @@ interface MediaStreamTrack : EventTarget {
             </tr>
           </tbody>
         </table>
+      </section>
+      <section>
+        <h2>Garbage Collection</h2>
+        <p>
+          A {{MediaStreamTrack}} object MUST not be garbage collected if it is
+          not [= MediaStreamTrack/ended =] and there are any event listeners
+          registered for mute, unmute or ended events.
+          <!-- FIXME: add configurationchange event -->
+          Each source type can further refine the garbage collection rules as
+          sources may never fire a particular event.
+          <div class="note">
+             Authors are encouraged to call stop() on {{MediaStreamTrack}},
+             especially capture tracks since the underlying resource are costly
+             and it can have effects on the privacy indicators presented to the user.
+          </div>
+        </p>
       </section>
     </section>
     <section>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -542,10 +542,11 @@ interface MediaStream : EventTarget {
         <section>
           <h2>Garbage Collection</h2>
           <p>
-            It is not needed to prevent GC of {{MediaStream}} objects which have
-            event listeners registered for addtrack events or removetrack events.
-            It is up to the object that will trigger these events to keep a reference to
-            the {{MediaStream}} object.
+            User agent code that expects to fire the addtrack or removetrack events
+            is expected to keep the target {{MediaStream}} objects alive by reference
+            from another object.
+            The presence of addtrack or removetrack event listeners does not need to
+            be taken into account when trying to garbage collect {{MediaStream}} objects.
           </p>
         </section>
       </div>
@@ -2047,7 +2048,7 @@ interface MediaStreamTrack : EventTarget {
       <section>
         <h2>Garbage Collection</h2>
         <p>
-          A {{MediaStreamTrack}} object MUST not be garbage collected if it is
+          A {{MediaStreamTrack}} object MUST NOT be garbage collected if it is
           not [=MediaStreamTrack/ended=] and there are any event listeners
           registered for <a data-lt=muted>mute</a>, <a data-lt=unmuted>unmute</a>
           or <a data-lt=ended>ended</a> events.

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -210,7 +210,6 @@
       the same source to have different constraints applied for different
       <a>consumer</a>s. The {{MediaStream}} object is also used in
       contexts outside {{MediaDevices/getUserMedia}}, such as [[?WEBRTC]].</p>
-      <p>A {{MediaStream}} object has a [[\CanFireEvent\]] slot initialized to <code>false</code> by default.</p>
     </section>
     <section>
       <h2>{{MediaStream}}</h2>
@@ -543,9 +542,10 @@ interface MediaStream : EventTarget {
         <section>
           <h2>Garbage Collection</h2>
           <p>
-            A {{MediaStream}} object MUST not be garbage collected if its [[\CanFireEvent]]
-            slot is <code>true</code> and there are any event listeners registered for addtrack
-            events or removetrack events.
+            It is not needed to prevent GC of {{MediaStream}} objects which have
+            event listeners registered for addtrack events or removetrack events.
+            It is up to the object that will trigger these events to keep a reference to
+            the {{MediaStream}} object.
           </p>
         </section>
       </div>
@@ -2048,8 +2048,9 @@ interface MediaStreamTrack : EventTarget {
         <h2>Garbage Collection</h2>
         <p>
           A {{MediaStreamTrack}} object MUST not be garbage collected if it is
-          not [= MediaStreamTrack/ended =] and there are any event listeners
-          registered for mute, unmute or ended events.
+          not [=MediaStreamTrack/ended=] and there are any event listeners
+          registered for <a data-lt=muted>mute</a>, <a data-lt=unmuted>unmute</a>
+          or <a data-lt=ended>ended</a> events.
           <!-- FIXME: add configurationchange event -->
           Each source type can further refine the garbage collection rules as
           sources may never fire a particular event.


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/910


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/1034.html" title="Last updated on Apr 24, 2025, 7:59 AM UTC (2403b09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1034/4d96849...youennf:2403b09.html" title="Last updated on Apr 24, 2025, 7:59 AM UTC (2403b09)">Diff</a>