### PR TITLE
Extend device exposure to camera if microphone is in use and vice versa

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3192,6 +3192,24 @@ interface MediaDevices : EventTarget {
             `true`. Otherwise, return `false`.</p>
           </li>
         </ol>
+        <p>To perform a <dfn>device exposure can be extended</dfn> check, given <var>deviceType</var>, run the following
+        steps:</p>
+        <ol class="algorithm">
+          <li>
+            <p>Let <var>permission</var> be the result of reading the [=permission state=] for the descriptor
+            whose name is <var>deviceType</var>.</p>
+          </li>
+          <li>
+            <p>If <var>permission</var> is {{PermissionState/"granted"}}, return <code>true</code>.</p>
+          </li>
+          <li>
+            <p>If <var>permission</var> is {{PermissionState/"prompt"}}, the User Agent MAY return <code>true</code>
+              if it knows that <var>deviceType</var> access was previously granted for that origin.</p>
+          </li>
+          <li>
+            <p>Return <code>false</code>.</p>
+          </li>
+        </ol>
       </section>
       <section>
         <h2>Set device information exposure</h2>
@@ -3200,13 +3218,28 @@ interface MediaDevices : EventTarget {
         <var>mediaDevices</var>, given a <var>requestedTypes</var> [=set=], and a boolean <var>value</var>, run the following steps:</p>
         <ol class="algorithm">
           <li>
-            <p>If <a>"video"</a> is in <var>requestedTypes</var>, then set
-            <var>mediaDevices</var>.{{MediaDevices/[[canExposeCameraInfo]]}} to <var>value</var>.</p>
+            <p>If <a>"video"</a> is in <var>requestedTypes</var>, run the following sub-steps:</p>
+            <ol>
+              <li>
+                <p>Set <var>mediaDevices</var>.{{MediaDevices/[[canExposeCameraInfo]]}} to <var>value</var>.</p>
+              </li>
+              <li>
+                <p>If <var>value</var> is <code>true</code> and if [=device exposure can be extended=] with "microphone",
+                set <var>mediaDevices</var>.{{MediaDevices/[[canExposeMicrophoneInfo]]}} to <code>true</code>.</p>
+              </li>
+            </ol>
           </li>
           <li>
-            <p>If <a>"audio"</a> is in <var>requestedTypes</var>, then set
-            <var>mediaDevices</var>.{{MediaDevices/[[canExposeMicrophoneInfo]]}} to
-            <var>value</var>.</p>
+            <p>If <a>"audio"</a> is in <var>requestedTypes</var>, run the following sub-steps:</p>
+            <ol>
+              <li>
+                <p>Set <var>mediaDevices</var>.{{MediaDevices/[[canExposeMicrophoneInfo]]}} to <var>value</var>.</p>
+              </li>
+              <li>
+                <p>If <var>value</var> is <code>true</code> and if [=device exposure can be extended=] with "camera",
+                set <var>mediaDevices</var>.{{MediaDevices/[[canExposeCameraInfo]]}} to <code>true</code>.</p>
+              </li>
+            </ol>
           </li>
         </ol>
         <div class="note">


### PR DESCRIPTION
Partially fixes https://github.com/w3c/mediacapture-main/issues/1019


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/1038.html" title="Last updated on Apr 24, 2025, 9:04 AM UTC (59f620c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1038/4d96849...youennf:59f620c.html" title="Last updated on Apr 24, 2025, 9:04 AM UTC (59f620c)">Diff</a>