### PR TITLE
Add stable link to note on device selection

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -5891,7 +5891,7 @@ window.onload = async () =&gt; {
     ability lasts until the web document is closed, and cannot be persisted.
     In most cases, the labels are stable across origins, and thus potentially
     provide a way to track a given device across time and origins.</p>
-    <p class="note">
+    <p class="note" id="note-device-enumeration">
     This specification exposes device information of devices other than those in
     use. This is for backwards compatibility and legacy reasons. Future
     specifications are advised to not use this model and instead follow


### PR DESCRIPTION
I have a blog post linking to a note in the spec, but the link isn't stable (alternating between `#h-note-37` and `#h-note-38`). This adds a stable reference for it (`#note-device-enumeration`) to encourage quoting.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/1049.html" title="Last updated on Jun 24, 2025, 11:16 PM UTC (e0ac2a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1049/c06d1de...jan-ivar:e0ac2a8.html" title="Last updated on Jun 24, 2025, 11:16 PM UTC (e0ac2a8)">Diff</a>