### PR TITLE
Revert #867 and note addTrack/removeTrack don't fire events

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -488,7 +488,10 @@ interface MediaStream : EventTarget {
                   steps.</p>
                 </li>
                 <li>
-                  <p>[=MediaStream/Add a track|Add=] <var>track</var> to <var>stream</var>'s [=track set=].</p>
+                  <p>Add <var>track</var> to <var>stream</var>'s [=track set=].</p>
+                  <div class="note">
+                    This does NOT call [=add a track=] or fire an event.
+                  </div>
                 </li>
               </ol>
             </dd>
@@ -509,7 +512,10 @@ interface MediaStream : EventTarget {
                   <p>If <var>track</var> is not in <var>stream's</var> [=track set=], then abort these steps.</p>
                 </li>
                 <li>
-                  <p>[=MediaStream/Remove a track|Remove=] <var>track</var> from <var>stream</var>'s [=track set=].</p>
+                  <p>Remove <var>track</var> from <var>stream</var>'s [=track set=].</p>
+                  <div class="note">
+                    This does NOT call [=remove a track=] or fire an event.
+                  </div>
                 </li>
               </ol>
             </dd>


### PR DESCRIPTION
Reverts accidental normative changes in the editorial https://github.com/w3c/mediacapture-main/pull/867, and adds a note to avoid future confusion.

This restores behavior clarified in https://github.com/w3c/mediacapture-main/issues/517#issuecomment-391680432, which is that the addTrack() and removeTrack() methods on the MediaStream itself do not fire events.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-main/pull/1062.html" title="Last updated on Jan 6, 2026, 12:35 AM UTC (97f712c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-main/1062/f11ed0e...jan-ivar:97f712c.html" title="Last updated on Jan 6, 2026, 12:35 AM UTC (97f712c)">Diff</a>