### PR TITLE
Set device information exposure to true once permission is granted and before starting to capture devices

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3782,17 +3782,27 @@ interface DeviceChangeEvent : Event {
                           <p>If the result of the request is {{PermissionState/"denied"}},
                           jump to the step labeled <em>Permission Failure</em> below.</p>
                         </li>
-                        <li>
-                          <p>Let <var>hasSystemFocus</var> be `false`.</p>
-                        </li>
-                        <li>
-                          <p>While <var>hasSystemFocus</var> is `false`, the
-                          [=User Agent=] MUST wait to proceed to the next step
-                          until a task queued to set <var>hasSystemFocus</var>
-                          to the result of the [=has system focus=]</a>
-                          algorithm, would set <var>hasSystemFocus</var> to
-                          `true`.</p>
-                        </li>
+                      </ol>
+                    </li>
+                    <li>
+                      <p>Let <var>hasSystemFocus</var> be `false`.</p>
+                    </li>
+                    <li>
+                      <p>While <var>hasSystemFocus</var> is `false`, the
+                      [=User Agent=] MUST wait to proceed to the next step
+                      until a task queued to set <var>hasSystemFocus</var>
+                      to the result of the [=has system focus=]</a>
+                      algorithm, would set <var>hasSystemFocus</var> to
+                      `true`.</p>
+                    </li>
+                    <li>
+                      <p>[=Set the device information exposure=] on <var>mediaDevices</var>
+                      with <code>requestedMediaTypes</code> and <code>true</code>.</p>
+                    </li>
+                    <li>
+                      <p>For each media type <var>kind</var> in
+                      <var>requestedMediaTypes</var>, run the following sub steps:</p>
+                      <ol>
                         <li>
                           <p>Let <var>finalCandidate</var> be the provided media, which
                           MUST be precisely one <a>candidate</a> of type <var>kind</var> from
@@ -3865,10 +3875,6 @@ interface DeviceChangeEvent : Event {
                       [=tie track source to `MediaDevices`=] with
                       <var>track</var>.{{MediaStreamTrack/[[Source]]}} and
                       <var>mediaDevices</var>.</p>
-                    </li>
-                    <li>
-                      <p>[=Set the device information exposure=] on <var>mediaDevices</var>
-                      with <code>requestedMediaTypes</code> and <code>true</code>.</p>
                     </li>
                     <li>
                       <p>[= Resolve =] <var>p</var> with <var>stream</var> and


### PR DESCRIPTION
This will help https://github.com/w3c/mediacapture-main/issues/1019 as devices will be exposed if:
- User granted access to camera and or microphone
- But somehow capture failed to start (NotReadableError or AbortError)

Before this PR, devices would be exposed if user granted access and capture did start properly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/1039.html" title="Last updated on Apr 24, 2025, 9:26 AM UTC (3c58796)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1039/4d96849...youennf:3c58796.html" title="Last updated on Apr 24, 2025, 9:26 AM UTC (3c58796)">Diff</a>