### PR TITLE
Make enumerateDevices expose an explicit audio output default entry

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -3138,7 +3138,7 @@ interface MediaDevices : EventTarget {
                           "default".</p>
                         </li>
                         <li>
-                          <p>The user agent MAY update <var>defaultAudioOutputInfo</var>'s {{MediaDeviceInfo/label}}
+                          <p>The user agent SHOULD update <var>defaultAudioOutputInfo</var>'s {{MediaDeviceInfo/label}}
                           to make it explicit that this is the system default audio output.</p>
                         </li>
                         <li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-output/issues/151


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-main/pull/1057.html" title="Last updated on Oct 9, 2025, 2:18 PM UTC (8ff7fcf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1057/d04a618...youennf:8ff7fcf.html" title="Last updated on Oct 9, 2025, 2:18 PM UTC (8ff7fcf)">Diff</a>