### PR TITLE
Clarify that bare values are only treated as `exact` iff they are present in an advanced ConstraintSet

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4817,8 +4817,9 @@ interface ConstrainablePattern {
                   <p>If the constraint is <dfn>required</dfn>
                   (<var>constraintValue</var>
                   either contains one or more members named 'min', 'max', or
-                  'exact', or is itself a bare value and bare values are to be
-                  treated as 'exact'), and the <a>settings dictionary</a>'s
+                  'exact', or is itself a bare value in an advanced
+                  ConstraintSet and bare values in advanced CS are to be treated
+                  as 'exact'), and the <a>settings dictionary</a>'s
                   <var>constraintName</var> member's value does not satisfy the
                   constraint or doesn't [= map/exist =], the fitness distance is
                   positive infinity.</p>

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -4818,8 +4818,7 @@ interface ConstrainablePattern {
                   (<var>constraintValue</var>
                   either contains one or more members named 'min', 'max', or
                   'exact', or is itself a bare value in an advanced
-                  ConstraintSet and bare values in advanced CS are to be treated
-                  as 'exact'), and the <a>settings dictionary</a>'s
+                  ConstraintSet), and the <a>settings dictionary</a>'s
                   <var>constraintName</var> member's value does not satisfy the
                   constraint or doesn't [= map/exist =], the fitness distance is
                   positive infinity.</p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ahmedmoussa10/mediacapture-main/pull/1055.html" title="Last updated on Sep 25, 2025, 2:24 PM UTC (6a1caa0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1055/6dd4900...ahmedmoussa10:6a1caa0.html" title="Last updated on Sep 25, 2025, 2:24 PM UTC (6a1caa0)">Diff</a>