### PR TITLE
list of inherent constrainable track properties is per source

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -972,12 +972,19 @@ interface MediaStream : EventTarget {
         APIs defined in the <a>ConstrainablePattern</a> Interface allow the
         retrieval and manipulation of the constraints currently established on
         a track.</p>
-        <p>Once ended, a track will continue exposing a
+        <p>Once ended, a track will continue exposing a subset of
+        constrainable track properties on the
         <dfn id="list-of-inherent-constrainable-track-properties">
         list of inherent constrainable track properties</dfn>.
-        This list contains <code><a href="#def-constraint-deviceId">deviceId</a></code>,
+        This list will vary by source. For tracks created by
+        {{MediaDevices.getUserMedia()}}, the list is
+        <code><a href="#def-constraint-deviceId">deviceId</a></code> and
+        <code><a href="#def-constraint-groupId">groupId</a></code> for
+        audio tracks, and
+        <code><a href="#def-constraint-deviceId">deviceId</a></code>,
         <code><a href="#def-constraint-facingMode">facingMode</a></code> and
-        <code><a href="#def-constraint-groupId">groupId</a></code>.
+        <code><a href="#def-constraint-groupId">groupId</a></code> for video
+        tracks.
         </p>
       </section>
       <section id="media-stream-track-interface-definition">


### PR DESCRIPTION
The existing list is meant for camera/microphone tracks, not all tracks.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/1046.html" title="Last updated on Jun 6, 2025, 6:05 PM UTC (201e132)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1046/33114d4...jan-ivar:201e132.html" title="Last updated on Jun 6, 2025, 6:05 PM UTC (201e132)">Diff</a>